### PR TITLE
fix: do not send implied default param values, fixes #9

### DIFF
--- a/cli/operation.go
+++ b/cli/operation.go
@@ -82,6 +82,12 @@ func (o Operation) command() *cobra.Command {
 					continue
 				}
 
+				if param.Default == nil && reflect.ValueOf(flags[param.Name]).Elem().IsZero() {
+					// No explicit default, so the implied default is the zero value.
+					// Again no need to send that default, so we skip.
+					continue
+				}
+
 				for _, v := range param.Serialize(flags[param.Name]) {
 					query.Add(param.Name, v)
 				}

--- a/cli/operation_test.go
+++ b/cli/operation_test.go
@@ -13,7 +13,7 @@ import (
 func TestOperation(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Get("/test/id1").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://example.com").Get("/test/id1").MatchParam("search", "foo").Reply(200).JSON(map[string]interface{}{
 		"hello": "world",
 	})
 
@@ -36,6 +36,12 @@ func TestOperation(t *testing.T) {
 				Type:        "string",
 				Name:        "search",
 				DisplayName: "search",
+				Description: "desc",
+			},
+			{
+				Type:        "string",
+				Name:        "def",
+				DisplayName: "def",
 				Description: "desc",
 			},
 		},


### PR DESCRIPTION
Sometimes the default value isn't specified. In that case, if the parameter is the zero value for the type, we should not send it.