### PR TITLE
fix: read body from stdin for generic calls

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -77,11 +77,11 @@ var au aurora.Aurora
 func generic(method string, addr string, args []string) {
 	var body io.Reader
 
-	if len(args) > 0 {
-		d, err := GetBody("application/json", args)
-		if err != nil {
-			panic(err)
-		}
+	d, err := GetBody("application/json", args)
+	if err != nil {
+		panic(err)
+	}
+	if len(d) > 0 {
 		body = strings.NewReader(d)
 	}
 


### PR DESCRIPTION
In what I assume was an attempt at optimization, we never looked at the body input for generic HTTP calls (i.e. when not using high-level operation names from OpenAPI docs) **unless** arguments are also passed on the commandline. This results in weird behavior, so that check is removed. Now we always look at *both* stdin and arguments for potential input to the command.

Examples which now all work properly:

```sh
# Generic call with no input still works
$ restish post :8000/foo

# Broken before, fixed now, reading input from file
$ restish post :8000/foo <input.json

# Worked before, still works now, both file and arguments as input
$ restish post :8888/foo id: value <input.json
```