### PR TITLE
feat: Autoconfiguration via x-cli-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Features include:
     - [RFC 5988](https://tools.ietf.org/html/rfc5988#section-6.2.2) `describedby` link relation
   - Supported formats
     - [OpenAPI 3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) and [JSON Schema](https://json-schema.org/)
+  - Automatic configuration of API auth if advertised by the API
 - Automatic pagination of resource collections via [RFC 5988](https://tools.ietf.org/html/rfc5988) `prev` and `next` hypermedia links
 - API endpoint-based auth built-in with support for profiles:
   - HTTP Basic

--- a/cli/api.go
+++ b/cli/api.go
@@ -21,6 +21,7 @@ type API struct {
 	Long       string      `json:"long,omitempty"`
 	Operations []Operation `json:"operations,omitempty"`
 	Auth       []APIAuth   `json:"auth,omitempty"`
+	AutoConfig AutoConfig  `json:"autoconfig,omitempty"`
 }
 
 // Merge two APIs together. Takes the description if none is set and merges

--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -21,8 +21,8 @@ type APIAuth struct {
 
 // APIProfile contains account-specific API information
 type APIProfile struct {
-	Headers map[string]string `json:"headers"`
-	Query   map[string]string `json:"query"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Query   map[string]string `json:"query,omitempty"`
 	Auth    *APIAuth          `json:"auth"`
 }
 
@@ -76,7 +76,7 @@ func initAPIConfig() {
 		Aliases: []string{"config"},
 		Short:   "Initialize an API",
 		Long:    "Initializes an API with a short interactive prompt session to set up the base URI and auth if needed.",
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MinimumNArgs(1),
 		Run:     askInitAPIDefault,
 	})
 

--- a/cli/autoconfig.go
+++ b/cli/autoconfig.go
@@ -1,0 +1,19 @@
+package cli
+
+// AutoConfigVar represents a variable given by the user when prompted during
+// auto-configuration setup of an API.
+type AutoConfigVar struct {
+	Description string        `json:"description,omitempty"`
+	Example     string        `json:"example,omitempty"`
+	Default     interface{}   `json:"default,omitempty"`
+	Enum        []interface{} `json:"enum,omitempty"`
+}
+
+// AutoConfig holds an API's automatic configuration settings for the CLI. These
+// are advertised via OpenAPI extension and picked up by the CLI to make it
+// easier to get started using an API.
+type AutoConfig struct {
+	Headers map[string]string        `json:"headers,omitempty"`
+	Prompt  map[string]AutoConfigVar `json:"prompt,omitempty"`
+	Auth    APIAuth                  `json:"auth,omitempty"`
+}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -99,6 +99,7 @@ func Init(name string, version string) {
 	contentTypes = []contentTypeEntry{}
 	encodings = map[string]ContentEncoding{}
 	linkParsers = []LinkParser{}
+	loaders = []Loader{}
 
 	// Determine if we are using a TTY or colored output is forced-on.
 	tty = false

--- a/cli/interactive_test.go
+++ b/cli/interactive_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"testing"
@@ -75,4 +77,121 @@ func TestInteractive(t *testing.T) {
 	}
 
 	askInitAPI(mock, Root, []string{"example"})
+}
+
+type testLoader struct {
+	API API
+}
+
+func (l *testLoader) LocationHints() []string {
+	return []string{"/openapi.json"}
+}
+
+func (l *testLoader) Detect(resp *http.Response) bool {
+	return true
+}
+
+func (l *testLoader) Load(entrypoint, spec url.URL, resp *http.Response) (API, error) {
+	return l.API, nil
+}
+
+func TestInteractiveAutoConfig(t *testing.T) {
+	// Remove existing config if present...
+	os.Remove(path.Join(userHomeDir(), ".test", "apis.json"))
+
+	reset(false)
+	AddLoader(&testLoader{
+		API: API{
+			Short: "Swagger Petstore",
+			Auth: []APIAuth{
+				{
+					Name: "oauth-authorization-code",
+					Params: map[string]string{
+						"client_id":     "",
+						"authorize_url": "https://example.com/authorize",
+						"token_url":     "https://example.com/token",
+					},
+				},
+			},
+			Operations: []Operation{
+				{
+					Name:         "createpets",
+					Short:        "Create a pet",
+					Long:         "\n## Response 201\n\nNull response\n\n## Response default (application/json)\n\nunexpected error\n\n```schema\n{\n  code*: (integer format:int32) \n  message*: (string) \n}\n```\n",
+					Method:       "POST",
+					URITemplate:  "http://api.example.com/pets",
+					PathParams:   []*Param{},
+					QueryParams:  []*Param{},
+					HeaderParams: []*Param{},
+				},
+				{
+					Name:        "listpets",
+					Short:       "List all pets",
+					Long:        "\n## Response 200 (application/json)\n\nA paged array of pets\n\n```schema\n[\n  {\n    id*: (integer format:int64) \n    name*: (string) \n    tag: (string) \n  }\n]\n```\n\n## Response default (application/json)\n\nunexpected error\n\n```schema\n{\n  code*: (integer format:int32) \n  message*: (string) \n}\n```\n",
+					Method:      "GET",
+					URITemplate: "http://api.example.com/pets",
+					PathParams:  []*Param{},
+					QueryParams: []*Param{
+						{
+							Type:        "integer",
+							Name:        "limit",
+							Description: "How many items to return at one time (max 100)",
+						},
+					},
+					HeaderParams: []*Param{},
+				},
+				{
+					Name:        "showpetbyid",
+					Short:       "Info for a specific pet",
+					Long:        "\n## Response 200 (application/json)\n\nExpected response to a valid request\n\n```schema\n{\n  id*: (integer format:int64) \n  name*: (string) \n  tag: (string) \n}\n```\n\n## Response default (application/json)\n\nunexpected error\n\n```schema\n{\n  code*: (integer format:int32) \n  message*: (string) \n}\n```\n",
+					Method:      "GET",
+					URITemplate: "http://api.example.com/pets/{petId}",
+					PathParams: []*Param{
+						{
+							Type:        "string",
+							Name:        "petId",
+							Description: "The id of the pet to retrieve",
+						},
+					},
+					QueryParams:  []*Param{},
+					HeaderParams: []*Param{},
+				},
+			},
+			AutoConfig: AutoConfig{
+				Prompt: map[string]AutoConfigVar{
+					"client_id": {
+						Description: "Client identifier",
+						Example:     "abc123",
+					},
+				},
+				Auth: APIAuth{
+					Name: "oauth-authorization-code",
+					Params: map[string]string{
+						"client_id":     "",
+						"authorize_url": "https://example.com/authorize",
+						"token_url":     "https://example.com/token",
+					},
+				},
+			},
+		},
+	})
+	defer reset(false)
+
+	defer gock.Off()
+
+	gock.New("http://api2.example.com").Get("/").Reply(200).JSON(map[string]interface{}{
+		"Hello": "World",
+	})
+
+	gock.New("http://api2.example.com").Get("/openapi.json").Reply(200).BodyString("dummy")
+
+	mock := &mockAsker{
+		t: t,
+		responses: []string{
+			"foo",
+			"Save and exit",
+		},
+	}
+
+	askInitAPI(mock, Root, []string{"autoconfig", "http://api2.example.com"})
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
     - [RFC 5988](https://tools.ietf.org/html/rfc5988#section-6.2.2) `describedby` link relation
   - Supported formats
     - [OpenAPI 3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md) and [JSON Schema](https://json-schema.org/)
+  - Automatic configuration of API auth if advertised by the API
 - Automatic pagination of resource collections via [RFC 5988](https://tools.ietf.org/html/rfc5988) `prev` and `next` hypermedia links
 - API endpoint-based auth built-in with support for profiles:
   - HTTP Basic

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,12 +53,14 @@ Should TTY autodetection for colored output cause any problems, you can manually
 Adding or editing an API is possible via an interactive terminal UI:
 
 ```bash
-$ restish api configure $NAME
+$ restish api configure $NAME [$BASE_URI]
 ```
 
 You should see something like the following, which enables you to create and edit profiles, headers, query params, and auth, eventually saving the data to `~/.restish/apis.json`:
 
 <img alt="Screen Shot" src="https://user-images.githubusercontent.com/106826/83099522-79dd3200-a062-11ea-8a78-b03a2fecf030.png">
+
+If the API offers autoconfiguration data (e.g. through the [`x-cli-config` OpenAPI extension](/openapi.md#AutoConfiguration)) then you may be prompted for other values and some settings may already be configured for you.
 
 Once an API is configured, you can start using it by using its short name. For example, given an API named `example`:
 

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -124,6 +124,19 @@ components:
           format: int32
         message:
           type: string
+  securitySchemes:
+    default:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/authorize
+          tokenUrl: https://example.com/token
+x-cli-config:
+  security: default
+  prompt:
+    client_id:
+      description: Client identifier
+      example: abc123
 `
 
 func TestLoadOpenAPI(t *testing.T) {
@@ -139,7 +152,16 @@ func TestLoadOpenAPI(t *testing.T) {
 
 	expected := cli.API{
 		Short: "Swagger Petstore",
-		Auth:  []cli.APIAuth{},
+		Auth: []cli.APIAuth{
+			{
+				Name: "oauth-authorization-code",
+				Params: map[string]string{
+					"client_id":     "",
+					"authorize_url": "https://example.com/authorize",
+					"token_url":     "https://example.com/token",
+				},
+			},
+		},
 		Operations: []cli.Operation{
 			{
 				Name:         "createpets",
@@ -182,6 +204,22 @@ func TestLoadOpenAPI(t *testing.T) {
 				},
 				QueryParams:  []*cli.Param{},
 				HeaderParams: []*cli.Param{},
+			},
+		},
+		AutoConfig: cli.AutoConfig{
+			Prompt: map[string]cli.AutoConfigVar{
+				"client_id": {
+					Description: "Client identifier",
+					Example:     "abc123",
+				},
+			},
+			Auth: cli.APIAuth{
+				Name: "oauth-authorization-code",
+				Params: map[string]string{
+					"client_id":     "",
+					"authorize_url": "https://example.com/authorize",
+					"token_url":     "https://example.com/token",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Adds support for an **optional** `x-cli-config` OpenAPI extension to let APIs tell Restish (and other clients) how to automatically configure themselves to make authenticated requests to the API, asking for user input for just the minimum set of necessary things (like secrets). This *significantly* simplifies having customers onboard to using a tool like Restish.