### PR TITLE
feat: ability to exclude autoconfig prompt vars

### DIFF
--- a/cli/autoconfig.go
+++ b/cli/autoconfig.go
@@ -7,6 +7,10 @@ type AutoConfigVar struct {
 	Example     string        `json:"example,omitempty"`
 	Default     interface{}   `json:"default,omitempty"`
 	Enum        []interface{} `json:"enum,omitempty"`
+
+	// Exclude the value from being sent to the server. This essentially makes
+	// it a value which is only used in param templates.
+	Exclude bool `json:"exclude,omitempty"`
 }
 
 // AutoConfig holds an API's automatic configuration settings for the CLI. These

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -88,7 +88,7 @@ Valid types for the security setting when not using a security scheme defined wi
 | `oauth-client-credentials` | OAuth2 pre-shared client key/secret (m2m) |
 | `oauth-authorization-code` | OAuth2 authorization code (user login)    |
 
-By default, all prompt variables become auth parameters of the same name. Additionally, a template system can be used to augment the value or create new params. Any value within `{...}` will get replaced by the value of the param with the given name. For example:
+By default, all prompt variables become auth parameters of the same name. This can be disabled by setting `exclude` to `true` if desired. Additionally, a template system can be used to augment the value or create new params. Any value within `{...}` will get replaced by the value of the param with the given name. For example:
 
 ```yaml
 x-cli-config:
@@ -96,12 +96,13 @@ x-cli-config:
     org:
       description: Organization ID
       example: github
+      exclude: true
   params:
     audience: https://example.com/{org}
     some_static_value: foo
 ```
 
-The above will prompt the user for an `org` and then fill in the params using the value from the user when creating the API configuration profile.
+The above will prompt the user for an `org` and then fill in the params using the value from the user when creating the API configuration profile. Since `exclude` is set, the `org` parameter is never sent to the server and is only used to fill in the param template for `audience`.
 
 #### Auth Parameters
 


### PR DESCRIPTION
Adds the ability to exclude prompt variables for CLI auto-configuration and gives a little more control over the variable naming when prompting the user.