### PR TITLE
Add support for client side TLS

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -19,6 +19,14 @@ type APIAuth struct {
 	Params map[string]string `json:"params"`
 }
 
+// TLSConfig contains the TLS setup for the HTTP client
+type TLSConfig struct {
+	InsecureSkipVerify bool   `json:"insecure" mapstructure:"insecure"`
+	Cert               string `json:"cert"`
+	Key                string `json:"key"`
+	CACert             string `json:"ca_cert" mapstructure:"ca_cert"`
+}
+
 // APIProfile contains account-specific API information
 type APIProfile struct {
 	Headers map[string]string `json:"headers,omitempty"`
@@ -33,6 +41,7 @@ type APIConfig struct {
 	Base      string                 `json:"base"`
 	SpecFiles []string               `json:"spec_files,omitempty" mapstructure:"spec_files,omitempty"`
 	Profiles  map[string]*APIProfile `json:"profiles,omitempty" mapstructure:",omitempty"`
+	TLS       *TLSConfig             `json:"tls,omitempty" mapstructure:",omitempty"`
 }
 
 // Save the API configuration to disk.

--- a/cli/flag.go
+++ b/cli/flag.go
@@ -16,20 +16,25 @@ func AddGlobalFlag(name, short, description string, defaultValue interface{}, mu
 	case bool:
 		if multi {
 			flags.BoolSliceP(name, short, viper.Get(name).([]bool), description)
+			GlobalFlags.BoolSliceP(name, short, viper.Get(name).([]bool), description)
 		} else {
 			flags.BoolP(name, short, viper.GetBool(name), description)
+			GlobalFlags.BoolP(name, short, viper.GetBool(name), description)
 		}
 	case int, int16, int32, int64, uint16, uint32, uint64:
 		if multi {
 			flags.IntSliceP(name, short, viper.Get(name).([]int), description)
+			GlobalFlags.IntSliceP(name, short, viper.Get(name).([]int), description)
 		} else {
 			flags.IntP(name, short, viper.GetInt(name), description)
+			GlobalFlags.IntP(name, short, viper.GetInt(name), description)
 		}
 	case float32, float64:
 		if multi {
 			panic(fmt.Errorf("unsupported float slice param"))
 		} else {
 			flags.Float64P(name, short, viper.GetFloat64(name), description)
+			GlobalFlags.Float64P(name, short, viper.GetFloat64(name), description)
 		}
 	default:
 		if multi {
@@ -40,8 +45,10 @@ func AddGlobalFlag(name, short, description string, defaultValue interface{}, mu
 				viper.Set(name, v)
 			}
 			flags.StringSliceP(name, short, v.([]string), description)
+			GlobalFlags.StringSliceP(name, short, v.([]string), description)
 		} else {
 			flags.StringP(name, short, fmt.Sprintf("%v", viper.Get(name)), description)
+			GlobalFlags.StringP(name, short, fmt.Sprintf("%v", viper.Get(name)), description)
 		}
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,19 +15,21 @@ Global configuration affects all commands and can be set in one of three ways, g
 
 The global options in addition to `--help` and `--version` are:
 
-| Argument                    | Env Var             | Example           | Description                                                                      |
-| --------------------------- | ------------------- | ----------------- | -------------------------------------------------------------------------------- |
-| `-f`, `--rsh-filter`        | `RSH_FILTER`        | `body.users[].id` | [JMESPath Plus](https://github.com/danielgtaylor/go-jmespath-plus#readme) filter |
-| `-H`, `--rsh-header`        | `RSH_HEADER`        | `Version:2020-05` | Set a header name/value                                                          |
-| `--rsh-insecure`            | `RSH_INSECURE`      |                   | Disable TLS certificate checks                                                   |
-| `--rsh-no-cache`            | `RSH_NO_CACHE`      |                   | Disable HTTP caching                                                             |
-| `--rsh-no-paginate`         | `RSH_NO_PAGINATE`   |                   | Disable automatic `next` link pagination                                         |
-| `-o`, `--rsh-output-format` | `RSH_OUTPUT_FORMAT` | `json`            | [Output format](/output.md), defaults to `auto`                                  |
-| `-p`, `--rsh-profile`       | `RSH_PROFILE`       | `testing`         | Auth profile name, defaults to `default`                                         |
-| `-q`, `--rsh-query`         | `RSH_QUERY`         | `search=foo`      | Set a query parameter                                                            |
-| `-r`, `--rsh-raw`           | `RSH_RAW`           |                   | Raw output for shell processing                                                  |
-| `-s`, `--rsh-server`        | `RSH_SERVER`        | `https://foo.com` | Override API server base URL                                                     |
-| `-v`, `--rsh-verbose`       | `RSH_VERBOSE`       |                   | Enable verbose output                                                            |
+| Argument                    | Env Var             | Example             | Description                                                                      |
+| --------------------------- | ------------------- | ------------------- | -------------------------------------------------------------------------------- |
+| `-f`, `--rsh-filter`        | `RSH_FILTER`        | `body.users[].id`   | [JMESPath Plus](https://github.com/danielgtaylor/go-jmespath-plus#readme) filter |
+| `-H`, `--rsh-header`        | `RSH_HEADER`        | `Version:2020-05`   | Set a header name/value                                                          |
+| `--rsh-insecure`            | `RSH_INSECURE`      |                     | Disable TLS certificate checks                                                   |
+| `--rsh-client-cert`         | `RSH_CLIENT_CERT`   | `/etc/ssl/cert.pem` | Path to a PEM encoded client certificate                                         |
+| `--rsh-client-key`          | `RSH_CLIENT_KEY`    | `/etc/ssl/key.pem`  | Path to a PEM encoded private key                                                |
+| `--rsh-ca-cert`             | `RSH_CA_CERT`       | `/etc/ssl/ca.pem`   | Path to a PEM encoded CA certificate                                             |
+| `--rsh-no-paginate`         | `RSH_NO_PAGINATE`   |                     | Disable automatic `next` link pagination                                         |
+| `-o`, `--rsh-output-format` | `RSH_OUTPUT_FORMAT` | `json`              | [Output format](/output.md), defaults to `auto`                                  |
+| `-p`, `--rsh-profile`       | `RSH_PROFILE`       | `testing`           | Auth profile name, defaults to `default`                                         |
+| `-q`, `--rsh-query`         | `RSH_QUERY`         | `search=foo`        | Set a query parameter                                                            |
+| `-r`, `--rsh-raw`           | `RSH_RAW`           |                     | Raw output for shell processing                                                  |
+| `-s`, `--rsh-server`        | `RSH_SERVER`        | `https://foo.com`   | Override API server base URL                                                     |
+| `-v`, `--rsh-verbose`       | `RSH_VERBOSE`       |                     | Enable verbose output                                                            |
 
 Configuration file keys are the same as long-form arguments without the `--` prefix.
 


### PR DESCRIPTION
This PR adds two main changes:
#### 1. Implement variable expansion in server URLs when determining the basePath
This was an outstanding TODO item in the code. 

It will use all `enum` values, or the `default` value if no `enum` is given. The openapi spec mandates that either of these are set.

#### 2. Support for TLS client certificates
This adds a TLS section to the API configuration object. It allows specifying InsecureSkipVerify, an additional CA cert, and client certs.
Client certs are not added as an API authentication method, since they are often used in together with these other authentication methods.

Global CLI options have been added to overwrite the API specific options and to be able to use them during API setup. The values used during initial API setup will be written to the config.

An additional CLI wizard/asker is also provided.
In order not to overload the wizard, we do not ask for TLS parameters during initial API configuration, instead relying on the global config flags. Similarly, the asker is only rendered if we detect that the current TLS parameters are not empty. This can of course easily be changed if you feel this does not provide the right UX.

As part of this change, a small refactoring on the CLI flags handling has been done: a secondary flagset with fixed global flags is created. This flagset can be parsed before API discovery, without getting in the way of cobra. I think this provides an elegant way to deal with the fact that some flags, such as `rsh-verbose` and the TLS flags, need to be parsed before the full flagset is known.

Both these features fill a real need for our usage.
I can split them in 2 PRs if you prefer.