### PR TITLE
fix: rsh-no-cache was not being honored

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -91,13 +91,13 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 	desc := API{}
 	found := false
 
-	fromFileOrUrl := func(uri string) ([]byte,error){
+	fromFileOrUrl := func(uri string) ([]byte, error) {
 		uriLower := strings.ToLower(uri)
 		if strings.Index(uriLower, "http") == 0 {
 			resp, err := http.Get(uri)
 			if err != nil {
 				return []byte{}, err
-			 }
+			}
 			return ioutil.ReadAll(resp.Body)
 		} else {
 			return ioutil.ReadFile(uri)
@@ -172,8 +172,6 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 	for _, l := range resp.Links["describedby"] {
 		uris = append(uris, l.URI)
 	}
-
-	
 
 	// Try hints from loaders next. These are likely places for API descriptions
 	// to be on the server, like e.g. `/openapi.json`.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -445,6 +445,9 @@ func Run() {
 			panic(err)
 		}
 	}
+	if noCache, _ := GlobalFlags.GetBool("rsh-no-cache"); noCache {
+		viper.Set("rsh-no-cache", true)
+	}
 	if verbose, _ := GlobalFlags.GetBool("rsh-verbose"); verbose {
 		viper.Set("rsh-verbose", true)
 	}


### PR DESCRIPTION
rsh-no-cache was not being read from the eager flags early enough, making it
impossible to invalidate the openapi spec.
This patch reads it when all the other http related eager flags are
being read.