### PR TITLE
feat: Expand environment variables in api spec_files and profile headers

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"net/url"
 	"strings"
 	"time"
@@ -100,7 +101,7 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 			 }
 			return ioutil.ReadAll(resp.Body)
 		} else {
-			return ioutil.ReadFile(uri)
+			return ioutil.ReadFile(os.ExpandEnv(uri))
 		}
 	}
 	if name != "" && len(config.SpecFiles) > 0 {

--- a/cli/request.go
+++ b/cli/request.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -89,7 +90,7 @@ func MakeRequest(req *http.Request, options ...requestOption) (*http.Response, e
 	query := req.URL.Query()
 	for k, v := range profile.Headers {
 		if req.Header.Get(k) == "" {
-			req.Header.Add(k, v)
+			req.Header.Add(k, os.ExpandEnv(v))
 		}
 	}
 


### PR DESCRIPTION
This PR adds support to use environment variables in `spec_files` and profile `headers` in `~/.restish/apis.json`.

Being able to use environment variables for the `spec_files` makes it easy to share `apis.json` between team-members or workstations and being able to use environment variables for headers makes it possible to use secure environment stores (like [`envchain`](https://github.com/sorah/envchain)), minimizing the risk of credentials leaking from config files secured only by file permissions.

If you can think of more places where being able to use environment variables would be beneficial please let me know I'm happy to extend this PR.

Example `apis.json`:

```
{
  "example": {
    "base": "https://api.example.net",
    "spec_files": ["$HOME/path/to/spec_file.yml"],
    "profiles": {
      "default": {
        "headers": {
          "ACCESS_TOKEN": "$MY_EXAMPLE_ACCESS_TOKEN"
        }
      }
    }
  }
}
```