### PR TITLE
chore: move off deprecated action runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,13 +2,13 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: Build & Test
     steps:
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.14"
+          go-version: "1.16"
       - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Also upgrades the Go version used for builds.