### PR TITLE
fix: Use API profile when loading definition

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -155,7 +155,7 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 		client = &http.Client{Transport: InvalidateCachedTransport()}
 	}
 
-	httpResp, err := MakeRequest(req, WithClient(client), WithoutLog())
+	httpResp, err := MakeRequest(req, WithClient(client))
 	if err != nil {
 		return API{}, err
 	}
@@ -190,7 +190,12 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 		resolved := uri.ResolveReference(parsed)
 		LogDebug("Checking %s", resolved)
 
-		resp, err := client.Get(resolved.String())
+		req, err := http.NewRequest(http.MethodGet, resolved.String(), nil)
+		if err != nil {
+			return API{}, err
+		}
+
+		resp, err := MakeRequest(req, WithClient(client))
 		if err != nil {
 			return API{}, err
 		}


### PR DESCRIPTION
We should use the configured API profile when trying to fetch the API definition, so that any configured authentication is injected into the request.

We already do when initially probing the API endpoint.

I have also taken the liberty of removing the `WithoutLogs()` option for these requests.
Debugging why the API definition couldn't be loaded was really hard without having access to the request and response.
In general these calls are cached and won't pollute the output.