### PR TITLE
fix: decode after MakeRequest

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -199,6 +199,9 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 		if err != nil {
 			return API{}, err
 		}
+		if err := DecodeResponse(resp); err != nil {
+			return API{}, err
+		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
Fixes a minor issue introduced with #62 where encoded responses (e.g. `br` for `Content-Encoding`) would not be decoded before trying to be processed. This is not an issue up above since `ParseResponse` also calls `DecodeResponse` inside of it.