### PR TITLE
fix: build/release using Go 1.17 to support arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.16"
+          go-version: "1.17"
       - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
This is due to messages like:

> DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check ...
> DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check  ...

See [example build](https://github.com/danielgtaylor/restish/runs/4530770137?check_suite_focus=true).