### PR TITLE
feat: print displayable unicode body when possible

### DIFF
--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintable(t *testing.T) {
+	// Printable with BOM
+	var body interface{} = []byte("\uFEFF\t\r\n Just a tést!.$%^{}/")
+	_, ok := printable(body)
+	assert.True(t, ok)
+
+	// Non-printable
+	body = []byte{0}
+	_, ok = printable(body)
+	assert.False(t, ok)
+
+	// Long printable
+	tmp := make([]byte, 150)
+	for i := 0; i < 150; i++ {
+		tmp[i] = 'a'
+	}
+	_, ok = printable(tmp)
+	assert.True(t, ok)
+
+	// Too long
+	tmp = make([]byte, 1000000)
+	for i := 0; i < 1000000; i++ {
+		tmp[i] = 'a'
+	}
+	_, ok = printable(tmp)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Previously if an unknown content type was encountered then the body would be printed as hex characters. This detects displayable unicode characters (and whitespace, and BOM) and prints them as text whenever possible. This is much more user-friendly than random hex values for things that may just be JSON or YAML or text with an incorrect or missing content type.