### PR TITLE
fix: sending non-structured-object input via stdin, fixes #81

### DIFF
--- a/cli/input.go
+++ b/cli/input.go
@@ -3,16 +3,39 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/danielgtaylor/shorthand"
 	yaml "gopkg.in/yaml.v2"
 )
 
+// Stdin represents the command input, which defaults to os.Stdin.
+var Stdin interface {
+	Stat() (fs.FileInfo, error)
+	io.Reader
+} = os.Stdin
+
 // GetBody returns the request body if one was passed either as shorthand
 // arguments or via stdin.
 func GetBody(mediaType string, args []string) (string, error) {
 	var body string
+
+	if info, err := Stdin.Stat(); err == nil {
+		if len(args) == 0 && (info.Mode()&os.ModeCharDevice) == 0 {
+			// There are no args but there is data on stdin. Just read it and
+			// pass it through as it may not be structured data we can parse or
+			// could be binary (e.g. file uploads).
+			b, err := ioutil.ReadAll(Stdin)
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		}
+	}
 
 	input, err := shorthand.GetInput(args)
 	if err != nil {

--- a/cli/input_test.go
+++ b/cli/input_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func WithFakeStdin(data []byte, mode fs.FileMode, f func()) {
+	fs := fstest.MapFS{
+		"stdin": {
+			Data: data,
+			Mode: mode,
+		},
+	}
+	stdinFile, _ := fs.Open("stdin")
+	Stdin = stdinFile
+	defer func() { Stdin = os.Stdin }()
+	f()
+}
+
+func TestInputStructuredJSON(t *testing.T) {
+	WithFakeStdin([]byte{}, fs.ModeCharDevice, func() {
+		body, err := GetBody("application/json", []string{"foo: 1, bar: false"})
+		assert.NoError(t, err)
+		assert.Equal(t, `{"bar":false,"foo":1}`, body)
+	})
+}
+
+func TestInputStructuredYAML(t *testing.T) {
+	WithFakeStdin([]byte{}, fs.ModeCharDevice, func() {
+		body, err := GetBody("application/yaml", []string{"foo: 1, bar: false"})
+		assert.NoError(t, err)
+		assert.Equal(t, "bar: false\nfoo: 1\n", body)
+	})
+}
+
+func TestInputBinary(t *testing.T) {
+	WithFakeStdin([]byte("This is not JSON!"), 0, func() {
+		body, err := GetBody("", []string{})
+		assert.NoError(t, err)
+		assert.Equal(t, "This is not JSON!", body)
+	})
+}
+
+func TestInputInvalidType(t *testing.T) {
+	WithFakeStdin([]byte{}, fs.ModeCharDevice, func() {
+		_, err := GetBody("application/unknown", []string{"foo: 1"})
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Turns out sending stuff like binary files was broken because we were trying to parse them. This fixes it by making the logic:

1. If no shorthand args are passed, and we are not a tty, then read and use stdin as the request body
2. Else, process the shorthand input