### PR TITLE
fix: better handling of params with unknown types, fixes #63

### DIFF
--- a/cli/operation.go
+++ b/cli/operation.go
@@ -72,18 +72,19 @@ func (o Operation) command() *cobra.Command {
 
 			query := url.Values{}
 			for _, param := range o.QueryParams {
-				if reflect.ValueOf(flags[param.Name]).Elem().Interface() == param.Default {
+				flag := flags[param.Name]
+				if reflect.ValueOf(flag).Elem().Interface() == param.Default {
 					// No need to send the default value. Just skip it.
 					continue
 				}
 
-				if param.Default == nil && reflect.ValueOf(flags[param.Name]).Elem().IsZero() {
+				if param.Default == nil && reflect.ValueOf(flag).Elem().IsZero() {
 					// No explicit default, so the implied default is the zero value.
 					// Again no need to send that default, so we skip.
 					continue
 				}
 
-				for _, v := range param.Serialize(flags[param.Name]) {
+				for _, v := range param.Serialize(flag) {
 					query.Add(param.Name, v)
 				}
 			}

--- a/cli/operation_test.go
+++ b/cli/operation_test.go
@@ -44,6 +44,13 @@ func TestOperation(t *testing.T) {
 				DisplayName: "def",
 				Description: "desc",
 			},
+			{
+				Type:        "string",
+				Name:        "def2",
+				DisplayName: "def2",
+				Description: "desc",
+				Default:     "",
+			},
 		},
 	}
 

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -142,7 +142,9 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 
 			typ := "string"
 			if p.Value.Schema != nil && p.Value.Schema.Value != nil {
-				typ = p.Value.Schema.Value.Type
+				if p.Value.Schema.Value.Type != "" {
+					typ = p.Value.Schema.Value.Type
+				}
 
 				if typ == "array" {
 					// TODO: nil checks


### PR DESCRIPTION
This fixes a bug where a param using `anyOf` with no type itself could cause a crash. Now there is no more crash and the param is treated as a plain string. Proper `anyOf` support may come some time in the future.