### PR TITLE
fix: trim trailing slashes from OpenAPI servers

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -397,7 +397,7 @@ func getBasePath(location *url.URL, servers openapi3.Servers) (string, error) {
 				if err != nil {
 					return "", err
 				}
-				return base.Path, nil
+				return strings.TrimSuffix(base.Path, "/"), nil
 			}
 		}
 	}


### PR DESCRIPTION
This prevents a bug where the URLs get generated incorrectly due to trailing slashes in the OpenAPI defined servers list. Fixes #60.