### PR TITLE
feat: enabled & document raw mode for saving files

### DIFF
--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -183,6 +183,15 @@ func (f *DefaultFormatter) Format(resp Response) error {
 	var data interface{} = resp.Map()
 
 	filter := viper.GetString("rsh-filter")
+	if filter == "" && viper.GetBool("rsh-raw") {
+		if b, ok := resp.Body.([]byte); ok {
+			// The response wasn't decoded so we have a bunch of bytes and the user
+			// asked for raw output, so just write it. This enables file downloads.
+			Stdout.Write(b)
+			return nil
+		}
+	}
+
 	if filter != "" {
 		// JMESPath can't support maps with arbitrary key types, so we convert
 		// to map[string]interface{} before filtering.

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +34,16 @@ func TestPrintable(t *testing.T) {
 	}
 	_, ok = printable(tmp)
 	assert.False(t, ok)
+}
+
+func TestFileDownload(t *testing.T) {
+	formatter := NewDefaultFormatter(false)
+	buf := &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", true)
+	viper.Set("rsh-filter", "")
+	formatter.Format(Response{
+		Body: []byte{0, 1, 2, 3},
+	})
+	assert.Equal(t, []byte{0, 1, 2, 3}, buf.Bytes())
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -155,3 +155,15 @@ id3
 If the filtered output result doesn't match one of the above types, then `-r` is a no-op.
 
 This feature is mainly useful for shell scripting, where you don't want to have to parse the JSON and instead just want to loop through a list of IDs and run further commands.
+
+## Downloading Files & Saving Responses
+
+Raw mode in combination with redirected output can also be used to download files, and saving a structured data response (e.g. JSON, CBOR, YAML, etc) is simple as well:
+
+```bash
+# Save a zip file from the server.
+$ restish api.example.com/file.zip -r >file.zip
+
+# Save structured data
+$ restish api.example.com/items -f body >items.json
+```


### PR DESCRIPTION
This documents how to save responses and enables the use of raw mode (`-r`) with binary files so they can be easily saved via output redirection to a file. Fixes #37.