### PR TITLE
fix: parameter serialization for style: form, fixes #47

### DIFF
--- a/cli/param.go
+++ b/cli/param.go
@@ -64,16 +64,17 @@ func (p Param) Serialize(value interface{}) []string {
 		tmp := []string{}
 		switch p.Style {
 		case StyleForm:
-			for i, item := range value.([]interface{}) {
+			for i := 0; i < v.Len(); i++ {
+				item := v.Index(i)
 				if p.Explode {
-					tmp = append(tmp, fmt.Sprintf("%v", item))
+					tmp = append(tmp, fmt.Sprintf("%v", item.Interface()))
 				} else {
 					if len(tmp) == 0 {
 						tmp = append(tmp, "")
 					}
 
-					tmp[0] += fmt.Sprintf("%v", item)
-					if i < len(value.([]interface{})) {
+					tmp[0] += fmt.Sprintf("%v", item.Interface())
+					if i < v.Len()-1 {
 						tmp[0] += ","
 					}
 				}
@@ -82,9 +83,6 @@ func (p Param) Serialize(value interface{}) []string {
 			tmp = append(tmp, "")
 			for i := 0; i < v.Len(); i++ {
 				item := v.Index(i)
-				if item.Kind() == reflect.Ptr {
-					item = item.Elem()
-				}
 				tmp[0] += fmt.Sprintf("%v", item.Interface())
 				if i < v.Len()-1 {
 					tmp[0] += ","

--- a/cli/param_test.go
+++ b/cli/param_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+var paramInputs = []struct {
+	Name     string
+	Type     string
+	Style    Style
+	Explode  bool
+	Value    interface{}
+	Expected []string
+}{
+	{"bool-simple", "boolean", StyleSimple, false, true, []string{"true"}},
+	{"bool-form", "boolean", StyleForm, false, true, []string{"test=true"}},
+	{"int-simple", "integer", StyleSimple, false, 123, []string{"123"}},
+	{"int-form", "integer", StyleForm, false, 123, []string{"test=123"}},
+	{"num-simple", "number", StyleSimple, false, 123.4, []string{"123.4"}},
+	{"num-form", "number", StyleForm, false, 123.4, []string{"test=123.4"}},
+	{"str-simple", "string", StyleSimple, false, "hello", []string{"hello"}},
+	{"str-form", "string", StyleForm, false, "hello", []string{"test=hello"}},
+	{"arr-bool-simple", "array[boolean]", StyleSimple, false, []bool{true, false}, []string{"true,false"}},
+	{"arr-bool-form", "array[boolean]", StyleForm, false, []bool{true, false}, []string{"true,false"}},
+	{"arr-bool-form-explode", "array[boolean]", StyleForm, true, []bool{true, false}, []string{"true", "false"}},
+	{"arr-int-simple", "array[integer]", StyleSimple, false, []int{123, 456}, []string{"123,456"}},
+	{"arr-int-form", "array[integer]", StyleForm, false, []int{123, 456}, []string{"123,456"}},
+	{"arr-int-form-explode", "array[integer]", StyleForm, true, []int{123, 456}, []string{"123", "456"}},
+	{"arr-str-simple", "array[string]", StyleSimple, false, []string{"one", "two"}, []string{"one,two"}},
+	{"arr-str-form", "array[string]", StyleForm, false, []string{"one", "two"}, []string{"one,two"}},
+	{"arr-str-form-explode", "array[string]", StyleForm, true, []string{"one", "two"}, []string{"one", "two"}},
+}
+
+func TestParamSerialize(t *testing.T) {
+	for _, input := range paramInputs {
+		t.Run(input.Name, func(t *testing.T) {
+			p := Param{
+				Name:    "test",
+				Type:    input.Type,
+				Style:   input.Style,
+				Explode: input.Explode,
+			}
+
+			serialized := p.Serialize(input.Value)
+			assert.Equal(t, input.Expected, serialized)
+		})
+	}
+}
+
+func TestParamFlag(t *testing.T) {
+	for _, input := range paramInputs {
+		t.Run(input.Name, func(t *testing.T) {
+			p := Param{
+				Name:    "test",
+				Type:    input.Type,
+				Style:   input.Style,
+				Explode: input.Explode,
+			}
+
+			flags := pflag.NewFlagSet("", pflag.PanicOnError)
+			p.AddFlag(flags)
+
+			assert.NotNil(t, flags.Lookup("test"))
+		})
+	}
+}


### PR DESCRIPTION
There was a bug looping over the array of values. This fixes it and adds tests for each supported type to prevent regressions in the future!