### PR TITLE
feat: add api sync command

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -92,6 +92,20 @@ func initAPIConfig() {
 		Run:     askInitAPIDefault,
 	})
 
+	apiCommand.AddCommand(&cobra.Command{
+		Use:   "sync short-name",
+		Short: "Sync an API",
+		Long:  "Force-fetch the latest API description and update the local cache.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			viper.Set("rsh-no-cache", true)
+			_, err := Load(fixAddress(args[0]), Root)
+			if err != nil {
+				panic(err)
+			}
+		},
+	})
+
 	// Register API sub-commands
 	configs = apiConfigs{}
 	if err := apis.Unmarshal(&configs); err != nil {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -220,3 +220,22 @@ func TestLoadCache(t *testing.T) {
 	runNoReset("cache-test --help")
 	runNoReset("cache-test --help")
 }
+
+func TestAPISync(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://sync-test.example.com/").Reply(404)
+	gock.New("https://sync-test.example.com/openapi.json").Reply(404)
+
+	reset(false)
+
+	configs["sync-test"] = &APIConfig{
+		name: "sync-test",
+		Base: "https://sync-test.example.com",
+		Profiles: map[string]*APIProfile{
+			"default": {},
+		},
+	}
+
+	runNoReset("api sync sync-test")
+}


### PR DESCRIPTION
This command forces a refresh of the named API, so users can use it to get the latest after an API release is made. Just a convenience for doing something like `RSH_NO_CACHE=1 restish your-api --help` or something along those lines to force a fetch/parse of the OpenAPI.