### PR TITLE
docs: add comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Restish](https://rest.sh/) is a CLI for interacting with [REST](https://apisyouwonthate.com/blog/rest-and-hypermedia-in-2019)-ish HTTP APIs with some nice features built-in, like always having the latest API resources, fields, and operations available when they go live on the API without needing to install or update anything.
 
-See the [user guide](https://rest.sh/#/guide) to get started.
+See the [user guide](https://rest.sh/#/guide) to get started, or how Restish [compares to cURL & HTTPie](https://rest.sh/#/comparison).
 
 Features include:
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,6 @@
 - [Home](/ "Restish")
 - [Guide](guide.md "Restish User Guide")
+- [Comparison](comparison.md "Comparison")
 - [Configuration](configuration.md "Configuring Restish")
 - [OpenAPI](openapi.md "OpenAPI 3 & Restish")
 - [Input](input.md "Restish Input")

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,147 @@
+# Comparison to other tools
+
+See how Restish compares to other tools below:
+
+| Feature                                              | Restish | HTTPie        | cURL            |
+| ---------------------------------------------------- | ------- | ------------- | --------------- |
+| Implementation Language                              | Go      | Python        | C               |
+| Fast native no-dependency binary                     | ✅      | ❌            | ✅              |
+| HEAD/GET/POST/PUT/PATCH/DELETE/OPTIONS/etc           | ✅      | ✅            | ✅              |
+| HTTPS by default                                     | ✅      | ❌            | ❌              |
+| HTTP/2 by default                                    | ✅      | ❌            | ❌              |
+| OAuth2.0 token fetching/caching                      | ✅      | 🟠 (plugin)   | ❌              |
+| Authentication profiles                              | ✅      | 🟠 (sessions) | ❌              |
+| Content negotiation by default                       | ✅      | 🟠 (encoding) | ❌              |
+| gzip encoding                                        | ✅      | ✅            | ❌              |
+| brotli encoding                                      | ✅      | ❌            | ❌              |
+| CBOR & MessagePack binary format decoding            | ✅      | ❌            | ❌              |
+| Local cache via `Cache-Control` or `Expires` headers | ✅      | ❌            | ❌              |
+| Shorthand for structured data input                  | ✅      | ✅            | ❌              |
+| Loading structured data fields from files via `@`    | ✅      | ✅            | ❌              |
+| Raw input via stdin just works                       | ✅      | ✅            | 🟠 (via `-d@-`) |
+| Per-domain configuration (e.g. default headers)      | ✅      | ❌            | ❌              |
+| API nicknames, e.g. `github/users/repos`             | ✅      | ❌            | ❌              |
+| OpenAPI 3 support                                    | ✅      | ❌            | ❌              |
+| API documentation & examples via `--help`            | ✅      | ❌            | ❌              |
+| Syntax highlighting                                  | ✅      | ✅            | ❌              |
+| Pretty printing                                      | ✅      | ✅            | ❌              |
+| Image response preview in terminal                   | ✅      | ❌            | ❌              |
+| Structured response filtering                        | ✅      | ❌            | ❌              |
+| Hypermedia link parsing                              | ✅      | ❌            | ❌              |
+| Automatic pagination for `next` link relations       | ✅      | ❌            | ❌              |
+| URL & command shell completion hints                 | ✅      | ❌            | ❌              |
+
+# Performance Comparison
+
+Test were run on a Macbook Pro and averages of several requests are reported as latency can and does vary. The general takeaway is that performance is better than HTTPie and very close to cURL but with many more features. Numbers below are in seconds.
+
+| Test                           | Restish | Restish (cached) | HTTPie |  cURL |
+| ------------------------------ | ------: | ---------------: | -----: | ----: |
+| Github list repos              |   1.210 |            0.620 |  1.358 | 1.122 |
+| Github list repo collaborators |   0.251 |            0.049 |  0.702 | 0.212 |
+| Digital Ocean get account      |   0.512 | no cache headers |  0.786 | 0.526 |
+| Get `httpbin.org/cache/60`     |   0.401 |            0.025 |  0.707 | 0.371 |
+
+As the above shows, if caching is enabled at the API level then Restish can actually outperform `curl` in some scenarios. Imagine the following naive shell script where a single user might own many items and the `get-user` operation is cacheable:
+
+```bash
+for ITEM_ID in $(restish my-api list-items); do
+  USER_ID=$(restish my-api get-item $ITEM_ID -f body.user_id)
+  # The following call is going to be cached sometimes, saving us time!
+  EMAIL=$(restish my-api get-user $USER_ID -f body.email)
+  echo "$ITEM_ID is owned by $EMAIL"
+done
+```
+
+This can be demonstrated in a very silly example with `zsh` showing how these small differences can easily compound to many second differences in how fast your scripts may run:
+
+```bash
+# curl total time: 3.968s
+time (repeat 10 {curl https://httpbin.org/cache/60})
+
+# HTTPie total time: 6.699s
+time (repeat 10 {https https://httpbin.org/cache/60})
+
+# Restish total time: 0.702s (first request is not cached)
+time (repeat 10 {restish https://httpbin.org/cache/60})
+```
+
+# Detailed Comparisons
+
+## Passing Headers & Query Params
+
+This is how you pass parameters to the API.
+
+cURL Example:
+
+```bash
+curl -H Header:value 'https://api.example.com/foo?a=1&b=true'
+curl -H Header:value https://api.example.com/foo -G -d a=1 -d b=true
+```
+
+HTTPie Example:
+
+```bash
+https Header:value 'api.example.com/foo?a=1&b=true'
+https Header:value api.example.com/foo a==1 b==true
+```
+
+Restish Example:
+
+```bash
+restish -H Header:value 'api.example.com/foo?a=1&b=true'
+restish -H Header:value api.example.com/foo -q a=1 -q b=true
+```
+
+## Input Shorthand
+
+This is one mechanism to generate and pass a request body to the API.
+
+cURL Example: n/a
+
+HTTPie Example:
+
+```bash
+http post pie.dev/post \
+  platform[name]=HTTPie \
+  platform[about][mission]='Make APIs simple and intuitive' \
+  platform[about][homepage]=httpie.io \
+  platform[about][stars]:=54000 \
+  platform[apps][]=Terminal \
+  platform[apps][]=Desktop \
+  platform[apps][]=Web \
+  platform[apps][]=Mobile
+```
+
+Restish equivalent:
+
+```bash
+restish post pie.dev/post \
+  platform.name: HTTPie, \
+  platform.about.mission: Make APIs simple and intuitive, \
+  platform.about.homepage: httpie.io, \
+  platform.about.stars: 54000, \
+  platform.apps: Terminal, Desktop, Web, Mobile
+```
+
+## Getting Header Values
+
+How easy is it to read the output of a header in a shell environment?
+
+cURL Exmaple:
+
+```bash
+curl httpbin.org/get --head 2>/dev/null | grep Content-Length | cut -d':' -d' ' -f2
+```
+
+HTTPie Example:
+
+```bash
+http --headers httpbin.org/get | grep Content-Length | cut -d':' -d' ' -f2
+```
+
+Restish Example:
+
+```bash
+restish httpbin.org/get -f 'headers."Content-Length"' -r
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -166,6 +166,15 @@
         subMaxLevel: 3,
         search: "auto",
         auto2top: true,
+        plugins: [
+          function (hook, vm) {
+            hook.beforeEach(function (html) {
+              return (
+                html + '<hr/><div style="text-align:center"><a href="https://github.com/danielgtaylor/restish/blob/main/docs/' + vm.route.file + '">Edit this page on Github</a></div>'
+              );
+            });
+          }
+        ]
       };
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
@@ -205,14 +214,14 @@
       };
 
       Prism.languages.bash = {
-        comment: /^#.*/m,
+        comment: /^\s*#.*/m,
         json: {
-          pattern: /^\{(.|\n)*\}/m,
+          pattern: /'?\{(.|\n)*\}'?/m,
           greedy: false,
           inside: Prism.languages.json,
         },
         uri: {
-          pattern: /(https?:\/\/)?[a-z0-9.-]+\.com\S*/,
+          pattern: /['"]?(https?:\/\/)?[a-z0-9.-]+\.(com|org|dev)\S*['"]?/,
         },
         variable: /[A-Z0-9_]+(?=[=])/,
         varuse: {
@@ -226,7 +235,7 @@
           },
         },
         queryparam: {
-          pattern: /-q [a-z0-9-]+=\S+/i,
+          pattern: /(-[qd] [a-z0-9-]+=\S+|[a-z0-9-]+==\S+)/i,
           inside: {
             property: /[a-z0-9-]+(?==)/i,
           },
@@ -235,11 +244,12 @@
           pattern: /("(?:\\.|[^\\"\r\n])*"(?!\s*:))|('(?:\\.|[^\\'\r\n])*'(?!\s*:))/,
           greedy: true,
         },
-        property: /[a-z0-9.\[\]-]+(?=:)/,
+        redirect: /2>\/dev\/null/,
+        property: /[A-Za-z0-9.\[\]-]+(?=:[a-z0-9. _-])/,
         number: /\b[0-9]+(\.[0-9]+)?/,
         boolean: /\b(?:true|false)\b/i,
         null: /\bnull\b/i,
-        keyword: /restish|</,
+        keyword: /restish|<|[|]|\b(for|do|done)(?!\/)\b/,
       };
     </script>
   </body>

--- a/docs/input.md
+++ b/docs/input.md
@@ -56,7 +56,7 @@ Will send the following request:
 
 ```http
 POST /items HTTP/2.0
-Content-Type: application/json; charset=utf-8
+Content-Type: application/json
 Host: example.com
 
 {


### PR DESCRIPTION
Adds some extra documentation and a comparison to cURL and HTTPie. Fixes #97.