### PR TITLE
fix: detect text/yaml response content type

### DIFF
--- a/cli/content.go
+++ b/cli/content.go
@@ -159,7 +159,7 @@ type YAML struct{}
 // Detect if the content type is YAML.
 func (y YAML) Detect(contentType string) bool {
 	first := strings.Split(contentType, ";")[0]
-	if first == "application/yaml" || first == "application/x-yaml" || strings.HasSuffix(first, "+yaml") {
+	if first == "application/yaml" || first == "application/x-yaml" || first == "text/yaml" || strings.HasSuffix(first, "+yaml") {
 		return true
 	}
 


### PR DESCRIPTION
Some servers will respond with `text/yaml` instead of the other types. This makes sure we can detect and handle it correctly.