### PR TITLE
fix: do not use scientific notation for large integers

### DIFF
--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -264,6 +265,10 @@ func (f *DefaultFormatter) Format(resp Response) error {
 			for _, item := range data.([]interface{}) {
 				if item == nil {
 					encoded = append(encoded, []byte("null\n")...)
+				} else if f, ok := item.(float64); ok && f == float64(int64(f)) {
+					// This is likely an integer from JSON that was loaded as a float64!
+					// Prevent the use of scientific notation!
+					encoded = append(strconv.AppendFloat(encoded, f, 'f', -1, 64), '\n')
 				} else {
 					encoded = append(encoded, []byte(fmt.Sprintf("%v\n", item))...)
 				}

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -47,3 +47,21 @@ func TestFileDownload(t *testing.T) {
 	})
 	assert.Equal(t, []byte{0, 1, 2, 3}, buf.Bytes())
 }
+
+func TestRawLargeJSONNumbers(t *testing.T) {
+	formatter := NewDefaultFormatter(false)
+	buf := &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", true)
+	viper.Set("rsh-filter", "body")
+	formatter.Format(Response{
+		Body: []interface{}{
+			nil,
+			float64(1000000000000000),
+			float64(1.2e5),
+			float64(1.234),
+			float64(0.00000000000005), // This should still use scientific notation!
+		},
+	})
+	assert.Equal(t, "null\n1000000000000000\n120000\n1.234\n5e-14\n", buf.String())
+}


### PR DESCRIPTION
Fixes #99. If it's a large number, and is an integer, then force a non-scientific notation representation. This mostly affects JSON as it uses `float64` for all numbers.