### PR TITLE
fix: do not panic on empty image

### DIFF
--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -293,7 +293,7 @@ func (f *DefaultFormatter) Format(resp Response) error {
 			var e []byte
 
 			ct := resp.Headers["Content-Type"]
-			if ct == "image/png" || ct == "image/jpeg" || ct == "image/webp" || ct == "image/gif" {
+			if resp.Body != nil && (ct == "image/png" || ct == "image/jpeg" || ct == "image/webp" || ct == "image/gif") {
 				// This is likely an image. Let's display it if we can! Get the window
 				// size, read and scale the image, and display it using unicode.
 				w, h, err := terminal.GetSize(0)

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -65,3 +65,20 @@ func TestRawLargeJSONNumbers(t *testing.T) {
 	})
 	assert.Equal(t, "null\n1000000000000000\n120000\n1.234\n5e-14\n", buf.String())
 }
+
+func TestFormatEmptyImage(t *testing.T) {
+	formatter := NewDefaultFormatter(false)
+	buf := &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", false)
+	viper.Set("rsh-filter", "")
+
+	// This should not panic!
+	formatter.Format(Response{
+		Headers: map[string]string{
+			"Content-Type":   "image/jpeg",
+			"Content-Length": "0",
+		},
+		Body: nil,
+	})
+}


### PR DESCRIPTION
Fixes a bug where a response may have an image content type but zero byte body, which resulted in a crash due to:

> `ERROR: Caught error: interface conversion: interface {} is nil, not []uint8`

Now it will just skip trying to write out an image if the body is `nil`.