### PR TITLE
fix: prevent escaping JSON for browsers

### DIFF
--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -366,11 +366,19 @@ func (f *DefaultFormatter) Format(resp Response) error {
 			lexer = "yaml"
 		} else {
 			data = makeJSONSafe(data, false)
-			encoded, err = json.MarshalIndent(data, "", "  ")
 
-			if err != nil {
+			// The default encoder escapes '<', '>', and '&' which we don't want
+			// since we are not a browser. Disable this with an encoder instance.
+			// See https://stackoverflow.com/a/28596225/164268
+			buf := &bytes.Buffer{}
+			enc := json.NewEncoder(buf)
+			enc.SetEscapeHTML(false)
+			enc.SetIndent("", "  ")
+
+			if err := enc.Encode(data); err != nil {
 				return err
 			}
+			encoded = buf.Bytes()
 
 			lexer = "json"
 		}

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -82,3 +82,24 @@ func TestFormatEmptyImage(t *testing.T) {
 		Body: nil,
 	})
 }
+
+func TestJSONEscape(t *testing.T) {
+	formatter := NewDefaultFormatter(false)
+	buf := &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", false)
+	viper.Set("rsh-filter", "")
+	viper.Set("rsh-output-format", "json")
+	defer func() { viper.Set("rsh-output_format", "auto") }()
+
+	formatter.Format(Response{
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: map[string]string{
+			"test": "<em> and & shouldn't get escaped",
+		},
+	})
+
+	assert.Contains(t, buf.String(), "<em> and & shouldn't get escaped")
+}


### PR DESCRIPTION
Prevents escaping `<`, `>`, and `&` in the JSON (which exists to support some legacy browsers). See also https://stackoverflow.com/a/28596225/164268