### PR TITLE
fix: find HAL links in array responses

### DIFF
--- a/cli/links.go
+++ b/cli/links.go
@@ -91,18 +91,27 @@ type HALParser struct{}
 
 // ParseLinks processes the links in a parsed response.
 func (h HALParser) ParseLinks(resp *Response) error {
-	hal := halBody{}
-	if err := mapstructure.Decode(resp.Body, &hal); err == nil {
-		for rel, link := range hal.Links {
-			if rel == "curies" {
-				// TODO: handle curies at some point?
-				continue
-			}
+	entries := []interface{}{}
+	if l, ok := resp.Body.([]interface{}); ok {
+		entries = l
+	} else {
+		entries = append(entries, resp.Body)
+	}
 
-			resp.Links[rel] = append(resp.Links[rel], &Link{
-				Rel: rel,
-				URI: link.Href,
-			})
+	for _, entry := range entries {
+		hal := halBody{}
+		if err := mapstructure.Decode(entry, &hal); err == nil {
+			for rel, link := range hal.Links {
+				if rel == "curies" {
+					// TODO: handle curies at some point?
+					continue
+				}
+
+				resp.Links[rel] = append(resp.Links[rel], &Link{
+					Rel: rel,
+					URI: link.Href,
+				})
+			}
 		}
 	}
 

--- a/cli/links_test.go
+++ b/cli/links_test.go
@@ -70,6 +70,34 @@ func TestHALParser(t *testing.T) {
 	assert.Equal(t, r.Links["item"][0].URI, "/item")
 }
 
+func TestHALParserArray(t *testing.T) {
+	r := &Response{
+		Links: Links{},
+		Body: []interface{}{
+			map[string]interface{}{
+				"_links": map[string]interface{}{
+					"self": map[string]interface{}{
+						"href": "/one",
+					},
+				},
+			},
+			map[string]interface{}{
+				"_links": map[string]interface{}{
+					"self": map[string]interface{}{
+						"href": "/two",
+					},
+				},
+			},
+		},
+	}
+
+	p := HALParser{}
+	err := p.ParseLinks(r)
+	assert.NoError(t, err)
+	assert.Equal(t, r.Links["self"][0].URI, "/one")
+	assert.Equal(t, r.Links["self"][1].URI, "/two")
+}
+
 func TestTerrificallySimpleJSONParser(t *testing.T) {
 	r := &Response{
 		Links: Links{},


### PR DESCRIPTION
This makes sure that arrays of objects (e.g. list operations) can have parsed links as well.