### PR TITLE
fix: formatting, simplify dates

### DIFF
--- a/cli/lexer.go
+++ b/cli/lexer.go
@@ -19,7 +19,7 @@ var ReadableLexer = lexers.Register(chroma.MustNewLexer(
 		},
 		"scalar": {
 			{`(true|false|null)\b`, chroma.KeywordConstant, nil},
-			{`"?0x[0-9a-f]+(...)?"?`, chroma.LiteralNumberHex, nil},
+			{`"?0x[0-9a-f]+(\\.\\.\\.)?"?`, chroma.LiteralNumberHex, nil},
 			{`"?[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9:+-.]+Z?)?"?`, chroma.LiteralDate, nil},
 			{`-?(0|[1-9]\d*)(\.\d+[eE](\+|-)?\d+|[eE](\+|-)?\d+|\.\d+)`, chroma.LiteralNumberFloat, nil},
 			{`-?(0|[1-9]\d*)`, chroma.LiteralNumberInteger, nil},

--- a/cli/readable.go
+++ b/cli/readable.go
@@ -148,6 +148,10 @@ func marshalReadable(indent string, v interface{}) ([]byte, error) {
 		return []byte(m), nil
 	case reflect.Struct:
 		if t, ok := v.(time.Time); ok {
+			if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+				// Special case: date only
+				return []byte(t.UTC().Format("2006-01-02")), nil
+			}
 			return []byte(t.UTC().Format(time.RFC3339Nano)), nil
 		}
 

--- a/cli/readable_test.go
+++ b/cli/readable_test.go
@@ -8,9 +8,11 @@ import (
 )
 
 func TestReadableMarshal(t *testing.T) {
+	created, _ := time.Parse(time.RFC3339, "2020-01-01T12:34:56Z")
 	data := map[string]interface{}{
 		"binary":     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		"created":    time.Time{},
+		"created":    created,
+		"date":       created.Truncate(24 * time.Hour),
 		"id":         "test",
 		"emptyMap":   map[string]interface{}{},
 		"emptyArray": []string{},
@@ -28,7 +30,8 @@ func TestReadableMarshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{
   binary: 0x00010203040506070809...
-  created: 0001-01-01T00:00:00Z
+  created: 2020-01-01T12:34:56Z
+  date: 2020-01-01
   emptyArray: []
   emptyMap: {}
   float: 1.2


### PR DESCRIPTION
Fixes a formatting bug where `.` was matching too many chars instead of a literal `.` and simplifies the human-readable representation of dates where the time component is empty.