### PR TITLE
fix: base64 handling of []byte and raw mode on structured input

### DIFF
--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -66,6 +66,37 @@ func TestRawLargeJSONNumbers(t *testing.T) {
 	assert.Equal(t, "null\n1000000000000000\n120000\n1.234\n5e-14\n", buf.String())
 }
 
+func TestBinary(t *testing.T) {
+	formatter := NewDefaultFormatter(false)
+	buf := &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", false)
+	viper.Set("rsh-filter", "")
+	viper.Set("rsh-output-format", "json")
+	formatter.Format(Response{
+		Body: []byte{0, 1, 2, 3, 4, 5},
+	})
+	assert.Contains(t, buf.String(), "AAECAwQF")
+
+	buf = &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", true)
+	viper.Set("rsh-filter", "body")
+	formatter.Format(Response{
+		Body: []byte{0, 1, 2, 3, 4, 5},
+	})
+	assert.Equal(t, "AAECAwQF\n", buf.String())
+
+	buf = &bytes.Buffer{}
+	Stdout = buf
+	viper.Set("rsh-raw", true)
+	viper.Set("rsh-filter", "")
+	formatter.Format(Response{
+		Body: []byte{0, 1, 2, 3, 4, 5},
+	})
+	assert.Equal(t, "\x00\x01\x02\x03\x04\x05", buf.String())
+}
+
 func TestFormatEmptyImage(t *testing.T) {
 	formatter := NewDefaultFormatter(false)
 	buf := &bytes.Buffer{}

--- a/cli/request.go
+++ b/cli/request.go
@@ -286,9 +286,14 @@ func ParseResponse(resp *http.Response) (Response, error) {
 	data, _ := ioutil.ReadAll(resp.Body)
 
 	if len(data) > 0 {
-		ct := resp.Header.Get("content-type")
-		if err := Unmarshal(ct, data, &parsed); err != nil {
+		if viper.GetBool("rsh-raw") && viper.GetString("rsh-filter") == "" {
+			// Raw mode without filtering, don't parse the response.
 			parsed = data
+		} else {
+			ct := resp.Header.Get("content-type")
+			if err := Unmarshal(ct, data, &parsed); err != nil {
+				parsed = data
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR:

- Fixes behavior when `-f` is blank and `-r` is passed as this should just dump the raw response instead of parsing.
- Fixes base64 behavior which was broken by converting `[]byte` into `[]interface{}` which disabled the built-in base64 behavior. This is now re-enabled and also supported for raw mode.