### PR TITLE
docs: update guide & other docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,4 +56,4 @@ Every API deserves a CLI for quick access and for power users to script against 
 
 ## Getting started
 
-Start with the [guide](/guide?id=guide).
+Start with the [guide](/guide.md) to learn how to install and configure Restish as well as getting an overview of all of its features.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -75,22 +75,22 @@ This is how you pass parameters to the API.
 cURL Example:
 
 ```bash
-curl -H Header:value 'https://api.example.com/foo?a=1&b=true'
-curl -H Header:value https://api.example.com/foo -G -d a=1 -d b=true
+curl -H Header:value 'https://api.rest.sh/?a=1&b=true'
+curl -H Header:value https://api.rest.sh/ -G -d a=1 -d b=true
 ```
 
 HTTPie Example:
 
 ```bash
-https Header:value 'api.example.com/foo?a=1&b=true'
-https Header:value api.example.com/foo a==1 b==true
+https Header:value 'api.rest.sh/?a=1&b=true'
+https Header:value api.rest.sh/ a==1 b==true
 ```
 
 Restish Example:
 
 ```bash
-restish -H Header:value 'api.example.com/foo?a=1&b=true'
-restish -H Header:value api.example.com/foo -q a=1 -q b=true
+restish -H Header:value 'api.rest.sh/?a=1&b=true'
+restish -H Header:value api.rest.sh/ -q a=1 -q b=true
 ```
 
 ## Input Shorthand
@@ -102,7 +102,7 @@ cURL Example: n/a
 HTTPie Example:
 
 ```bash
-http post pie.dev/post \
+https post api.rest.sh \
   platform[name]=HTTPie \
   platform[about][mission]='Make APIs simple and intuitive' \
   platform[about][homepage]=httpie.io \
@@ -116,7 +116,7 @@ http post pie.dev/post \
 Restish equivalent:
 
 ```bash
-restish post pie.dev/post \
+restish post api.rest.sh \
   platform.name: HTTPie, \
   platform.about.mission: Make APIs simple and intuitive, \
   platform.about.homepage: httpie.io, \
@@ -131,17 +131,17 @@ How easy is it to read the output of a header in a shell environment?
 cURL Exmaple:
 
 ```bash
-curl httpbin.org/get --head 2>/dev/null | grep Content-Length | cut -d':' -d' ' -f2
+curl https://api.rest.sh/ --head 2>/dev/null | grep -i Content-Length | cut -d':' -d' ' -f2
 ```
 
 HTTPie Example:
 
 ```bash
-http --headers httpbin.org/get | grep Content-Length | cut -d':' -d' ' -f2
+https --headers api.rest.sh | grep Content-Length | cut -d':' -d' ' -f2
 ```
 
 Restish Example:
 
 ```bash
-restish httpbin.org/get -f 'headers."Content-Length"' -r
+restish api.rest.sh -f 'headers."Content-Length"' -r
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,18 +37,18 @@ The following three would be equivalent ways to configure restish:
 
 ```bash
 # CLI arguments
-$ restish -v -p testing https://api.example.com/items
+$ restish -v -p testing api.rest.sh/images
 ```
 
 ```bash
 # Environment variables
-$ RSH_VERBOSE=1 RSH_PROFILE=testing restish https://api.example.com/items
+$ RSH_VERBOSE=1 RSH_PROFILE=testing restish api.rest.sh/images
 ```
 
 ```bash
 # Configuration file
 $ echo '{"rsh-verbose": true, "rsh-profile": "testing"}' > ~/.restish/config.json
-$ restish https://api.example.com/items
+$ restish api.rest.sh/images
 ```
 
 Should TTY autodetection for colored output cause any problems, you can manually disable colored output via the `NOCOLOR=1` environment variable.
@@ -72,14 +72,15 @@ If the API offers autoconfiguration data (e.g. through the [`x-cli-config` OpenA
 Once an API is configured, you can start using it by using its short name. For example, given an API named `example`:
 
 ```bash
-# If it has an API service description, call an operation
-$ restish example list-items
+# If it has an API service description, call an operation:
+$ restish example list-images
 
-# If there is no API description you can still use persistent headers and auth
-$ restish example/items
+# If there is no API description you can still use persistent headers, auth,
+# and the API short-name in URLs:
+$ restish example/images
 
 # It also works for full URIs, e.g. auth will be applied to:
-$ restish https://api.example.com/items
+$ restish https://api.example.com/images
 ```
 
 Read on the learn more about the available API options.

--- a/docs/hypermedia.md
+++ b/docs/hypermedia.md
@@ -17,14 +17,126 @@ Restish uses these standardized links to automatically handle paginated collecti
 
 This behavior can be disabled via the `--rsh-no-paginate` argument or `RSH_NO_PAGINATE=1` environment variable when needed. You may need to do this for large or slow collections.
 
+```bash
+# Automatic paginated response returns all pages
+$ restish api.rest.sh/images
+...
+[
+  {
+    format: "jpeg"
+    name: "Dragonfly macro"
+    self: "/images/jpeg"
+  }
+  {
+    format: "webp"
+    name: "Origami under blacklight"
+    self: "/images/webp"
+  }
+  {
+    format: "gif"
+    name: "Andy Warhol mural in Miami"
+    self: "/images/gif"
+  }
+  {
+    format: "png"
+    name: "Station in Prague"
+    self: "/images/png"
+  }
+  {
+    format: "heic"
+    name: "Chihuly glass in boats"
+    self: "/images/heic"
+  }
+]
+```
+
+```bash
+# Return a single page of results
+$ restish --rsh-no-paginate api.rest.sh/images
+Link: </images?cursor=abc123>; rel="next", </schemas/ImageItemList.json>; rel="describedby"
+...
+[
+  {
+    format: "jpeg"
+    name: "Dragonfly macro"
+    self: "/images/jpeg"
+  }
+  {
+    format: "webp"
+    name: "Origami under blacklight"
+    self: "/images/webp"
+  }
+]
+```
+
 ## Links Command
 
-The links command provides a shorthand for displaying the available links.
+The links command provides a shorthand for displaying the available links. All links are normalized to include the full URL. Paginated responses may generate the same link multiple times.
 
 ```bash
 # Display available links
-$ restish links api.example.com/items
+$ restish links api.rest.sh/images
+{
+  "describedby": [
+    {
+      "rel": "describedby",
+      "uri": "https://api.rest.sh/schemas/ImageItemList.json"
+    },
+    {
+      "rel": "describedby",
+      "uri": "https://api.rest.sh/schemas/ImageItemList.json"
+    },
+    {
+      "rel": "describedby",
+      "uri": "https://api.rest.sh/schemas/ImageItemList.json"
+    }
+  ],
+  "next": [
+    {
+      "rel": "next",
+      "uri": "https://api.rest.sh/images?cursor=abc123"
+    },
+    {
+      "rel": "next",
+      "uri": "https://api.rest.sh/images?cursor=def456"
+    }
+  ],
+  "self-item": [
+    {
+      "rel": "self-item",
+      "uri": "https://api.rest.sh/images/jpeg"
+    },
+    {
+      "rel": "self-item",
+      "uri": "https://api.rest.sh/images/webp"
+    },
+    {
+      "rel": "self-item",
+      "uri": "https://api.rest.sh/images/gif"
+    },
+    {
+      "rel": "self-item",
+      "uri": "https://api.rest.sh/images/png"
+    },
+    {
+      "rel": "self-item",
+      "uri": "https://api.rest.sh/images/heic"
+    }
+  ]
+}
+```
 
+```bash
 # Optionally filter to certain link relations
-$ restish links api.example.com/items next prev
+$ restish links api.rest.sh/images next
+[
+  {
+    "rel": "next",
+    "uri": "https://api.rest.sh/images?cursor=abc123"
+  },
+  {
+    "rel": "next",
+    "uri": "https://api.rest.sh/images?cursor=def456"
+  }
+]
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,7 +123,8 @@
       .token.class-name,
       .token.constant,
       .token.symbol,
-      .token.key {
+      .token.key,
+      .token.keypress {
         color: #5fafd7;
       }
 
@@ -153,7 +154,7 @@
         color: #af87af;
       }
 
-      .token.uri {
+      .token.uri, .token.url {
         color: #d6ffb7;
         font-style: italic;
       }
@@ -171,7 +172,7 @@
         auto2top: true,
         plugins: [
           function (hook, vm) {
-            hook.beforeEach(function (html) {
+            hook.afterEach(function (html) {
               return (
                 html + '<hr/><div style="text-align:center"><a href="https://github.com/danielgtaylor/restish/blob/main/docs/' + vm.route.file + '">Edit this page on Github</a></div>'
               );
@@ -181,8 +182,12 @@
       };
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+    <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0"></script>
+    <script src="//unpkg.com/mermaid/dist/mermaid.js"></script>
+    <script src="//unpkg.com/docsify-mermaid@latest/dist/docsify-mermaid.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true });</script>
     <script src="//unpkg.com/prismjs/components/prism-http.min.js"></script>
     <script src="//unpkg.com/prismjs/components/prism-json.min.js"></script>
     <script src="//unpkg.com/prismjs/components/prism-yaml.min.js"></script>
@@ -203,7 +208,7 @@
             property: /[A-Z][a-zA-Z0-9-]+(?=:)/,
           },
         },
-        property: /^\s+[a-z0-9-_]+(?=:)/im,
+        property: /^\s+['"]?[a-z0-9-_$]+['"]?(?=:)/im,
         date: /"?20[0-9]{2}-[01][0-9]-[0-9]{2}(T[0-9:+-.]+Z?)?"?/,
         uri: /"([a-z]+:\/\/|\/).*"/,
         string: {
@@ -218,13 +223,25 @@
 
       Prism.languages.bash = {
         comment: /^\s*#.*/m,
-        json: {
-          pattern: /'?\{(.|\n)*\}'?/m,
+        redirect: /2>\/dev\/null/,
+        response: {
+          pattern: /^(HTTP\/[12]|\{|\[)(.|\n)+(\]|\}(\n|$))/gm,
           greedy: false,
-          inside: Prism.languages.json,
+          inside: Prism.languages.readable
         },
         uri: {
-          pattern: /['"]?(https?:\/\/)?[a-z0-9.-]+\.(com|org|dev)\S*['"]?/,
+          pattern: /['"]?(https?:\/\/)?[a-z0-9.-]+\.(com|org|dev|sh)[\S{}]*['"]?/,
+        },
+        shorturi: {
+          alias: "uri",
+          pattern: /\s[a-z0-9_.-]+\/[a-zA-Z0-9_\.\/?=&{}-]*/,
+        },
+        date: {
+          pattern: /"?20[0-9]{2}-[01][0-9]-[0-9]{2}(T[0-9:+-.]+Z?)?"?/,
+        },
+        httpdate: {
+          alias: "date",
+          pattern: /"?(Mon|Tue|Wed|Thu|Fri|Sat|Sun), [0-9]+ \S+ [0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2} GMT"?/,
         },
         variable: /[A-Z0-9_]+(?=[=])/,
         varuse: {
@@ -247,7 +264,7 @@
           pattern: /("(?:\\.|[^\\"\r\n])*"(?!\s*:))|('(?:\\.|[^\\'\r\n])*'(?!\s*:))/,
           greedy: true,
         },
-        redirect: /2>\/dev\/null/,
+        keypress: /<\S+>/,
         property: /[A-Za-z0-9.\[\]-]+(?=:[a-z0-9. _-])/,
         number: /\b[0-9]+(\.[0-9]+)?/,
         boolean: /\b(?:true|false)\b/i,

--- a/docs/input.md
+++ b/docs/input.md
@@ -8,17 +8,17 @@ Request headers and query parameters are set via arguments or in the URI itself:
 
 ```bash
 # Pass a query param (either way)
-$ restish example.com/items?search=foo
-$ restish -q search=foo example.com/items
+$ restish api.rest.sh/?search=foo
+$ restish -q search=foo api.rest.sh
 
 # Query params with an API short name
-$ restish do/droplets?tag_name=prod
+$ restish example/images?cursor=abc123
 
 # Pass a header
-$ restish -H MyHeader:value example.com
+$ restish -H MyHeader:value api.rest.sh
 
 # Pass multiple
-$ restish -H Header1:val1 -H Header2:val2 example.com
+$ restish -H Header1:val1 -H Header2:val2 api.rest.sh
 ```
 
 ?> Note that query params use `=` as a delimiter while haders use `:`, just like with HTTP.
@@ -36,10 +36,10 @@ Any stream of data passed to standard input will be sent as the request body.
 
 ```bash
 # Set body from file
-$ restish put example.com/items <item.json
+$ restish put api.rest.sh <input.json
 
 # Set body from piped command
-$ echo '{"name": "hello"}' | restish put example.com/items
+$ echo '{"name": "hello"}' | restish put api.rest.sh
 ```
 
 ?> Don't forget to set the `Content-Type` header if needed. It will default to JSON if unset.
@@ -49,15 +49,15 @@ $ echo '{"name": "hello"}' | restish put example.com/items
 The [CLI Shorthand](shorthand.md) is a convenient way of providing structured data on the commandline. It is a JSON-like syntax that enables you to easily create nested structured data. For example:
 
 ```bash
-$ restish post example.com/items foo.bar[].baz: 1, .hello: world
+$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
 ```
 
 Will send the following request:
 
 ```http
-POST /items HTTP/2.0
+POST / HTTP/2.0
 Content-Type: application/json
-Host: example.com
+Host: api.rest.sh
 
 {
   "foo": {
@@ -79,8 +79,10 @@ It's also possible to use standard in as a template and replace or set values vi
 
 ```bash
 # Use both a file and override a value
-$ restish post example.com/items <template.json id: test1
-$ restish post example.com/items <template.json id: test2, tags[]: group1
+$ restish post api.rest.sh <template.json id: test1
+$ restish post api.rest.sh <template.json id: test2, tags[]: group1
 ```
 
 If you have a known small set of fields that need to change between calls, this makes it easy to do so without large complex commands.
+
+?> Hint: want to replace an array? Use something like `value: null, value[]: item` to first empty the array, then start building it up again.

--- a/docs/shorthand.md
+++ b/docs/shorthand.md
@@ -1,13 +1,17 @@
 # CLI Shorthand Syntax
 
-Restish comes with an optional contextual shorthand syntax for passing structured data into calls that require a body (i.e. `POST`, `PUT`, `PATCH`). While you can always pass full JSON or other documents through `stdin`, you can also specify or modify them by hand as arguments to the command using this shorthand syntax. For example:
+Restish comes with an optional contextual shorthand syntax for passing structured data into calls that require a body (i.e. `POST`, `PUT`, `PATCH`). While you can always pass full JSON or other documents through `stdin`, you can also specify or modify them by hand as arguments to the command using this shorthand syntax.
+
+?> Note: for the examples below, you may need to escape or quote the values depending on your shell & settings. Instead of `foo.bar[].baz: 1`, use `'foo.bar[].baz: 1'`. If using `zsh` you can prefix a command with `noglob` to ignore `?` and `[]`.
+
+For example:
 
 ```bash
 # Make an HTTP POST with a JSON body
-$ restish post api.example.com/items foo.bar[].baz: 1, .hello: world
+$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
 ```
 
-Would result in the following body contents being sent on the wire (assuming a JSON media type is specified in the service spec):
+Would result in the following body contents being sent on the wire (assuming a JSON content type):
 
 ```json
 {
@@ -61,10 +65,10 @@ It seems reasonable to ask, why create a new syntax?
 
 ## Features in Depth
 
-You can use the `j` executable from the OpenAPI CLI Generator project to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or CBOR if you prefer.
+You can use the `j` executable from the [CLI Shorthand](https://github.com/danielgtaylor/shorthand) project to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or CBOR if you prefer.
 
 ```bash
-go get -u github.com/danielgtaylor/openapi-cli-generator/j
+$ go install github.com/danielgtaylor/shorthand/cmd/j@latest
 ```
 
 Also feel free to use this tool to generate structured data for input to other commands.


### PR DESCRIPTION
This updates the guide in various ways:

- Switch to https://api.rest.sh/ as the example URL
- Clarifications  & fixes on several pages
- Fixes to syntax highlighting