### PR TITLE
docs: update missed example.com reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ $ restish example list-images
 $ restish example/images
 
 # It also works for full URIs, e.g. auth will be applied to:
-$ restish https://api.example.com/images
+$ restish https://api.rest.sh/images
 ```
 
 Read on the learn more about the available API options.

--- a/docs/hypermedia.md
+++ b/docs/hypermedia.md
@@ -5,7 +5,7 @@ Restish uses a standardized internal representation of hypermedia links to make 
 ```json
 {
   "rel": "next",
-  "uri": "https://api.example.com/items?cursor=abc123"
+  "uri": "https://api.rest.sh/images?cursor=abc123"
 }
 ```
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -48,7 +48,7 @@ Date: Thu, 28 May 2020 05:56:31 GMT
   id: "test"
   nested: {
     saved: true
-    self: "https://example.com/nested"
+    self: "https://api.rest.sh/example"
   }
   json: {
     datetime: "2020-05-27T05:41:19.603396Z"
@@ -109,7 +109,7 @@ Internally, the response is structured like this:
     "next": [
       {
         "rel": "next",
-        "uri": "https://api.example.com/items?cursor=abc123"
+        "uri": "https://api.rest.sh/images?cursor=abc123"
       }
     ]
   },

--- a/docs/shorthand.md
+++ b/docs/shorthand.md
@@ -47,7 +47,7 @@ The built-in CLI shorthand syntax is not the only one you can use to generate da
 For example, the shorthand example given above could be rewritten as:
 
 ```bash
-$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish post api.example.com/items
+$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish post api.rest.sh
 ```
 
 The built-in shorthand syntax implementation described herein uses those and the following for inspiration:


### PR DESCRIPTION
Fixes a few missed references to api.rest.sh that will return real data.