### PR TITLE
Password prompt when user defined but not password

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"net/http"
+	"syscall"
+
+	"golang.org/x/term"
 )
 
 // AuthParam describes an auth input parameter for an AuthHandler.
@@ -42,6 +46,18 @@ func (a *BasicAuth) Parameters() []AuthParam {
 
 // OnRequest gets run before the request goes out on the wire.
 func (a *BasicAuth) OnRequest(req *http.Request, key string, params map[string]string) error {
+	_, usernamePresent := params["username"]
+	_, passwordPresent := params["password"]
+
+	if usernamePresent && !passwordPresent {
+		fmt.Print("password: ")
+		inputPassword, err := term.ReadPassword(syscall.Stdin)
+		if err == nil {
+			params["password"] = string(inputPassword)
+		}
+		fmt.Println()
+	}
+
 	req.SetBasicAuth(params["username"], params["password"])
 	return nil
 }


### PR DESCRIPTION
The goal of this commit is to get the password used for Basic Auth from the prompt when it is not defined in the apis.json file for security reason.