### PR TITLE
api: add show and add missing sync documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,16 @@ $ restish https://api.rest.sh/images
 
 Read on the learn more about the available API options.
 
+### Showing an API configuration
+
+Showing an API is possible via the following command:
+
+```bash
+$ restish api configure $NAME
+```
+
+Output is in JSON by default. It can be displayed as a YAML by using `--rsh-output-format yaml` or `-o yaml`
+
 ### Persistent Headers & Query Params
 
 Follow the prompts to add or edit persistent headers or query params. These are values that get sent with **every request** when using that profile.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,14 @@ $ restish api configure $NAME
 
 Output is in JSON by default. It can be displayed as a YAML by using `--rsh-output-format yaml` or `-o yaml`
 
+### Syncing an API configuration
+
+If the API endpoints changed, you can force-fetch the latest API description and update the local cache:
+
+```bash
+$ restish api sync $NAME
+```
+
 ### Persistent Headers & Query Params
 
 Follow the prompts to add or edit persistent headers or query params. These are values that get sent with **every request** when using that profile.


### PR DESCRIPTION
This PR is to add "restish api show <name>" command.

Also adds missing "restish api sync" documentation.

Partially answering to #53 