### PR TITLE
auth: support deferring authentication to a third party script

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 
 	"golang.org/x/term"
@@ -59,5 +65,102 @@ func (a *BasicAuth) OnRequest(req *http.Request, key string, params map[string]s
 	}
 
 	req.SetBasicAuth(params["username"], params["password"])
+	return nil
+}
+
+// ExternalToolAuth defers authentication to a third party tool.
+// This avoids baking all possible authentication implementations
+// inside restish itself.
+type ExternalToolAuth struct{}
+
+// Request is used to exchange requests with the external tool.
+type Request struct {
+	Method string      `json:"method"`
+	URI    string      `json:"uri"`
+	Header http.Header `json:"headers"`
+	Body   string      `json:"body"`
+}
+
+// Parameters defines the ExternalToolAuth parameter names.
+// A single parameter is supported and required: `commandline` which
+// points to the tool to call to authenticate a request.
+func (a *ExternalToolAuth) Parameters() []AuthParam {
+	return []AuthParam{
+		{Name: "commandline", Required: true},
+		{Name: "omitbody", Required: false},
+	}
+}
+
+// OnRequest gets run before the request goes out on the wire.
+// The supplied commandline argument is ran with a JSON input
+// and expects a JSON output on stdout
+func (a *ExternalToolAuth) OnRequest(req *http.Request, key string, params map[string]string) error {
+	commandLine, _ := params["commandline"]
+	omitBodyStr, omitBodyPresent := params["omitbody"]
+	omitBody := false
+	if omitBodyPresent && strings.EqualFold(omitBodyStr, "true") {
+		omitBody = true
+	}
+	shell, shellPresent := os.LookupEnv("SHELL")
+	if !shellPresent {
+		shell = "/bin/sh"
+	}
+	cmd := exec.Command(shell, "-c", commandLine)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	bodyStr := ""
+	if req.Body != nil && !omitBody {
+		bodyBytes, err := io.ReadAll(req.Body)
+		if err != nil {
+			return err
+		}
+		bodyStr = string(bodyBytes)
+		req.Body = io.NopCloser(strings.NewReader(bodyStr))
+	}
+
+	textRequest := Request{
+		Method: req.Method,
+		URI:    req.URL.String(),
+		Header: req.Header,
+		Body:   bodyStr,
+	}
+	requestBytes, err := json.Marshal(textRequest)
+	if err != nil {
+		return err
+	}
+	_, err = stdin.Write(requestBytes)
+	if err != nil {
+		return err
+	}
+	stdin.Close()
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+	if len(outBytes) <= 0 {
+		return nil
+	}
+	var requestUpdates Request
+	err = json.Unmarshal(outBytes, &requestUpdates)
+	if err != nil {
+		return err
+	}
+
+	if len(requestUpdates.URI) > 0 {
+		req.URL, err = url.Parse(requestUpdates.URI)
+		if err != nil {
+			return err
+		}
+	}
+
+	for k, vs := range requestUpdates.Header {
+		for _, v := range vs {
+			// A single value is supported for each header
+			req.Header.Set(k, v)
+		}
+	}
 	return nil
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -652,6 +652,7 @@ func Defaults() {
 
 	// Register auth schemes
 	AddAuth("http-basic", &BasicAuth{})
+	AddAuth("external-tool", &ExternalToolAuth{})
 }
 
 // Run the CLI! Parse arguments, make requests, print responses.


### PR DESCRIPTION
Some OpenAPI backed APIs implement a custom API signature scheme to provide stronger guarantees against replay attacks than those provided by OAuth.

Generally speaking, these APIs tend to either wire a computed signature in an HTTP header or in a query argument in the URL.

This patch implements a new `external-tool` auth method which executes a configured program against a JSON representation of the request built by restish. If the program returns any output it is deserialized from JSON, allowing for new headers to be set, or for the URL to be modified. This then allows small script to be used alongside restish to implement any sort of API signature mechanism.