### PR TITLE
feat: mark & hide deprecated operations

### DIFF
--- a/cli/operation.go
+++ b/cli/operation.go
@@ -28,6 +28,7 @@ type Operation struct {
 	BodyMediaType string   `json:"bodyMediaType,omitempty"`
 	Examples      []string `json:"examples,omitempty"`
 	Hidden        bool     `json:"hidden,omitempty"`
+	Deprecated    string   `json:"deprecated,omitempty"`
 }
 
 // command returns a Cobra command instance for this operation.
@@ -52,14 +53,15 @@ func (o Operation) command() *cobra.Command {
 	}
 
 	sub := &cobra.Command{
-		Use:     use,
-		GroupID: o.Group,
-		Aliases: o.Aliases,
-		Short:   o.Short,
-		Long:    long,
-		Example: examples,
-		Args:    argSpec,
-		Hidden:  o.Hidden,
+		Use:        use,
+		GroupID:    o.Group,
+		Aliases:    o.Aliases,
+		Short:      o.Short,
+		Long:       long,
+		Example:    examples,
+		Args:       argSpec,
+		Hidden:     o.Hidden,
+		Deprecated: o.Deprecated,
 		Run: func(cmd *cobra.Command, args []string) {
 			uri := o.URITemplate
 

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -340,6 +340,11 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 		group = op.Tags[0]
 	}
 
+	dep := ""
+	if op.Deprecated {
+		dep = "do not use"
+	}
+
 	return cli.Operation{
 		Name:          name,
 		Group:         group,
@@ -354,6 +359,7 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 		BodyMediaType: mediaType,
 		Examples:      examples,
 		Hidden:        hidden,
+		Deprecated:    dep,
 	}
 }
 


### PR DESCRIPTION
This feature marks operations that are deprecated in OpenAPI as deprecated in the CLI as well, effectively hiding them from the top level `--help` listing and putting a warning when using them directly by utilizing a built-in cobra feature.