### PR TITLE
feat!: switch to shorthand v2

### DIFF
--- a/cli/edit.go
+++ b/cli/edit.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	jmespath "github.com/danielgtaylor/go-jmespath-plus"
-	"github.com/danielgtaylor/shorthand"
+	"github.com/danielgtaylor/shorthand/v2"
 	"github.com/google/shlex"
 	"github.com/hexops/gotextdiff"
 	"github.com/hexops/gotextdiff/myers"
@@ -99,7 +99,7 @@ export EDITOR="vim"`)
 	var modified interface{} = data
 
 	if len(args) > 0 {
-		modified, err = shorthand.ParseAndBuild(req.URL.Path, strings.Join(args, " "), modified.(map[string]interface{}))
+		modified, err = shorthand.Unmarshal(strings.Join(args, " "), shorthand.ParseOptions{EnableFileInput: true, EnableObjectDetection: true}, modified)
 		panicOnErr(err)
 	}
 

--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -19,7 +19,7 @@ import (
 	"github.com/alecthomas/chroma/quick"
 	"github.com/alecthomas/chroma/styles"
 	"github.com/charmbracelet/glamour/ansi"
-	jmespath "github.com/danielgtaylor/go-jmespath-plus"
+	"github.com/danielgtaylor/shorthand/v2"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -421,10 +421,12 @@ func (f *DefaultFormatter) Format(resp Response) error {
 	}
 
 	if filter != "" {
-		// JMESPath can't support maps with arbitrary key types, so we convert
-		// to map[string]interface{} before filtering.
-		data = makeJSONSafe(data, true)
-		result, err := jmespath.Search(filter, data)
+		opts := shorthand.GetOptions{}
+		if enableVerbose {
+			opts.DebugLogger = LogDebug
+		}
+
+		result, _, err := shorthand.GetPath(filter, data, opts)
 
 		if err != nil {
 			return err

--- a/cli/input.go
+++ b/cli/input.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/danielgtaylor/shorthand"
+	"github.com/danielgtaylor/shorthand/v2"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -36,7 +36,10 @@ func GetBody(mediaType string, args []string) (string, error) {
 		}
 	}
 
-	input, err := shorthand.GetInput(args)
+	input, _, err := shorthand.GetInput(args, shorthand.ParseOptions{
+		EnableFileInput:       true,
+		EnableObjectDetection: true,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/cli/lexer.go
+++ b/cli/lexer.go
@@ -130,11 +130,13 @@ var SchemaLexer = lexers.Register(chroma.MustNewLazyLexer(
 					Type:    chroma.ByGroups(chroma.Text, chroma.Keyword),
 				},
 				{
-					Pattern: `([^:]+)(:)([^ )]+)`,
+					Pattern: `([^: )]+)(:)([^ )]+)`,
 					Type:    chroma.ByGroups(chroma.String, chroma.Text, chroma.Text),
 				},
 				{
-					Pattern: `[^\n]*`, Type: chroma.Text, Mutator: chroma.Pop(1),
+					Pattern: `[^\n]*`,
+					Type:    chroma.Text,
+					Mutator: chroma.Pop(1),
 				},
 			},
 			"row": {

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -121,7 +121,7 @@ restish post api.rest.sh \
   platform.about.mission: Make APIs simple and intuitive, \
   platform.about.homepage: httpie.io, \
   platform.about.stars: 54000, \
-  platform.apps: Terminal, Desktop, Web, Mobile
+  platform.apps: [Terminal, Desktop, Web, Mobile]
 ```
 
 ## Getting Header Values
@@ -143,5 +143,5 @@ https --headers api.rest.sh | grep Content-Length | cut -d':' -d' ' -f2
 Restish Example:
 
 ```bash
-restish api.rest.sh -f 'headers."Content-Length"' -r
+restish api.rest.sh -f 'headers.Content-Length' -r
 ```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -9,11 +9,8 @@ You can install in one of three ways: Homebrew tap, GitHub release, or via `go g
 If you have [Homebrew](https://brew.sh/) then install via the official tap:
 
 ```bash
-# Add the tap
-$ brew tap danielgtaylor/restish
-
-# Install the executable
-$ brew install restish
+# Install directly through the Homebrew tap
+$ brew install danielgtaylor/restish/restish
 ```
 
 If you don't have Homebrew, you can grab a [release](https://github.com/danielgtaylor/restish/releases) for your platform and manually copy the executable to the right location (e.g. `/usr/local/bin/restish`), otherwise if you have Go installed:
@@ -30,7 +27,7 @@ You can confirm the installation worked by trying to run Restish:
 $ restish --version
 ```
 
-?> If using `zsh` as your shell (the default on macOS), you should set `alias restish="noglob restish"` in your `~/.zshrc` to prevent it from trying to handle `?` in URLs and `[]` in shorthand input!
+?> If using `zsh` as your shell (the default on macOS), you should set `alias restish="noglob restish"` in your `~/.zshrc` to prevent it from trying to handle `?` in URLs and `[]` in shorthand input. Alternatively you can use quotes around your inputs.
 
 ## Basic Usage
 
@@ -97,7 +94,7 @@ $ restish post api.rest.sh <input.json
 $ restish post api.rest.sh name: Kari, tags[]: admin
 ```
 
-Read more about [CLI Shorthand](/shorthand.md). Headers and query params can also be set via environment variables, for example:
+Read more about [CLI Shorthand](/shorthand.md). Headers and query params can also be set via environment variables by prefixing with `RSH_`, for example:
 
 ```bash
 # Set via env vars
@@ -121,11 +118,11 @@ $ restish edit -i api.rest.sh/types
 
 To use interactive mode you must have the `VISUAL` or `EDITOR` environment variable set to an editor, for example `export VISUAL="code --wait"` for VSCode.
 
-Editing resources will make use of [conditional requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) if any relevant headers are found on the `GET` response.
+Editing resources will make use of [conditional requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) if any relevant headers are found on the `GET` response. For example, if an `ETag` header is present in the `GET` response then an `If-Match` header will be send on the `PUT` to prevent performing the write operation if the resource was modified by someone else while you are editing.
 
 ### Output Filtering
 
-By default, you will see the entire response as output. Restish includes built-in filtering using [JMESPath Plus](https://github.com/danielgtaylor/go-jmespath-plus#readme) which enables you to filter & project the response data. Using a filter automatically enables JSON output mode. Here are some basic examples:
+By default, you will see the entire response as output. Restish includes built-in filtering using [Shorthand queries]() which enable you to filter & project the response data. Using a filter automatically enables JSON output mode and only prints the result of the filter expression. Here are some basic examples:
 
 ```bash
 # Get social media profiles from a JSON Resume:
@@ -146,7 +143,7 @@ $ restish api.rest.sh/example -f body.basics.profiles
 ]
 
 # Advanced filtering example:
-$ restish api.rest.sh/example -f 'body.volunteer[?organization==`"Restish"`]|[0].{name, startDate, summary}'
+$ restish api.rest.sh/example -f 'body.volunteer[organization.lower == restish]|[0].{organization, startDate, summary}'
 {
   "organization": "Restish",
   "startDate": "2018-09-29T00:00:00Z",
@@ -180,6 +177,9 @@ Each profile can have a number of preset headers or query params, a type of auth
 Getting started registering an API is easy and uses an interactive prompt to set up profiles, auth, etc. At a minimum you must provide a short nickname and a base URL:
 
 ```bash
+# How to register a new API
+$ restish api configure $SHORT_NAME $URL
+
 # Register a new API called `example`
 $ restish api configure example https://api.rest.sh
 ```
@@ -269,6 +269,8 @@ $ restish completion bash --help
 $ restish completion zsh --help
 $ restish completion powershell --help
 ```
+
+If using Homebrew, you may need one additional step to [include the Homebrew completions path](https://docs.brew.sh/Shell-Completion) for your shell.
 
 Once set up, you can use the `tab` key to discover API commands. For example:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,7 +146,8 @@
       }
 
       .token.variable,
-      .token.binary {
+      .token.binary,
+      .token.function {
         color: #ffd7d7;
       }
 
@@ -261,14 +262,16 @@
           },
         },
         string: {
-          pattern: /("(?:\\.|[^\\"\r\n])*"(?!\s*:))|('(?:\\.|[^\\'\r\n])*'(?!\s*:))/,
+          // pattern: /("(?:\\.|[^\\"\r\n])*"(?!\s*:))|('(?:\\.|[^\\'\r\n])*'(?!\s*:))/,
+          pattern: /("(?:\\.|[^\\"\r\n])*"(?!\s*:))/,
           greedy: true,
         },
         keypress: /<\S+>/,
-        property: /[A-Za-z0-9.\[\]-]+(?=:[a-z0-9. _-])/,
+        property: /[A-Za-z0-9.-]+(?=[:[{][a-z0-9.^ _-\}[\]])/,
         number: /\b[0-9]+(\.[0-9]+)?/,
         boolean: /\b(?:true|false)\b/i,
         null: /\bnull\b/i,
+        function: /contains|startsWith/,
         keyword: /restish|<|[|]|\b(for|do|done)(?!\/)\b/,
       };
     </script>

--- a/docs/input.md
+++ b/docs/input.md
@@ -25,7 +25,7 @@ $ restish -H Header1:val1 -H Header2:val2 api.rest.sh
 
 ## Request Body
 
-A request body can be set in two ways for requests that support bodies (e.g. `POST` / `PUT` / `PATCH`):
+A request body can be set in two ways (or a combination of both) for requests that support bodies (e.g. `POST` / `PUT` / `PATCH`):
 
 1. Standard input
 2. CLI shorthand
@@ -49,7 +49,7 @@ $ echo '{"name": "hello"}' | restish put api.rest.sh
 The [CLI Shorthand](shorthand.md) is a convenient way of providing structured data on the commandline. It is a JSON-like syntax that enables you to easily create nested structured data. For example:
 
 ```bash
-$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
+$ restish post api.rest.sh 'foo.bar[]{baz: 1, hello: world}'
 ```
 
 Will send the following request:
@@ -71,7 +71,7 @@ Host: api.rest.sh
 }
 ```
 
-The shorthand supports nested objects, arrays, automatic type coercion, context-aware backreferences, and loading data from files. See the [CLI Shorthand Syntax](shorthand.md) for more info.
+The shorthand supports nested objects, arrays, automatic type coercion, and loading data from files. See the [CLI Shorthand Syntax](shorthand.md) for more info.
 
 ### Combined Body Input
 
@@ -85,4 +85,4 @@ $ restish post api.rest.sh <template.json id: test2, tags[]: group1
 
 If you have a known small set of fields that need to change between calls, this makes it easy to do so without large complex commands.
 
-?> Hint: want to replace an array? Use something like `value: null, value[]: item` to first empty the array, then start building it up again.
+?> Hint: want to replace an array? Use something like `value: [item]` rather than appending.

--- a/docs/output.md
+++ b/docs/output.md
@@ -131,27 +131,20 @@ $ restish -o json api.rest.sh/images
 
 ## Filtering & Projection
 
-Restish includes JMESPath Plus, which includes all of [JMESPath](https://jmespath.org/) plus some [additional enhancements](https://github.com/danielgtaylor/go-jmespath-plus#readme). If you've ever used the [AWS CLI](https://aws.amazon.com/cli/), then you've likely used JMESPath. It's a language for filtering and projecting the response value that's useful for massaging the response data for scripts.
+Restish includes basic response filtering functionality through the [Shorthand Query Syntax](shorthand.md#Querying). It's a language for filtering and projecting the response value that's useful for paring down and massaging the response data for scripts.
 
 The response format described above is used as the input, so don't forget the `body` prefix when accessing body members!
 
 ```bash
 # Print out request headers
-$ restish api.rest.sh/images -f "headers"
+$ restish api.rest.sh/images -f headers
 
 # Filter results to just the names
-$ restish api.rest.sh/images -f "body[].{name}"
+$ restish api.rest.sh/images -f 'body[].{name}'
 
 # Get all `url` fields recursively from a response that are from Github
-$ restish api.rest.sh/example -f "..url|[?starts_with(@, 'https://github')]"
-
-# Pivot data, e.g. group/sort company names by title
-$ restish api.rest.sh/example -f "pivot(body.work, &position, &name)"
+$ restish api.rest.sh/example -f '..url|[@ contains github]'
 ```
-
-See the JMESPath documentation for more information and examples.
-
-!> Warning: structured data from binary formats like CBOR may be converted to its JSON equivalent before applying JMESPath filters. For example, a byte slice and a date would both be treated as strings.
 
 ## Raw Mode
 
@@ -164,15 +157,15 @@ For example:
 
 ```bash
 # Normal mode
-$ restish api.rest.sh/images -f body[0].self
+$ restish api.rest.sh/images -f 'body[0].self'
 "/images/jpeg"
 
 # Raw mode strips the quotes
-$ restish api.rest.sh/images -f body[0].self -r
+$ restish api.rest.sh/images -f 'body[0].self' -r
 /images/jpeg
 
 # It also works with arrays
-$ restish api.rest.sh/images -f body[].self -r
+$ restish api.rest.sh/images -f 'body[].self' -r
 /images/jpeg
 /images/webp
 /images/gif

--- a/docs/shorthand.md
+++ b/docs/shorthand.md
@@ -1,45 +1,91 @@
-# CLI Shorthand Syntax
+# CLI Shorthand
 
-Restish comes with an optional contextual shorthand syntax for passing structured data into calls that require a body (i.e. `POST`, `PUT`, `PATCH`). While you can always pass full JSON or other documents through `stdin`, you can also specify or modify them by hand as arguments to the command using this shorthand syntax.
+?> This describes CLI Shorthand version 2. Restish 0.14.0 and older use [Shorthand v1](shorthandv1.md) instead.
 
-?> Note: for the examples below, you may need to escape or quote the values depending on your shell & settings. Instead of `foo.bar[].baz: 1`, use `'foo.bar[].baz: 1'`. If using `zsh` you can prefix a command with `noglob` to ignore `?` and `[]`.
+The CLI Shorthand language is a superset of JSON that is made in part to support passing structured data easily on the command line for the bodies of `POST`, `PUT`, `PATCH`, etc API operations. Some of its high level features include:
 
-For example:
+- Superset of JSON (valid JSON is valid shorthand)
+  - Optional commas, quotes, and sometimes colons
+- Addtional types & binary
+  - Support for bytes, datetimes, and maps with non-string keys
+- Easy nested object & array creation
+- Basic templating
+  - Mix stdin with passed arguments
+  - Load values from files
+- Editing existing data
+  - Appending & inserting to arrays
+  - Unsetting properties
+  - Moving properties & items
 
-```bash
-# Make an HTTP POST with a JSON body
-$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
-```
+Here is a diagram overview of the language syntax, which is similar to [JSON's syntax](https://www.json.org/json-en.html) but adds a few things:
 
-Would result in the following body contents being sent on the wire (assuming a JSON content type):
+<!--
+https://tabatkins.github.io/railroad-diagrams/generator.html
 
-```json
-{
-  "foo": {
-    "bar": [
-      {
-        "baz": 1,
-        "hello": "world"
-      }
-    ]
-  }
-}
-```
+Diagram(
+    Choice(0,
+      Sequence('//', NonTerminal('comment')),
+      Sequence(
+        '{',
+        OneOrMore(
+          Sequence(
+            OneOrMore(Sequence(NonTerminal('string'), Optional(Sequence('[', Optional('^'), ZeroOrMore('0-9'), ']'))), '.'),
+            Choice(0,
+              Sequence(':', NonTerminal('value')),
+              Sequence('^', NonTerminal('query')),
+              NonTerminal('object'),
+            ),
+          ),
+          Choice(0, ',', '\\n'),
+        ),
+        '}'
+      ),
+      Sequence(
+        '[',
+        OneOrMore(NonTerminal('value'), Choice(0, ',', '\\n')),
+        ']'
+      ),
+      'undefined',
+      'null',
+      'true',
+      'false',
+      NonTerminal('integer'),
+      NonTerminal('float'),
+      Stack(
+        Sequence(
+          NonTerminal('YYYY'),
+          '-',
+          NonTerminal('MM'),
+          '-',
+          NonTerminal('DD'),
+        ),
+          Sequence(
+          'T',
+          NonTerminal('hh'),
+          ':',
+          NonTerminal('mm'),
+          ':',
+          NonTerminal('ss'),
+          NonTerminal('zone')
+        ),
+      ),
+      Sequence('%', NonTerminal('base64')),
+      Sequence('@', NonTerminal('filename')),
+      NonTerminal('string'),
+    ),
+)
+-->
 
-The shorthand syntax supports the following features, described in more detail with examples below:
+![shorthand-syntax](https://user-images.githubusercontent.com/106826/198850895-a1a8481a-2c63-484c-9bf2-ce472effa8c3.svg)
 
-- Automatic type coercion & forced strings
-- Nested object creation
-- Object property grouping
-- Nested array creation
-- Appending to arrays
-- Both object and array backreferences
-- Loading property values from files
-  - Supports structured, forced string, and base64 data
+Note:
+
+- `string` can be quoted (with `"`) or unquoted.
+- The `query` syntax in the diagram above is described below in the [Querying](#querying) section.
 
 ## Alternatives & Inspiration
 
-The built-in CLI shorthand syntax is not the only one you can use to generate data for CLI commands. Here are some alternatives:
+The CLI shorthand syntax is not the only one you can use to generate data for CLI commands. Here are some alternatives:
 
 - [jo](https://github.com/jpmens/jo)
 - [jarg](https://github.com/jdp/jarg)
@@ -47,10 +93,10 @@ The built-in CLI shorthand syntax is not the only one you can use to generate da
 For example, the shorthand example given above could be rewritten as:
 
 ```bash
-$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish post api.rest.sh
+$ jo -p foo=$(jo -p bar=$(jo -a $(jo -p baz=1 hello=world)))
 ```
 
-The built-in shorthand syntax implementation described herein uses those and the following for inspiration:
+The shorthand syntax implementation described herein uses those and the following for inspiration:
 
 - [YAML](http://yaml.org/)
 - [W3C HTML JSON Forms](https://www.w3.org/TR/html-json-forms/)
@@ -59,19 +105,22 @@ The built-in shorthand syntax implementation described herein uses those and the
 
 It seems reasonable to ask, why create a new syntax?
 
-1. Built-in. No extra executables required.
+1. Built-in. No extra executables required. Your tool ships ready-to-go.
 2. No need to use sub-shells to build complex structured data.
-3. Syntax is closer to YAML & JSON and mimics how we do queries using tools like `jq` and `jmespath`.
+3. Syntax is closer to YAML & JSON and mimics how you do queries using tools like `jq` and `jmespath`.
+4. It's _optional_, so you can use your favorite tool/language instead, while at the same time it provides a minimum feature set everyone will have in common.
 
 ## Features in Depth
 
-You can use the `j` executable from the [CLI Shorthand](https://github.com/danielgtaylor/shorthand) project to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or CBOR if you prefer.
+You can use the included `j` executable to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or TOML if you prefer.
 
 ```bash
-$ go install github.com/danielgtaylor/shorthand/cmd/j@latest
+go get -u github.com/danielgtaylor/shorthand/cmd/j
 ```
 
 Also feel free to use this tool to generate structured data for input to other commands.
+
+?> Note: for the examples below, you may need to escape or quote the values depending on your shell & settings. Instead of `foo.bar[].baz: 1`, use `'foo.bar[].baz: 1'`. If using `zsh` you can prefix a command with `noglob` to ignore `?` and `[]`.
 
 ### Keys & Values
 
@@ -85,9 +134,24 @@ $ j hello: world, question: how are you?
 }
 ```
 
-### Types and Type Coercion
+### Types
 
-Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. If needed, you can disable this automatic coercion by forcing a value to be treated as a string with the `~` operator. **Note**: the `~` modifier must come _directly after_ the colon.
+Shorthand supports the standard JSON types, but adds some of its own as well to better support binary formats and its query features.
+
+| Type      | Description                                                      |
+| --------- | ---------------------------------------------------------------- |
+| `null`    | JSON `null`                                                      |
+| `boolean` | Either `true` or `false`                                         |
+| `number`  | JSON number, e.g. `1`, `2.5`, or `1.4e5`                         |
+| `string`  | Quoted or unquoted strings, e.g. `hello` or `"hello"`            |
+| `bytes`   | `%`-prefixed, unquoted, base64-encoded binary data, e.g. `%wg==` |
+| `time`    | Date/time in ISO8601, e.g. `2022-01-01T12:00:00Z`                |
+| `array`   | JSON array, e.g. `[1, 2, 3]`                                     |
+| `object`  | JSON object, e.g. `{"hello": "world"}`                           |
+
+### Type Coercion
+
+Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers, bytes, and times also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. This automatic coercion can be disabled by just wrapping your value in quotes.
 
 ```bash
 # With coercion
@@ -100,7 +164,7 @@ $ j empty: null, bool: true, num: 1.5, string: hello
 }
 
 # As strings
-$ j empty:~ null, bool:~ true, num:~ 1.5, string:~ hello
+$ j empty: "null", bool: "true", num: "1.5", string: "hello"
 {
   "bool": "true",
   "empty": "null",
@@ -109,21 +173,10 @@ $ j empty:~ null, bool:~ true, num:~ 1.5, string:~ hello
 }
 
 # Passing the empty string
-$ j blank:~
+$ j blank1: , blank2: ""
 {
-  "blank": ""
-}
-
-# Passing a tilde using whitespace
-$ j foo: ~/Documents
-{
-  "foo": "~/Documents"
-}
-
-# Passing a tilde using forced strings
-$ j foo:~~/Documents
-{
-  "foo": "~/Documents"
+  "blank1": "",
+  "blank2": ""
 }
 ```
 
@@ -142,7 +195,7 @@ $ j foo.bar.baz: 1
 }
 ```
 
-Properties of nested objects can be grouped by placing them inside `{` and `}`.
+Properties of nested objects can be grouped by placing them inside `{` and `}`. The `:` becomes optional for nested objects, so `foo.bar: {...}` is equivalent to `foo.bar{...}`.
 
 ```bash
 $ j foo.bar{id: 1, count.clicks: 5}
@@ -160,32 +213,32 @@ $ j foo.bar{id: 1, count.clicks: 5}
 
 ### Arrays
 
-Simple arrays use a `,` between values. Nested arrays use square brackets `[` and `]` to specify the zero-based index to insert an item. Use a blank index to append to the array.
+Arrays are surrounded by square brackets like in JSON:
 
 ```bash
-# Array shorthand
-$ j a: 1, 2, 3
-{
-  "a": [
-    1,
-    2,
-    3
-  ]
-}
+# Simple array
+$ j [1, 2, 3]
+[
+  1,
+  2,
+  3
+]
+```
 
+Array indexes use square brackets `[` and `]` to specify the zero-based index to set an item. If the index is out of bounds then `null` values are added as necessary to fill the array. Use an empty index `[]` to append to the an existing array. If the item is not an array, then a new one will be created.
+
+```bash
 # Nested arrays
-$ j a[0][2][0]: 1
-{
-  "a": [
+$ j [0][2][0]: 1
+[
+  [
+    null,
+    null,
     [
-      null,
-      null,
-      [
-        1
-      ]
+      1
     ]
   ]
-}
+]
 
 # Appending arrays
 $ j a[]: 1, a[]: 2, a[]: 3
@@ -198,58 +251,9 @@ $ j a[]: 1, a[]: 2, a[]: 3
 }
 ```
 
-### Backreferences
-
-Since the shorthand syntax is context-aware, it is possible to use the current context to reference back to the most recently used object or array when creating new properties or items.
-
-```bash
-# Backref with object properties
-$ j foo.bar: 1, .baz: 2
-{
-  "foo": {
-    "bar": 1,
-    "baz": 2
-  }
-}
-
-# Backref with array appending
-$ j foo.bar[]: 1, []: 2, []: 3
-{
-  "foo": {
-    "bar": [
-      1,
-      2,
-      3
-    ]
-  }
-}
-
-# Easily build complex structures
-$ j name: foo, tags[]{id: 1, count.clicks: 5, .sales: 1}, []{id: 2, count.clicks: 8, .sales: 2}
-{
-  "name": "foo",
-  "tags": [
-    {
-      "count": {
-        "clicks": 5,
-        "sales": 1
-      },
-      "id": 1
-    },
-    {
-      "count": {
-        "clicks": 8,
-        "sales": 2
-      },
-      "id": 2
-    }
-  ]
-}
-```
-
 ### Loading from Files
 
-Sometimes a field makes more sense to load from a file than to be specified on the commandline. The `@` preprocessor and `~` & `%` modifiers let you load structured data, strings, and base64-encoded data into values.
+Sometimes a field makes more sense to load from a file than to be specified on the commandline. The `@` preprocessor lets you load structured data, text, and bytes depending on the file extension and whether all bytes are valid UTF-8:
 
 ```bash
 # Load a file's value as a parameter
@@ -265,25 +269,186 @@ $ j foo: @hello.json
     "hello": "world"
   }
 }
-
-# Force loading a string
-$ j foo: @~hello.json
-{
-  "foo": "{\n  \"hello\": \"world\"\n}"
-}
-
-# Load as base 64 data
-$ j foo: @%hello.json
-{
-  "foo": "ewogICJoZWxsbyI6ICJ3b3JsZCIKfQ=="
-}
 ```
 
-Remember, it's possible to disable this behavior with the string modifier `~`:
+Remember, it's possible to disable this behavior with quotes:
 
 ```bash
-$ j twitter:~ @user
+$ j 'twitter: "@user"'
 {
   "twitter": "@user"
 }
+```
+
+### Patch (Partial Update)
+
+Partial updates are supported on existing data, which can be used to implement HTTP `PATCH`, templating, and other similar features. The suggested content type for HTTP `PATCH` is `application/shorthand-patch`. This feature combines the best of both:
+
+- [JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386)
+- [JSON Patch](https://www.rfc-editor.org/rfc/rfc6902)
+
+Partial updates support:
+
+- Appending arrays via `[]`
+- Inserting before via `[^index]`
+- Removing fields or array items via `undefined`
+- Moving/swapping fields or array items via `^`
+  - The right hand side is a path to the value to swap. See Querying below for the path syntax.
+
+Note: When sending shorthand patches file loading via `@` should be disabled as the files will not exist on the server.
+
+Some examples:
+
+```bash
+# First, let's create some data we'll modify later
+$ j id: 1, tags: [a, b, c] >data.json
+
+# Now let's append to the tags array
+$ j <data.json 'tags[]: d'
+{
+  "id": 1,
+  "tags": [
+    "a",
+    "b",
+    "c",
+    "d"
+  ]
+}
+
+# Array item insertion (prepend the array)
+$ j <data.json 'tags[^0]: z'
+{
+  "id": 1,
+  "tags": [
+    "z",
+    "a",
+    "b",
+    "c"
+  ]
+}
+
+# Remove stuff
+$ j <data.json 'id: undefined, tags[1]: undefined'
+{
+  "tags": [
+    "a",
+    "c"
+  ]
+}
+
+# Rename the ID property, and swap the first/last array items
+$ j <data.json 'id ^ name, tags[0] ^ tags[-1]'
+{
+  "name": 1,
+  "tags": [
+    "c",
+    "b",
+    "a"
+  ]
+}
+```
+
+## Querying
+
+A data query language is included, which allows you to query, filter, and select fields to return. This functionality is used by the patch move operations described above and is similar to tools like:
+
+- [jq](https://stedolan.github.io/jq/)
+- [JMESPath](http://jmespath.org/)
+- [JSON Path](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-06.html)
+
+The query language supports:
+
+- Paths for objects & arrays `foo.items.name`
+- Wildcards for unknown props `foo.*.name`
+- Array indexing & slicing `foo.items[1:2].name`
+  - Including negative indexes `foo.items[-1].name`
+- Array filtering via [mexpr](https://github.com/danielgtaylor/mexpr) `foo.items[name.lower startsWith d]`
+- Object property selection `foo.{created, names: items.name}`
+- Recursive search `foo..name`
+- Stopping processing with a pipe `|`
+- Flattening nested arrays `[]`
+
+The query syntax is recursive and looks like this:
+
+<!--
+Diagram(
+  Stack(
+    OneOrMore(Sequence(
+      Choice(1,
+        Skip(),
+        NonTerminal('string'),
+        '*',
+      ),
+      Optional(
+        Sequence(
+          '[',
+          Choice(1,
+            Skip(),
+            NonTerminal('number'),
+            NonTerminal('slice'),
+            NonTerminal('filter')
+          ),
+          ']',
+        )
+      ),
+      Optional('|'),
+    ), Choice(0, '.', '..')),
+    Optional(
+      Sequence(
+        '.',
+        '{',
+        OneOrMore(
+          Sequence(
+            NonTerminal('string'),
+            Optional(
+              Sequence(':', NonTerminal('query')),
+              'skip'
+            ),
+          ),
+          ','
+        ),
+        '}',
+      ), 'skip',
+    ),
+  )
+)
+-->
+
+![shorthand-query-syntax](https://user-images.githubusercontent.com/106826/198693468-fadf8d48-8223-4dd9-a2cb-a1651e342fc5.svg)
+
+The `filter` syntax is described in the documentation for [mexpr](https://github.com/danielgtaylor/mexpr).
+
+Examples:
+
+```bash
+# First, let's make a complex file to query
+$ j 'users: [{id: 1, age: 5, friends: [a, b]}, {id: 2, age: 6, friends: [b, c]}, {id: 3, age: 5, friends: [c, d]}]' >data.json
+
+# Query for each user's ID
+$ j <data.json -q 'users.id'
+[
+  1,
+  2,
+  3
+]
+
+# Get the users who are friends with `b`
+$ j <data.json -q 'users[friends contains b].id'
+[
+  1,
+  2
+]
+
+# Get the ID & age of users who are friends with `b`
+$ j <data.json -q 'users[friends contains b].{id, age}'
+[
+  {
+    "age": null,
+    "id": 1
+  },
+  {
+    "age": null,
+    "id": 2
+  }
+]
 ```

--- a/docs/shorthandv1.md
+++ b/docs/shorthandv1.md
@@ -1,0 +1,291 @@
+# CLI Shorthand v1
+
+?> This page describes the shorthand version 1 used by Restish 0.14.0 and older.
+
+Restish comes with an optional contextual shorthand syntax for passing structured data into calls that require a body (i.e. `POST`, `PUT`, `PATCH`). While you can always pass full JSON or other documents through `stdin`, you can also specify or modify them by hand as arguments to the command using this shorthand syntax.
+
+?> Note: for the examples below, you may need to escape or quote the values depending on your shell & settings. Instead of `foo.bar[].baz: 1`, use `'foo.bar[].baz: 1'`. If using `zsh` you can prefix a command with `noglob` to ignore `?` and `[]`.
+
+For example:
+
+```bash
+# Make an HTTP POST with a JSON body
+$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
+```
+
+Would result in the following body contents being sent on the wire (assuming a JSON content type):
+
+```json
+{
+  "foo": {
+    "bar": [
+      {
+        "baz": 1,
+        "hello": "world"
+      }
+    ]
+  }
+}
+```
+
+The shorthand syntax supports the following features, described in more detail with examples below:
+
+- Automatic type coercion & forced strings
+- Nested object creation
+- Object property grouping
+- Nested array creation
+- Appending to arrays
+- Both object and array backreferences
+- Loading property values from files
+  - Supports structured, forced string, and base64 data
+
+## Alternatives & Inspiration
+
+The built-in CLI shorthand syntax is not the only one you can use to generate data for CLI commands. Here are some alternatives:
+
+- [jo](https://github.com/jpmens/jo)
+- [jarg](https://github.com/jdp/jarg)
+
+For example, the shorthand example given above could be rewritten as:
+
+```bash
+$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish post api.rest.sh
+```
+
+The built-in shorthand syntax implementation described herein uses those and the following for inspiration:
+
+- [YAML](http://yaml.org/)
+- [W3C HTML JSON Forms](https://www.w3.org/TR/html-json-forms/)
+- [jq](https://stedolan.github.io/jq/)
+- [JMESPath](http://jmespath.org/)
+
+It seems reasonable to ask, why create a new syntax?
+
+1. Built-in. No extra executables required.
+2. No need to use sub-shells to build complex structured data.
+3. Syntax is closer to YAML & JSON and mimics how we do queries using tools like `jq` and `jmespath`.
+
+## Features in Depth
+
+You can use the `j` executable from the [CLI Shorthand](https://github.com/danielgtaylor/shorthand) project to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or CBOR if you prefer.
+
+```bash
+$ go install github.com/danielgtaylor/shorthand/cmd/j@latest
+```
+
+Also feel free to use this tool to generate structured data for input to other commands.
+
+### Keys & Values
+
+At its most basic, a structure is built out of key & value pairs. They are separated by commas:
+
+```bash
+$ j hello: world, question: how are you?
+{
+  "hello": "world",
+  "question": "how are you?"
+}
+```
+
+### Types and Type Coercion
+
+Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. If needed, you can disable this automatic coercion by forcing a value to be treated as a string with the `~` operator. **Note**: the `~` modifier must come _directly after_ the colon.
+
+```bash
+# With coercion
+$ j empty: null, bool: true, num: 1.5, string: hello
+{
+  "bool": true,
+  "empty": null,
+  "num": 1.5,
+  "string": "hello"
+}
+
+# As strings
+$ j empty:~ null, bool:~ true, num:~ 1.5, string:~ hello
+{
+  "bool": "true",
+  "empty": "null",
+  "num": "1.5",
+  "string": "hello"
+}
+
+# Passing the empty string
+$ j blank:~
+{
+  "blank": ""
+}
+
+# Passing a tilde using whitespace
+$ j foo: ~/Documents
+{
+  "foo": "~/Documents"
+}
+
+# Passing a tilde using forced strings
+$ j foo:~~/Documents
+{
+  "foo": "~/Documents"
+}
+```
+
+### Objects
+
+Nested objects use a `.` separator when specifying the key.
+
+```bash
+$ j foo.bar.baz: 1
+{
+  "foo": {
+    "bar": {
+      "baz": 1
+    }
+  }
+}
+```
+
+Properties of nested objects can be grouped by placing them inside `{` and `}`.
+
+```bash
+$ j foo.bar{id: 1, count.clicks: 5}
+{
+  "foo": {
+    "bar": {
+      "count": {
+        "clicks": 5
+      },
+      "id": 1
+    }
+  }
+}
+```
+
+### Arrays
+
+Simple arrays use a `,` between values. Nested arrays use square brackets `[` and `]` to specify the zero-based index to insert an item. Use a blank index to append to the array.
+
+```bash
+# Array shorthand
+$ j a: 1, 2, 3
+{
+  "a": [
+    1,
+    2,
+    3
+  ]
+}
+
+# Nested arrays
+$ j a[0][2][0]: 1
+{
+  "a": [
+    [
+      null,
+      null,
+      [
+        1
+      ]
+    ]
+  ]
+}
+
+# Appending arrays
+$ j a[]: 1, a[]: 2, a[]: 3
+{
+  "a": [
+    1,
+    2,
+    3
+  ]
+}
+```
+
+### Backreferences
+
+Since the shorthand syntax is context-aware, it is possible to use the current context to reference back to the most recently used object or array when creating new properties or items.
+
+```bash
+# Backref with object properties
+$ j foo.bar: 1, .baz: 2
+{
+  "foo": {
+    "bar": 1,
+    "baz": 2
+  }
+}
+
+# Backref with array appending
+$ j foo.bar[]: 1, []: 2, []: 3
+{
+  "foo": {
+    "bar": [
+      1,
+      2,
+      3
+    ]
+  }
+}
+
+# Easily build complex structures
+$ j name: foo, tags[]{id: 1, count.clicks: 5, .sales: 1}, []{id: 2, count.clicks: 8, .sales: 2}
+{
+  "name": "foo",
+  "tags": [
+    {
+      "count": {
+        "clicks": 5,
+        "sales": 1
+      },
+      "id": 1
+    },
+    {
+      "count": {
+        "clicks": 8,
+        "sales": 2
+      },
+      "id": 2
+    }
+  ]
+}
+```
+
+### Loading from Files
+
+Sometimes a field makes more sense to load from a file than to be specified on the commandline. The `@` preprocessor and `~` & `%` modifiers let you load structured data, strings, and base64-encoded data into values.
+
+```bash
+# Load a file's value as a parameter
+$ j foo: @hello.txt
+{
+  "foo": "hello, world"
+}
+
+# Load structured data
+$ j foo: @hello.json
+{
+  "foo": {
+    "hello": "world"
+  }
+}
+
+# Force loading a string
+$ j foo: @~hello.json
+{
+  "foo": "{\n  \"hello\": \"world\"\n}"
+}
+
+# Load as base 64 data
+$ j foo: @%hello.json
+{
+  "foo": "ewogICJoZWxsbyI6ICJ3b3JsZCIKfQ=="
+}
+```
+
+Remember, it's possible to disable this behavior with the string modifier `~`:
+
+```bash
+$ j twitter:~ @user
+{
+  "twitter": "@user"
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/glamour v0.5.1-0.20221024082230-3c5ceaed91cc
 	github.com/danielgtaylor/casing v0.0.0-20210126043903-4e55e6373ac3
 	github.com/danielgtaylor/go-jmespath-plus v0.0.0-20200228063638-e0b6f132acba
-	github.com/danielgtaylor/shorthand v1.1.0
+	github.com/danielgtaylor/shorthand/v2 v2.0.0-beta2
 	github.com/eliukblau/pixterm v1.3.1
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/gbl08ma/httpcache v1.0.2
@@ -41,6 +41,7 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52 v1.2.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/danielgtaylor/mexpr v1.7.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yuin/goldmark v1.5.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
+	golang.org/x/exp v0.0.0-20221108223516-5d533826c662 // indirect
 	golang.org/x/image v0.1.0 // indirect
 	golang.org/x/net v0.1.0 // indirect
 	golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221108223516-5d533826c662 h1:QIza2Vre5WI+NE5AQ6Wi2nGDgDOckLCHJdhcM/kxcfw=
+golang.org/x/exp v0.0.0-20221108223516-5d533826c662/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,12 @@ github.com/danielgtaylor/casing v0.0.0-20210126043903-4e55e6373ac3 h1:qDsADtCM9A
 github.com/danielgtaylor/casing v0.0.0-20210126043903-4e55e6373ac3/go.mod h1:eFdYmNxcuLDrRNW0efVoxSaApmvGXfHZ9k2CT/RSUF0=
 github.com/danielgtaylor/go-jmespath-plus v0.0.0-20200228063638-e0b6f132acba h1:COT94fQgUPh7CG42x3RTfab3V9jK9x4i2GLpubq7eZM=
 github.com/danielgtaylor/go-jmespath-plus v0.0.0-20200228063638-e0b6f132acba/go.mod h1:A57wu2YKZM9dwidFjak6swlRJPKbg+TfHsFm0py9/i8=
+github.com/danielgtaylor/mexpr v1.7.2 h1:NDAIvh3BIE8jDSjJEO/EqTNxuguaNbNEH/LPTDbM4bQ=
+github.com/danielgtaylor/mexpr v1.7.2/go.mod h1:Jcg0kPd2IPMV8ZxnpOj/UbNwMbM9As23hi8yxKsrI0U=
 github.com/danielgtaylor/shorthand v1.1.0 h1:ZCp6zUFPI6yJbbxy0y7Lks6Zbm6cic9h2Pzjhoahgz0=
 github.com/danielgtaylor/shorthand v1.1.0/go.mod h1:cGt46ErC5zbLmtuQIXcavU06e8gLQbp97oDPYVYny3I=
+github.com/danielgtaylor/shorthand/v2 v2.0.0-beta2 h1:CCeH9yL+GQ9BspSEbUZ8OQykXRSiYe49js6DBdmfYNY=
+github.com/danielgtaylor/shorthand/v2 v2.0.0-beta2/go.mod h1:iWZyWz+QrYscKroB6hdrK01C2u6qIg/dE3ttmsrUZfE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/danielgtaylor/casing"
 	"github.com/danielgtaylor/restish/cli"
-	"github.com/danielgtaylor/shorthand"
+	"github.com/danielgtaylor/shorthand/v2"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gosimple/slug"
 	"github.com/spf13/cobra"
@@ -244,7 +244,7 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 					// Not a string, so it's structured data. Let's marshal it to the
 					// shorthand syntax if we can.
 					if m, ok := ex.(map[string]interface{}); ok {
-						exs := shorthand.Get(m)
+						exs := shorthand.MarshalCLI(m)
 
 						if len(exs) < 150 {
 							examples = append(examples, exs)


### PR DESCRIPTION
Switch to the new Shorthand v2 syntax, see https://github.com/danielgtaylor/shorthand/releases/tag/v2.0.0-beta

This replaces the Shorthand v1 CLI input as well as JMESPath for filtering as Shorthand v2 includes a query syntax to support certain patch operations.