### PR TITLE
feat!: revamp default output behavior

### DIFF
--- a/cli/apiconfig_test.go
+++ b/cli/apiconfig_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIContentTypes(t *testing.T) {
+	captured := run("api content-types")
+	assert.Contains(t, captured, "application/json")
+	assert.Contains(t, captured, "table")
+	assert.Contains(t, captured, "readable")
+}
+
+func TestAPIShow(t *testing.T) {
+	reset(false)
+	configs["test"] = &APIConfig{
+		name: "test",
+		Base: "https://api.example.com",
+	}
+	captured := runNoReset("api show test")
+	assert.Equal(t, captured, "\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74m\"base\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"https://api.example.com\"\x1b[0m\n\x1b[38;5;247m}\x1b[0m\n")
+}

--- a/cli/auth.go
+++ b/cli/auth.go
@@ -95,7 +95,7 @@ func (a *ExternalToolAuth) Parameters() []AuthParam {
 // The supplied commandline argument is ran with a JSON input
 // and expects a JSON output on stdout
 func (a *ExternalToolAuth) OnRequest(req *http.Request, key string, params map[string]string) error {
-	commandLine, _ := params["commandline"]
+	commandLine := params["commandline"]
 	omitBodyStr, omitBodyPresent := params["omitbody"]
 	omitBody := false
 	if omitBodyPresent && strings.EqualFold(omitBodyStr, "true") {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -16,7 +16,7 @@ import (
 
 func reset(color bool) {
 	viper.Reset()
-
+	viper.Set("tty", true)
 	if color {
 		viper.Set("color", true)
 	} else {
@@ -159,7 +159,7 @@ func TestDefaultOutput(t *testing.T) {
 	})
 
 	captured := run("http://example.com/foo", true)
-	assert.Equal(t, "\x1b[38;5;204mHTTP\x1b[0m/\x1b[38;5;172m1.1\x1b[0m \x1b[38;5;172m200\x1b[0m \x1b[38;5;74mOK\x1b[0m\n\x1b[38;5;74mContent-Type\x1b[0m: application/json\n\n\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74mhello\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"world\"\x1b[0m\x1b[38;5;247m\n}\x1b[0m\n", captured)
+	assert.Equal(t, "\x1b[38;5;204mHTTP\x1b[0m/\x1b[38;5;172m1.1\x1b[0m \x1b[38;5;172m200\x1b[0m \x1b[38;5;74mOK\x1b[0m\n\x1b[38;5;74mContent-Type\x1b[0m: application/json\n\n\x1b[38;5;172m{\x1b[0m\n  \x1b[38;5;74mhello\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"world\"\x1b[0m\x1b[38;5;247m\n\x1b[0m\x1b[38;5;172m}\x1b[0m\n", captured)
 }
 
 func TestHelp(t *testing.T) {

--- a/cli/content.go
+++ b/cli/content.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
+	"github.com/alexeyco/simpletable"
 	"github.com/amzn/ion-go/ion"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/shamaton/msgpack/v2"
@@ -19,6 +23,13 @@ type ContentType interface {
 	Unmarshal(data []byte, value interface{}) error
 }
 
+// PrettyMarshaller describes an optional method that ContentTypes can implement
+// to provide nicer output for humans. This is optional because only some
+// formats support the pretty/indented concept.
+type PrettyMarshaller interface {
+	MarshalPretty(value any) ([]byte, error)
+}
+
 type contentTypeEntry struct {
 	name string
 	q    float32
@@ -26,23 +37,25 @@ type contentTypeEntry struct {
 }
 
 // contentTypes is a list of acceptable content types
-var contentTypes []contentTypeEntry = []contentTypeEntry{}
+var contentTypes map[string]contentTypeEntry = map[string]contentTypeEntry{}
 
 // AddContentType adds a new content type marshaller with the given default
 // content type name and q factor (0-1.0, higher has priority).
-func AddContentType(name string, q float32, ct ContentType) {
-	contentTypes = append(contentTypes, contentTypeEntry{
+func AddContentType(short, name string, q float32, ct ContentType) {
+	contentTypes[short] = contentTypeEntry{
 		name: name,
 		q:    q,
 		ct:   ct,
-	})
+	}
 }
 
 func buildAcceptHeader() string {
 	accept := []string{}
 
 	for _, entry := range contentTypes {
-		accept = append(accept, fmt.Sprintf("%s;q=%.3g", entry.name, entry.q))
+		if entry.q >= 0 {
+			accept = append(accept, fmt.Sprintf("%s;q=%.3g", entry.name, entry.q))
+		}
 	}
 
 	accept = append(accept, "*/*")
@@ -50,7 +63,7 @@ func buildAcceptHeader() string {
 	return strings.Join(accept, ",")
 }
 
-// Marshal a value to the given content type if possible.
+// Marshal a value to the given content type, e.g. `application/json`.
 func Marshal(contentType string, value interface{}) ([]byte, error) {
 	for _, entry := range contentTypes {
 		if entry.ct.Detect(contentType) {
@@ -59,6 +72,32 @@ func Marshal(contentType string, value interface{}) ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("cannot marshal %s", contentType)
+}
+
+// MarshalShort marshals a value given a short name, e.g. `json`. If pretty is
+// true then the output will be pretty/indented if the marshaler supports
+// pretty output (e.g. JSON).
+func MarshalShort(name string, pretty bool, value any) ([]byte, error) {
+	var encoded []byte
+	if cte, ok := contentTypes[name]; ok {
+		var err error
+
+		if pm, ok := cte.ct.(PrettyMarshaller); ok && pretty {
+			encoded, err = pm.MarshalPretty(value)
+		} else {
+			encoded, err = cte.ct.Marshal(value)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if encoded[len(encoded)-1] != '\n' {
+			encoded = append(encoded, '\n')
+		}
+	} else {
+		return nil, fmt.Errorf("unknown format %s", name)
+	}
+
+	return encoded, nil
 }
 
 // Unmarshal raw data from the given content type into a value.
@@ -109,7 +148,7 @@ func (t Text) Marshal(value interface{}) ([]byte, error) {
 		return []byte(s.String()), nil
 	}
 
-	return nil, fmt.Errorf("cannot convert to string: %v", value)
+	return []byte(fmt.Sprintf("%v", value)), nil
 }
 
 // Unmarshal the value from a text string.
@@ -128,6 +167,78 @@ func (t Text) Unmarshal(data []byte, value interface{}) error {
 	return nil
 }
 
+// Table describes an output format for terminal tables.
+type Table struct{}
+
+// Detect if the content type is table.
+func (t Table) Detect(contentType string) bool {
+	return false
+}
+
+// Marshal the value to a table string.
+func (t Table) Marshal(value interface{}) ([]byte, error) {
+	d, ok := makeJSONSafe(value).([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error building table. Must be array of objects")
+	}
+
+	return setTable(d)
+}
+
+// Unmarshal the value from a table string.
+func (t Table) Unmarshal(data []byte, value interface{}) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// Only applicable to collection of repeating objects.
+// Filter down to a collection of objects first then apply the table output.
+// Simpletable has much more styling that can be applied.
+func setTable(data []interface{}) ([]byte, error) {
+	table := simpletable.New()
+
+	var headerCells []*simpletable.Cell
+	defineHeader := true
+	for _, maps := range data {
+		var bodyCells []*simpletable.Cell
+		if mapData, ok := maps.(map[string]interface{}); ok {
+			// Discover headers for repeating objects
+			// Iterate first instance of one of the repeating objects
+			if defineHeader {
+				for k := range mapData {
+					headerCells = append(headerCells, &simpletable.Cell{Align: simpletable.AlignCenter, Text: k})
+				}
+				sort.Slice(headerCells, func(i, j int) bool {
+					return headerCells[i].Text < headerCells[j].Text
+				})
+			}
+			defineHeader = false
+
+			// Add body cells based on order of header cells
+			// Will get out of order otherwise
+			for _, cellKey := range headerCells {
+				if val, ok := mapData[cellKey.Text]; ok {
+					bodyCells = append(bodyCells, &simpletable.Cell{Align: simpletable.AlignRight, Text: fmt.Sprintf("%v", val)})
+				} else {
+					return nil, fmt.Errorf("error building table. Header Key not found in repeating object: %s", cellKey.Text)
+				}
+			}
+			table.Body.Cells = append(table.Body.Cells, bodyCells)
+		} else {
+			// Defensive just in case
+			return nil, errors.New("error building table. Collection not supported")
+		}
+	}
+
+	table.Header = &simpletable.Header{
+		Cells: headerCells,
+	}
+
+	table.SetStyle(simpletable.StyleUnicode)
+
+	ret := []byte(table.String())
+	return ret, nil
+}
+
 // JSON describes content types like `application/json` or
 // `application/problem+json`.
 type JSON struct{}
@@ -144,7 +255,31 @@ func (j JSON) Detect(contentType string) bool {
 
 // Marshal the value to encoded JSON.
 func (j JSON) Marshal(value interface{}) ([]byte, error) {
-	return json.Marshal(value)
+	// The default encoder escapes '<', '>', and '&' which we don't want
+	// since we are not a browser. Disable this with an encoder instance.
+	// See https://stackoverflow.com/a/28596225/164268
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(makeJSONSafe(value)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// MarshalPretty the value to pretty encoded JSON.
+func (j JSON) MarshalPretty(value interface{}) ([]byte, error) {
+	// The default encoder escapes '<', '>', and '&' which we don't want
+	// since we are not a browser. Disable this with an encoder instance.
+	// See https://stackoverflow.com/a/28596225/164268
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(makeJSONSafe(value)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // Unmarshal the value from encoded JSON.
@@ -239,10 +374,39 @@ func (i Ion) Detect(contentType string) bool {
 
 // Marshal the value to encoded binary Ion.
 func (i Ion) Marshal(value interface{}) ([]byte, error) {
-	return ion.MarshalBinary(value)
+	return ion.MarshalBinary(makeJSONSafe(value))
+}
+
+// MarshalPretty the value to pretty encoded JSON.
+func (i Ion) MarshalPretty(value interface{}) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	tw := ion.NewTextWriterOpts(buf, ion.TextWriterPretty|ion.TextWriterQuietFinish)
+	err := ion.MarshalTo(tw, makeJSONSafe(value))
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // Unmarshal the value form encoded binary or text Ion.
 func (i Ion) Unmarshal(data []byte, value interface{}) error {
 	return ion.Unmarshal(data, value)
+}
+
+// Readable describes a readable marshaller.
+type Readable struct{}
+
+// Detect if the content type is Ion.
+func (r Readable) Detect(contentType string) bool {
+	return false
+}
+
+// Marshal the value to encoded binary Ion.
+func (r Readable) Marshal(value interface{}) ([]byte, error) {
+	return MarshalReadable(value)
+}
+
+// Unmarshal the value form encoded binary or text Ion.
+func (i Readable) Unmarshal(data []byte, value interface{}) error {
+	return fmt.Errorf("unimplemented")
 }

--- a/cli/content_test.go
+++ b/cli/content_test.go
@@ -7,17 +7,18 @@ import (
 )
 
 var contentTests = []struct {
-	name  string
-	types []string
-	ct    ContentType
-	data  []byte
+	name   string
+	types  []string
+	ct     ContentType
+	data   []byte
+	pretty []byte
 }{
-	{"text", []string{"text/plain", "text/html"}, &Text{}, []byte("hello world")},
-	{"json", []string{"application/json", "foo+json"}, &JSON{}, []byte(`{"hello":"world"}`)},
-	{"yaml", []string{"application/yaml", "foo+yaml"}, &YAML{}, []byte("hello: world\n")},
-	{"cbor", []string{"application/cbor", "foo+cbor"}, &CBOR{}, []byte("\xf6")},
-	{"msgpack", []string{"application/msgpack", "application/x-msgpack", "application/vnd.msgpack", "foo+msgpack"}, &MsgPack{}, []byte("\x81\xa5\x68\x65\x6c\x6c\x6f\xa5\x77\x6f\x72\x6c\x64")},
-	{"ion", []string{"application/ion", "foo+ion"}, &Ion{}, []byte("\xe0\x01\x00\xea\x0f")},
+	{"text", []string{"text/plain", "text/html"}, &Text{}, []byte("hello world"), nil},
+	{"json", []string{"application/json", "foo+json"}, &JSON{}, []byte("{\"hello\":\"world\"}\n"), []byte("{\n  \"hello\": \"world\"\n}\n")},
+	{"yaml", []string{"application/yaml", "foo+yaml"}, &YAML{}, []byte("hello: world\n"), nil},
+	{"cbor", []string{"application/cbor", "foo+cbor"}, &CBOR{}, []byte("\xf6"), nil},
+	{"msgpack", []string{"application/msgpack", "application/x-msgpack", "application/vnd.msgpack", "foo+msgpack"}, &MsgPack{}, []byte("\x81\xa5\x68\x65\x6c\x6c\x6f\xa5\x77\x6f\x72\x6c\x64"), nil},
+	{"ion", []string{"application/ion", "foo+ion"}, &Ion{}, []byte("\xe0\x01\x00\xea\x0f"), []byte("null")},
 }
 
 func TestContentTypes(parent *testing.T) {
@@ -35,6 +36,16 @@ func TestContentTypes(parent *testing.T) {
 
 			b, err := tt.ct.Marshal(data)
 			assert.NoError(t, err)
+
+			if tt.pretty != nil {
+				if p, ok := tt.ct.(PrettyMarshaller); ok {
+					b, err := p.MarshalPretty(data)
+					assert.NoError(t, err)
+					assert.Equal(t, tt.pretty, b)
+				} else {
+					t.Fatal("not a pretty marshaller")
+				}
+			}
 
 			assert.Equal(t, tt.data, b)
 		})

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -64,7 +64,7 @@ export EDITOR="vim"`)
 	// Convert from CBOR or other formats which might allow map[any]any to the
 	// constraints of JSON (i.e. map[string]interface{}).
 	var data interface{} = resp.Map()
-	data = makeJSONSafe(data, false)
+	data = makeJSONSafe(data)
 
 	filter := viper.GetString("rsh-filter")
 	if filter == "" {
@@ -144,7 +144,7 @@ export EDITOR="vim"`)
 		panicOnErr(editUnmarshal(b, &modified))
 	}
 
-	modified = makeJSONSafe(modified, false)
+	modified = makeJSONSafe(modified)
 	mod, err := json.MarshalIndent(modified, "", "  ")
 	panicOnErr(err)
 	edits := myers.ComputeEdits(span.URIFromPath("original"), string(orig), string(mod))
@@ -155,7 +155,7 @@ export EDITOR="vim"`)
 		return
 	} else {
 		diff := fmt.Sprint(gotextdiff.ToUnified("original", "modified", string(orig), edits))
-		if tty {
+		if useColor {
 			d, _ := Highlight("diff", []byte(diff))
 			diff = string(d)
 		}

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -36,101 +37,197 @@ func TestPrintable(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestFileDownload(t *testing.T) {
-	formatter := NewDefaultFormatter(false)
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", true)
-	viper.Set("rsh-filter", "")
-	formatter.Format(Response{
-		Body: []byte{0, 1, 2, 3},
-	})
-	assert.Equal(t, []byte{0, 1, 2, 3}, buf.Bytes())
-}
+var img, _ = base64.StdEncoding.DecodeString("iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVR42mP8/5+hngEIGGEMADlqBP1mY/qhAAAAAElFTkSuQmCC")
 
-func TestRawLargeJSONNumbers(t *testing.T) {
-	formatter := NewDefaultFormatter(false)
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", true)
-	viper.Set("rsh-filter", "body")
-	formatter.Format(Response{
-		Body: []interface{}{
+var formatterTests = []struct {
+	name    string
+	tty     bool
+	color   bool
+	raw     bool
+	format  string
+	filter  string
+	headers map[string]string
+	body    any
+	result  any
+	err     string
+}{
+	{
+		name:   "body-string",
+		tty:    true,
+		body:   "string",
+		result: " 0 \n\nstring\n",
+	},
+	{
+		name: "image",
+		tty:  true,
+		headers: map[string]string{
+			"Content-Type": "image/png",
+		},
+		body:   img,
+		result: []byte{0x20, 0x30, 0x20, 0xa, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x2d, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x20, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x2f, 0x70, 0x6e, 0x67, 0xa, 0xa},
+	},
+	{
+		name: "image-empty",
+		tty:  true,
+		headers: map[string]string{
+			"Content-Type":   "image/png",
+			"Content-Length": "0",
+		},
+		body:   []byte{},
+		result: []byte{0x20, 0x30, 0x20, 0xa, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x2d, 0x4c, 0x65, 0x6e, 0x67, 0x74, 0x68, 0x3a, 0x20, 0x30, 0xa, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x6e, 0x74, 0x2d, 0x54, 0x79, 0x70, 0x65, 0x3a, 0x20, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x2f, 0x70, 0x6e, 0x67, 0xa, 0xa},
+	},
+	{
+		name:   "json-pretty-explicit-full",
+		tty:    true,
+		color:  true,
+		format: "json",
+		filter: "@",
+		body:   "string",
+		result: "\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74m\"body\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"string\"\x1b[0m\x1b[38;5;247m,\x1b[0m\n  \x1b[38;5;74m\"headers\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;247m{},\x1b[0m\n  \x1b[38;5;74m\"links\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;247m{},\x1b[0m\n  \x1b[38;5;74m\"proto\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"\"\x1b[0m\x1b[38;5;247m,\x1b[0m\n  \x1b[38;5;74m\"status\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;172m0\x1b[0m\n\x1b[38;5;247m}\x1b[0m\n",
+	},
+	{
+		name:   "json-escape",
+		format: "json",
+		body:   "<em> and & shouldn't get escaped",
+		result: `"<em> and & shouldn't get escaped"` + "\n",
+	},
+	{
+		name:   "json-bytes",
+		format: "json",
+		filter: "body",
+		body:   []byte{0, 1, 2, 3, 4, 5},
+		result: "\"AAECAwQF\"\n",
+	},
+	{
+		name:   "json-filter",
+		format: "json",
+		filter: "body.id",
+		body: []any{
+			map[string]any{"id": 1},
+			map[string]any{"id": 2},
+		},
+		result: "[\n  1,\n  2\n]\n",
+	},
+	{
+		name:   "table",
+		format: "table",
+		filter: "body",
+		body: []any{
+			map[string]any{"id": 1, "registered": true},
+			map[string]any{"id": 2, "registered": false},
+		},
+		result: `╔════╤════════════╗
+║ id │ registered ║
+╟━━━━┼━━━━━━━━━━━━╢
+║  1 │       true ║
+║  2 │      false ║
+╚════╧════════════╝
+`,
+	},
+	{
+		name:   "raw-bytes",
+		tty:    true,
+		raw:    true,
+		body:   []byte{0, 1, 2, 3, 4, 5},
+		result: []byte{0, 1, 2, 3, 4, 5},
+	},
+	{
+		name:   "raw-filtered-value",
+		tty:    true,
+		raw:    true,
+		filter: "body",
+		body:   "[1, 2, 3]",
+		result: "[1, 2, 3]\n",
+	},
+	{
+		name:   "raw-filtered-bytes",
+		tty:    true,
+		raw:    true,
+		filter: "body",
+		body:   []byte{0, 1, 2, 3, 4, 5},
+		result: "AAECAwQF\n",
+	},
+	{
+		name:   "raw-large-json-num",
+		raw:    true,
+		filter: "body",
+		body: []interface{}{
 			nil,
 			float64(1000000000000000),
 			float64(1.2e5),
 			float64(1.234),
 			float64(0.00000000000005), // This should still use scientific notation!
 		},
-	})
-	assert.Equal(t, "null\n1000000000000000\n120000\n1.234\n5e-14\n", buf.String())
+		result: "null\n1000000000000000\n120000\n1.234\n5e-14\n",
+	},
+	{
+		name:   "redirect-bytes",
+		body:   []byte{0, 1, 2, 3},
+		result: []byte{0, 1, 2, 3},
+	},
+	{
+		name: "redirect-json",
+		body: map[string]any{"example": true},
+		result: `{
+  "example": true
+}
+`,
+	},
+	{
+		name:   "redirect-explicit-full-response",
+		body:   "foo",
+		filter: "@",
+		result: "{\n  \"body\": \"foo\",\n  \"headers\": {},\n  \"links\": {},\n  \"proto\": \"\",\n  \"status\": 0\n}\n",
+	},
+	{
+		name:   "redirect-yaml",
+		format: "yaml",
+		body:   map[string]any{"example": true},
+		result: "example: true\n",
+	},
+	{
+		name:   "error-prefix",
+		filter: "boby.id", // should be body.id
+		body:   map[string]any{"id": 123},
+		err:    "filter must begin with one of",
+	},
+	{
+		name:   "error-missing-dot",
+		filter: "body{id}", // should be body.{id}
+		body:   map[string]any{"id": 123},
+		err:    "expected '.'",
+	},
 }
 
-func TestBinary(t *testing.T) {
-	formatter := NewDefaultFormatter(false)
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", false)
-	viper.Set("rsh-filter", "")
-	viper.Set("rsh-output-format", "json")
-	formatter.Format(Response{
-		Body: []byte{0, 1, 2, 3, 4, 5},
-	})
-	assert.Contains(t, buf.String(), "AAECAwQF")
-
-	buf = &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", true)
-	viper.Set("rsh-filter", "body")
-	formatter.Format(Response{
-		Body: []byte{0, 1, 2, 3, 4, 5},
-	})
-	assert.Equal(t, "AAECAwQF\n", buf.String())
-
-	buf = &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", true)
-	viper.Set("rsh-filter", "")
-	formatter.Format(Response{
-		Body: []byte{0, 1, 2, 3, 4, 5},
-	})
-	assert.Equal(t, "\x00\x01\x02\x03\x04\x05", buf.String())
-}
-
-func TestFormatEmptyImage(t *testing.T) {
-	formatter := NewDefaultFormatter(false)
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", false)
-	viper.Set("rsh-filter", "")
-
-	// This should not panic!
-	formatter.Format(Response{
-		Headers: map[string]string{
-			"Content-Type":   "image/jpeg",
-			"Content-Length": "0",
-		},
-		Body: nil,
-	})
-}
-
-func TestJSONEscape(t *testing.T) {
-	formatter := NewDefaultFormatter(false)
-	buf := &bytes.Buffer{}
-	Stdout = buf
-	viper.Set("rsh-raw", false)
-	viper.Set("rsh-filter", "")
-	viper.Set("rsh-output-format", "json")
-	defer func() { viper.Set("rsh-output_format", "auto") }()
-
-	formatter.Format(Response{
-		Headers: map[string]string{
-			"Content-Type": "application/json",
-		},
-		Body: map[string]string{
-			"test": "<em> and & shouldn't get escaped",
-		},
-	})
-
-	assert.Contains(t, buf.String(), "<em> and & shouldn't get escaped")
+func TestFormatter(t *testing.T) {
+	for _, input := range formatterTests {
+		t.Run(input.name, func(t *testing.T) {
+			formatter := NewDefaultFormatter(input.tty, input.color)
+			buf := &bytes.Buffer{}
+			Stdout = buf
+			viper.Reset()
+			viper.Set("rsh-raw", input.raw)
+			viper.Set("rsh-filter", input.filter)
+			if input.format != "" {
+				viper.Set("rsh-output-format", input.format)
+			} else {
+				viper.Set("rsh-output-format", "auto")
+			}
+			err := formatter.Format(Response{
+				Headers: input.headers,
+				Body:    input.body,
+			})
+			if input.err != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), input.err)
+			} else {
+				assert.NoError(t, err)
+				if b, ok := input.result.([]byte); ok {
+					assert.Equal(t, b, buf.Bytes())
+				} else {
+					assert.Equal(t, input.result, buf.String())
+				}
+			}
+		})
+	}
 }

--- a/cli/logger.go
+++ b/cli/logger.go
@@ -28,7 +28,7 @@ func LogDebugRequest(req *http.Request) {
 			return
 		}
 
-		if tty {
+		if useColor {
 			sb := &strings.Builder{}
 			quick.Highlight(sb, string(dumped), "http", "terminal256", "cli-dark")
 			dumped = []byte(sb.String())
@@ -47,7 +47,7 @@ func LogDebugResponse(start time.Time, resp *http.Response) {
 			return
 		}
 
-		if tty {
+		if useColor {
 			sb := &strings.Builder{}
 			quick.Highlight(sb, string(dumped), "http", "terminal256", "cli-dark")
 			dumped = []byte(sb.String())

--- a/cli/operation_test.go
+++ b/cli/operation_test.go
@@ -88,6 +88,7 @@ func TestOperation(t *testing.T) {
 
 	viper.Reset()
 	viper.Set("nocolor", true)
+	viper.Set("tty", true)
 	Init("test", "1.0.0")
 	Defaults()
 	capture := &strings.Builder{}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -106,7 +106,7 @@ $ restish api.rest.sh
 
 ### Editing Resources
 
-If an API supports both a `GET` and a `PUT` for a resource, there is an `edit` convenience operation which allows you to edit the resource similar to how you might use a `PATCH` if the API were available.
+If an API supports both a `GET` and a `PUT` for a resource, there is a client-side `edit` convenience operation which allows you to edit the resource similar to how you might use a `PATCH` if the API were available.
 
 ```bash
 # Modify a field on the command line via CLI shorthand
@@ -116,13 +116,13 @@ $ restish edit api.rest.sh/types string: changed, tags[]: another
 $ restish edit -i api.rest.sh/types
 ```
 
-To use interactive mode you must have the `VISUAL` or `EDITOR` environment variable set to an editor, for example `export VISUAL="code --wait"` for VSCode.
+To use interactive mode you must have the `VISUAL` or `EDITOR` environment variable set to an editor, for example `export VISUAL="code --wait"` for VSCode. If the API resource includes a `$schema` then you will also get documentation on hover, completion suggestions, and linting as you type in your editor.
 
 Editing resources will make use of [conditional requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) if any relevant headers are found on the `GET` response. For example, if an `ETag` header is present in the `GET` response then an `If-Match` header will be send on the `PUT` to prevent performing the write operation if the resource was modified by someone else while you are editing.
 
 ### Output Filtering
 
-By default, you will see the entire response as output. Restish includes built-in filtering using [Shorthand queries]() which enable you to filter & project the response data. Using a filter automatically enables JSON output mode and only prints the result of the filter expression. Here are some basic examples:
+Restish includes built-in filtering using [Shorthand queries](shorthand.md#querying) which enable you to filter & project the response data. Using a filter only prints the result of the filter expression. Here are some basic examples:
 
 ```bash
 # Get social media profiles from a JSON Resume:
@@ -155,9 +155,42 @@ $ restish api.rest.sh -f headers.Date -r
 Sat, 1 Jan 2022 12:00:00 GMT
 ```
 
-See [output](/output.md) for more info & examples.
+See [filtering & projection](output.md#filtering--projection) for more info & examples.
 
-?> Quick tip: If you want the JSON body for scripting just use `-f body`!
+### Output Defaults
+
+Like some other well-known tools, the output defaults are different depending on whether the command is running in an interactive shell or output is being redirected to a pipe or file.
+
+```mermaid
+graph TD
+  Interactive[Is interactive terminal<br/>or redirected to file/pipe?] -->|interactive| Readable[Colorized<br/>Full pretty response<br/>Human readable]
+  Interactive -->|redirected| JSON[No color<br/>Body only</br>JSON]
+```
+
+See [output defaults](output.md#output-defaults) for more information.
+
+!> Use `restish api content-types` to see the avialable content types and output formats you can use.
+
+### Tabular Output
+
+Sometimes it's easier to read a response when you can see it in the form of a two-dimentional table. Restish supports the `table` output format for this purpose if the response (or filtered result) is an array of objects. For example:
+
+```bash
+$ restish api.rest.sh/images -o table
+HTTP/2.0 200 OK
+Accept-Ranges: bytes
+...
+
+╔════════╤════════════════════════════╤══════════════╗
+║ format │            name            │     self     ║
+╟━━━━━━━━┼━━━━━━━━━━━━━━━━━━━━━━━━━━━━┼━━━━━━━━━━━━━━╢
+║   jpeg │            Dragonfly macro │ /images/jpeg ║
+║   webp │   Origami under blacklight │ /images/webp ║
+║    gif │ Andy Warhol mural in Miami │  /images/gif ║
+║    png │          Station in Prague │  /images/png ║
+║   heic │     Chihuly glass in boats │ /images/heic ║
+╚════════╧════════════════════════════╧══════════════╝
+```
 
 ## API Operation Commands
 


### PR DESCRIPTION
This includes a number of small but related changes, the biggest being the breaking change in default output behavior when redirecting output to a file or pipe as it now just sends the response body as JSON when no filters are passed. List of all changes:

- Default redirected output to response body as JSON
- Remove `--rsh-table` in favor of `-o table`
- Reuse registered content types as output marshallers
- Add a `PrettyMarshaller` which content types can (optionally) provide, e.g. JSON and Ion provide one now.
- Readable output now colorizes matching braces/brackets
- Differentiate between TTY and color within the code
- When the filter `-f` option doesn't start with e.g. `body`, `headers`, or one of the valid other values it now returns an error rather than no output.

Note: this is a breaking change in behavior.