### PR TITLE
fix: fix loader hints overriding the whole base url

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -618,7 +618,7 @@ func (l *loader) Resolve(relURI string) (*url.URL, error) {
 }
 
 func (l *loader) LocationHints() []string {
-	return []string{"/openapi.json", "/openapi.yaml"}
+	return []string{"/openapi.json", "/openapi.yaml", "openapi.json", "openapi.yaml"}
 }
 
 func (l *loader) Detect(resp *http.Response) bool {


### PR DESCRIPTION
Usage of url ResolveReference with '/openapi.json' argument prevented discovery of APIs with versions in URL, such as 'https://api.example.com/v2', only looking for 'https://api.example.com/openapi.json' instead of 'https://api.example.com/v2/openapi.json'