### PR TITLE
Allow specifying config and cache directory via environment variables

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -99,7 +99,7 @@ func cacheAPI(name string, api *API) {
 	if err != nil {
 		LogError("Could not marshal API cache %s", err)
 	}
-	filename := path.Join(viper.GetString("config-directory"), name+".cbor")
+	filename := path.Join(getCacheDir(), name+".cbor")
 	if err := os.WriteFile(filename, b, 0o600); err != nil {
 		LogError("Could not write API cache %s", err)
 	}
@@ -131,7 +131,7 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 	expires := Cache.GetTime(name + ".expires")
 	if !viper.GetBool("rsh-no-cache") && !expires.IsZero() && expires.After(time.Now()) {
 		var cached API
-		filename := path.Join(viper.GetString("config-directory"), name+".cbor")
+		filename := path.Join(getCacheDir(), name+".cbor")
 		if data, err := os.ReadFile(filename); err == nil {
 			if err := cbor.Unmarshal(data, &cached); err == nil {
 				if cached.RestishVersion == root.Version {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -570,14 +570,33 @@ func userHomeDir() string {
 	return os.Getenv("HOME")
 }
 
-func cacheDir() string {
-	return path.Join(userHomeDir(), "."+viper.GetString("app-name"))
+func getConfigDir(appName string) string {
+	configDirEnv := strings.ToUpper(appName) + "_CONFIG_DIR"
+
+	configDir := os.Getenv(configDirEnv)
+
+	if configDir == "" {
+		configDir = path.Join(userHomeDir(), "."+appName)
+	}
+	return configDir
+}
+
+func getCacheDir() string {
+	appName := viper.GetString("app-name")
+	cacheDirEnv := strings.ToUpper(appName) + "_CACHE_DIR"
+
+	cacheDir := os.Getenv(cacheDirEnv)
+
+	if cacheDir == "" {
+		cacheDir = path.Join(userHomeDir(), "."+appName)
+	}
+	return cacheDir
 }
 
 func initConfig(appName, envPrefix string) {
 	// One-time setup to ensure the path exists so we can write files into it
 	// later as needed.
-	configDir := path.Join(userHomeDir(), "."+appName)
+	configDir := getConfigDir(appName)
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		panic(err)
 	}
@@ -603,11 +622,17 @@ func initConfig(appName, envPrefix string) {
 func initCache(appName string) {
 	Cache = viper.New()
 	Cache.SetConfigName("cache")
-	Cache.AddConfigPath(viper.GetString("config-directory"))
+
+	cacheDir := getCacheDir()
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		panic(err)
+	}
+
+	Cache.AddConfigPath(cacheDir)
 
 	// Write a blank cache if no file is already there. Later you can use
 	// cli.Cache.SaveConfig() to write new values.
-	filename := path.Join(viper.GetString("config-directory"), "cache.json")
+	filename := path.Join(cacheDir, "cache.json")
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		if err := os.WriteFile(filename, []byte("{}"), 0600); err != nil {
 			panic(err)

--- a/cli/transport.go
+++ b/cli/transport.go
@@ -44,7 +44,7 @@ func shouldCache(resp *http.Response) bool {
 
 // CachedTransport returns an HTTP transport with caching abilities.
 func CachedTransport() *httpcache.Transport {
-	t := httpcache.NewTransport(diskcache.New(path.Join(cacheDir(), "responses")))
+	t := httpcache.NewTransport(diskcache.New(path.Join(getCacheDir(), "responses")))
 	t.MarkCachedResponses = false
 	return t
 }


### PR DESCRIPTION
This allows users to specify the location of the configuration and cache directory via the `RESTISH_CONFIG_DIR` and `RESTISH_CACHE_DIR` environment variables. As an example, this aids in a use case where we want to ship different API configurations for different products, let them manage the configuration, and invoke restish as needed.

If not specified, the existing default paths are used.