### PR TITLE
Allow circular references

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/danielgtaylor/restish
 
 go 1.18
 
-// replace github.com/pb33f/libopenapi => ../libopenapi
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/alecthomas/chroma v0.10.0
@@ -25,7 +23,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.3.4
+	github.com/pb33f/libopenapi v0.3.7
 	github.com/shamaton/msgpack/v2 v2.1.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.3.4 h1:DCdi6B6WwSTU8YYY7fb7C+llmMy84YPBAjhgaW+HU7M=
-github.com/pb33f/libopenapi v0.3.4/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
+github.com/pb33f/libopenapi v0.3.7 h1:5qvRwUedU0PM+hDrUJIHVcAKGJ9R3Ex2j/r7MExRgyc=
+github.com/pb33f/libopenapi v0.3.7/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=

--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -340,7 +340,7 @@ func (h *AuthorizationCodeHandler) OnRequest(request *http.Request, key string, 
 			TokenSource:    source,
 		}
 
-		return TokenHandler(refreshSource, key, request)
+		return TokenHandler(&refreshSource, key, request)
 	}
 
 	return nil

--- a/oauth/clientcreds.go
+++ b/oauth/clientcreds.go
@@ -1,12 +1,12 @@
 package oauth
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/danielgtaylor/restish/cli"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -54,7 +54,7 @@ func (h *ClientCredentialsHandler) OnRequest(request *http.Request, key string, 
 			TokenURL:       params["token_url"],
 			EndpointParams: endpointParams,
 			Scopes:         strings.Split(params["scopes"], ","),
-		}).TokenSource(oauth2.NoContext)
+		}).TokenSource(context.Background())
 
 		return TokenHandler(source, key, request)
 	}

--- a/oauth/refresh.go
+++ b/oauth/refresh.go
@@ -32,7 +32,7 @@ type RefreshTokenSource struct {
 
 // Token generates a new token using either a refresh token or by falling
 // back to the original source.
-func (ts RefreshTokenSource) Token() (*oauth2.Token, error) {
+func (ts *RefreshTokenSource) Token() (*oauth2.Token, error) {
 	if ts.RefreshToken != "" {
 		cli.LogDebug("Trying refresh token to get a new access token")
 		payload := fmt.Sprintf("grant_type=refresh_token&client_id=%s&refresh_token=%s", ts.ClientID, ts.RefreshToken)

--- a/oauth/request.go
+++ b/oauth/request.go
@@ -3,7 +3,7 @@ package oauth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -42,7 +42,7 @@ func requestToken(tokenURL, payload string) (*oauth2.Token, error) {
 	}
 	cli.LogDebugResponse(start, res)
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 
 	if res.StatusCode > 200 {
 		return nil, fmt.Errorf("bad response from token endpoint:\n%s", body)

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -178,7 +177,7 @@ func TestBrokenRequest(t *testing.T) {
 	spec, _ := url.Parse("/openapi.yaml")
 
 	resp := &http.Response{
-		Body: ioutil.NopCloser(iotest.ErrReader(fmt.Errorf("request closed"))),
+		Body: io.NopCloser(iotest.ErrReader(fmt.Errorf("request closed"))),
 	}
 
 	_, err := New().Load(*base, *spec, resp)
@@ -190,7 +189,7 @@ func TestEmptyDocument(t *testing.T) {
 	spec, _ := url.Parse("/openapi.yaml")
 
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader("")),
+		Body: io.NopCloser(strings.NewReader("")),
 	}
 
 	_, err := New().Load(*base, *spec, resp)
@@ -202,7 +201,7 @@ func TestUnsupported(t *testing.T) {
 	spec, _ := url.Parse("/openapi.yaml")
 
 	resp := &http.Response{
-		Body: ioutil.NopCloser(strings.NewReader(`swagger: 2.0`)),
+		Body: io.NopCloser(strings.NewReader(`swagger: 2.0`)),
 	}
 
 	_, err := New().Load(*base, *spec, resp)
@@ -228,7 +227,7 @@ func TestLoader(t *testing.T) {
 			spec, _ := url.Parse("/openapi.yaml")
 
 			resp := &http.Response{
-				Body: ioutil.NopCloser(bytes.NewReader(input)),
+				Body: io.NopCloser(bytes.NewReader(input)),
 			}
 
 			api, err := New().Load(*base, *spec, resp)


### PR DESCRIPTION
The main change in this PR is to stop panicking when an API has circular references.

After the change I made here https://github.com/pb33f/libopenapi/pull/39 libopenapi will return both the `Model` and a list of errors, if the only errors it encountered are circular references.
Restish has no issues with processing API documents that contain circular references (verified experimentally).
An alternative implementation is to check if the Model is not nil, but I think the current implementation represents the intent better, at the expense of slightly more verbose error checking code.

I also took the liberty of fixing some deprecated function lint warnings.

Finally, I also changed the `Token` method of `RefreshTokenSource` to be a pointer receiver. The last line in that function tries to save the new token on the original token source, but that is ineffective: because it has a value receiver, you work on a copied value, and the change is never visible outside.
This probably causes restish to go through a full auth flow way more often than it needs to be (essentially  makes the refresh token single use).

It might be worthwhile to set up golangci-lint in CI, it's excellent at highlighting bugs like these.