### PR TITLE
fix: print responses without a body

### DIFF
--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -586,7 +586,7 @@ func (f *DefaultFormatter) formatAuto(format string, resp Response) ([]byte, err
 	}
 
 	// No body to display.
-	return nil, nil
+	return encoded, nil
 }
 
 // Format will filter, prettify, colorize and output the data.


### PR DESCRIPTION
This fixes a small bug introduced in the default output behavior refactor related to printing responses which have no body (e.g. HTTP 204). With this fix the behavior is back to displaying the HTTP status code and headers for such responses.