### PR TITLE
fix: completion for multi-variable templates

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -94,6 +94,7 @@ func matchTemplate(url, template string) string {
 			matcher := regexp.MustCompile(templateVarRegex.ReplaceAllString(tplPart, ".*"))
 			if matcher.MatchString(urlPart) && urlPart != "" {
 				tplParts[i] = urlPart
+				continue
 			}
 		} else if urlPart == tplPart {
 			// This is an exact path match.


### PR DESCRIPTION
This fixes the behavior for URI templates with multiple variables, which were matching incorrectly due to breaking out of the loop. If the match is successful here we force the continue to keep going to check for other variables.