### PR TITLE
fix: properly support commas in headers

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -728,10 +728,10 @@ func Run() error {
 	if caCert, _ := GlobalFlags.GetString("rsh-ca-cert"); caCert != "" {
 		viper.Set("rsh-ca-cert", caCert)
 	}
-	if query, _ := GlobalFlags.GetStringSlice("rsh-query"); len(query) > 0 {
+	if query, _ := GlobalFlags.GetStringArray("rsh-query"); len(query) > 0 {
 		viper.Set("rsh-query", query)
 	}
-	if headers, _ := GlobalFlags.GetStringSlice("rsh-header"); len(headers) > 0 {
+	if headers, _ := GlobalFlags.GetStringArray("rsh-header"); len(headers) > 0 {
 		viper.Set("rsh-header", headers)
 	}
 	profile, _ := GlobalFlags.GetString("rsh-profile")

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -91,6 +91,15 @@ func TestPutURI400(t *testing.T) {
 	}`)
 }
 
+func TestHeaderWithComma(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com").Get("/").MatchHeader("Foo", "a,b,c").Reply(204)
+
+	out := run("http://example.com/ -H Foo:a,b,c")
+	assert.Contains(t, out, "204 No Content")
+}
+
 type TestAuth struct{}
 
 // Parameters returns a list of OAuth2 Authorization Code inputs.

--- a/cli/flag.go
+++ b/cli/flag.go
@@ -44,8 +44,8 @@ func AddGlobalFlag(name, short, description string, defaultValue interface{}, mu
 				v = strings.Split(s, ",")
 				viper.Set(name, v)
 			}
-			flags.StringSliceP(name, short, v.([]string), description)
-			GlobalFlags.StringSliceP(name, short, v.([]string), description)
+			flags.StringArrayP(name, short, v.([]string), description)
+			GlobalFlags.StringArrayP(name, short, v.([]string), description)
 		} else {
 			flags.StringP(name, short, fmt.Sprintf("%v", viper.Get(name)), description)
 			GlobalFlags.StringP(name, short, fmt.Sprintf("%v", viper.Get(name)), description)


### PR DESCRIPTION
Previously commas would break the headers, e.g. sending a `Date` or `Last-Modified` or `If-Unmodified-Since` header. That was because the flags parser was splitting on commas, which is now disabled with this fix. The custom logic splitting on commas on environment variables is left in for now to support multiple headers set via the environment.