### PR TITLE
Fix bug #128

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -217,7 +217,14 @@ func initAPIConfig() {
 }
 
 func findAPI(uri string) (string, *APIConfig) {
+	apiName := viper.GetString("api-name")
+
 	for name, config := range configs {
+		// fixes https://github.com/danielgtaylor/restish/issues/128
+		if len(apiName) > 0 && name != apiName {
+			continue
+		}
+
 		profile := viper.GetString("rsh-profile")
 		if profile != "default" {
 			if config.Profiles[profile] == nil {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -757,6 +757,11 @@ func Run() error {
 			// there is no need to do anything since the normal flow will catch
 			// the command being missing and print help.
 			if cfg, ok := configs[apiName]; ok {
+
+				// This is used to give context to findApi
+				// Smallest fix for https://github.com/danielgtaylor/restish/issues/128
+				viper.Set("api-name", apiName)
+
 				currentConfig = cfg
 				for _, cmd := range Root.Commands() {
 					if cmd.Use == apiName {


### PR DESCRIPTION
When an API base matches another API's base the API is chosen based on the order the JSON parser unmarshalled the apis.json. 