### PR TITLE
fix: run tests on pulls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     name: Build & Test


### PR DESCRIPTION
This should ensure that the tests get run on pull requests by outside contributors as those don't trigger a `push` event.