### PR TITLE
fix: properly set error on panic recovery

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -682,7 +682,7 @@ func Defaults() {
 }
 
 // Run the CLI! Parse arguments, make requests, print responses.
-func Run() error {
+func Run() (returnErr error) {
 	// We need to register new commands at runtime based on the selected API
 	// so that we don't have to potentially refresh and parse every single
 	// registered API just to run. So this is a little hacky, but we hijack
@@ -798,8 +798,6 @@ func Run() error {
 		}
 	}
 
-	var returnErr error
-
 	// Phew, we made it. Execute the command now that everything is loaded
 	// and all the relevant sub-commands are registered.
 	defer func() {
@@ -808,6 +806,8 @@ func Run() error {
 			LogDebug("%s", string(debug.Stack()))
 			if e, ok := err.(error); ok {
 				returnErr = e
+			} else {
+				returnErr = fmt.Errorf("%v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
Related to #125, this bug prevented the error from getting returned which meant no non-zero exit code was ever set for panics. Now every panic should result in an exit code of 1.

I'm leaving the linked issue open because of the feature request for an option to exit non-zero for 3xx/4xx/5xx status codes for easier scripting.