### PR TITLE
feat: set exit code from status code, fixes #125

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -552,6 +552,7 @@ Not after (expires): %s (%s)
 	AddGlobalFlag("rsh-client-cert", "", "Path to a PEM encoded client certificate", "", false)
 	AddGlobalFlag("rsh-client-key", "", "Path to a PEM encoded private key", "", false)
 	AddGlobalFlag("rsh-ca-cert", "", "Path to a PEM encoded CA cert", "", false)
+	AddGlobalFlag("rsh-ignore-status-code", "", "Do not set exit code from HTTP status code", false, false)
 
 	Root.RegisterFlagCompletionFunc("rsh-output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
@@ -817,4 +818,13 @@ func Run() (returnErr error) {
 	}
 
 	return returnErr
+}
+
+// GetExitCode returns the exit code to use based on the last HTTP status code.
+func GetExitCode() int {
+	if s := GetLastStatus() / 100; s > 2 && !viper.GetBool("rsh-ignore-status-code") {
+		return s
+	}
+
+	return 0
 }

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -85,3 +85,41 @@ func TestAuthHookFailure(t *testing.T) {
 		MakeRequest(r)
 	})
 }
+
+func TestGetStatus(t *testing.T) {
+	defer gock.Off()
+
+	reset(false)
+	lastStatus = 0
+
+	gock.New("http://example.com").
+		Get("/").
+		Reply(http.StatusOK)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
+	resp, err := MakeRequest(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	assert.Equal(t, http.StatusOK, GetLastStatus())
+}
+
+func TestIgnoreStatus(t *testing.T) {
+	defer gock.Off()
+
+	reset(false)
+	lastStatus = 0
+
+	gock.New("http://example.com").
+		Get("/").
+		Reply(http.StatusOK)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
+	resp, err := MakeRequest(req, IgnoreStatus())
+
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	assert.Equal(t, 0, GetLastStatus())
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -238,3 +238,18 @@ $ restish api.rest.sh/types -H Accept:application/json -r >types.json
 ```
 
 ?> Raw mode without filtering will not parse the response, but _will_ decode it if compressed (e.g. with gzip or brotli).
+
+## Exit Status Codes
+
+Restish will exit with the following status codes by default in order to facilitate scripting. The most recent HTTP status code is used when a command makes more than one request.
+
+| Code | Description          |
+| ---- | -------------------- |
+| 0    | Success              |
+| 1    | Unrecoverable errors |
+| 2    | -                    |
+| 3    | 3xx HTTP response    |
+| 4    | 4xx HTTP response    |
+| 5    | 5xx HTTP response    |
+
+Use the `--rsh-ignore-status-code` option or `RSH_IGNORE_STATUS_CODE=1` environment variable to ignore the exit status code and always return 0 for 3xx/4xx/5xx responses.

--- a/main.go
+++ b/main.go
@@ -40,4 +40,7 @@ func main() {
 	if err := cli.Run(); err != nil {
 		os.Exit(1)
 	}
+
+	// Exit based on the status code of the last request.
+	os.Exit(cli.GetExitCode())
 }


### PR DESCRIPTION
This sets the exit status code depending on the HTTP response status code using 3, 4, or 5 for 3xx, 4xx, 5xx errors respectively. This is similar to HTTPie's `--check-status` and curl's `--fail-with-body`:

- https://httpie.io/docs/cli/scripting
- https://daniel.haxx.se/blog/2021/02/11/curl-fail-with-body/

Unlike those (but like [xh#144](https://github.com/ducaale/xh/issues/144)) setting the exit code is the default behavior. You can opt-out via `--rsh-ignore-status-code`.