### PR TITLE
Various documentation fixes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# MIT License
+
 Copyright 2020 Daniel G. Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Features include:
   - OAuth2 authorization code (with PKCE [RFC 7636](https://tools.ietf.org/html/rfc7636)) flow
   - On the fly authorization through external tools for custom API signature mechanisms
 - Content negotiation, decoding & unmarshalling built-in:
-  - JSON ([RFC 8259](https://tools.ietf.org/html/rfc8259), https://www.json.org/)
-  - YAML (https://yaml.org/)
-  - CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049), http://cbor.io/)
-  - MessagePack (https://msgpack.org/)
-  - Amazon Ion (http://amzn.github.io/ion-docs/)
+  - JSON ([RFC 8259](https://tools.ietf.org/html/rfc8259), <https://www.json.org/>)
+  - YAML (<https://yaml.org/>)
+  - CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049), <http://cbor.io/>)
+  - MessagePack (<https://msgpack.org/>)
+  - Amazon Ion (<http://amzn.github.io/ion-docs/>)
   - Gzip ([RFC 1952](https://tools.ietf.org/html/rfc1952)) and Brotli ([RFC 7932](https://tools.ietf.org/html/rfc7932)) content encoding
 - Standardized [hypermedia](https://smartbear.com/learn/api-design/what-is-hypermedia/) parsing into queryable/followable response links:
   - HTTP Link relation headers ([RFC 5988](https://tools.ietf.org/html/rfc5988#section-6.2.2))

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -1,0 +1,13 @@
+default: true
+
+# no-hard-tabs
+MD010: false
+
+# line-length
+MD013: false
+
+# commands-show-output
+MD014: false
+
+# no-inline-html
+MD033: false

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,11 +35,11 @@ Start with the [guide](/guide.md) to learn how to install and configure Restish 
   - OAuth2 client credentials flow (machine-to-machine, [RFC 6749](https://tools.ietf.org/html/rfc6749))
   - OAuth2 authorization code (with PKCE [RFC 7636](https://tools.ietf.org/html/rfc7636)) flow
 - Content negotiation, decoding & unmarshalling built-in:
-  - JSON ([RFC 8259](https://tools.ietf.org/html/rfc8259), https://www.json.org/)
-  - YAML (https://yaml.org/)
-  - CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049), http://cbor.io/)
-  - MessagePack (https://msgpack.org/)
-  - Amazon Ion (http://amzn.github.io/ion-docs/)
+  - JSON ([RFC 8259](https://tools.ietf.org/html/rfc8259), <https://www.json.org/>)
+  - YAML (<https://yaml.org/>)
+  - CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049), <http://cbor.io/>)
+  - MessagePack (<https://msgpack.org/>)
+  - Amazon Ion (<http://amzn.github.io/ion-docs/>)
   - Gzip ([RFC 1952](https://tools.ietf.org/html/rfc1952)) and Brotli ([RFC 7932](https://tools.ietf.org/html/rfc7932)) content encoding
 - Standardized [hypermedia](https://smartbear.com/learn/api-design/what-is-hypermedia/) parsing into queryable/followable response links:
   - HTTP Link relation headers ([RFC 5988](https://tools.ietf.org/html/rfc5988#section-6.2.2))

--- a/docs/bulk.md
+++ b/docs/bulk.md
@@ -1,4 +1,4 @@
-# Bulk Resource Management
+# Bulk resource management
 
 Restish includes support for a `git`-like client-side bulk resource management interface, enabling you to pull resources onto disk and track both remote and local changes, get diffs, batch submit updates, etc.
 
@@ -19,7 +19,7 @@ DELETE /books/{book-id} Delete book
 
 ?> Resource creation via Restish `bulk` requires the use of client-generated identifiers and HTTP `PUT` requests. Use plain old `restish post ...` otherwise.
 
-## Getting Started & Demo
+## Getting started & demo
 
 Let's see how it works in action by using an example CRUD API:
 
@@ -137,7 +137,7 @@ Alias: `i`
 | `-f`, `--rsh-filter` | Filter the response via [Shorthand Query](./shorthand.md#querying)<br/>Example: `-f 'body.{id, version: last_modified_dt}'`                                                    |
 | `--url-template`     | Template string to build URLs from list response items. If a filter is passed, it is processed _before_ rendering the URL template.<br/>Example: `--url-template='/items/{id}` |
 
-#### Automatically Recognized Fields
+#### Automatically recognized fields
 
 The following fields are automatically recognized and used when available in the list response items, allowing bulk resource management to just work out of the box with a large number of APIs. Fields are checked in the order listed below and the first that is found will be used.
 
@@ -146,7 +146,7 @@ The following fields are automatically recognized and used when available in the
 | Resource URL     | `url`, `uri`, `self`, `link`                                   |
 | Resource version | `version`, `etag`, `last_modified`, `lastModified`, `modified` |
 
-#### Complex Example
+#### Complex example
 
 For a more complex example, let's assume you have an API at `example.com/items` which returns resources for multiple people via a list operation like this:
 

--- a/docs/bulk.md
+++ b/docs/bulk.md
@@ -57,7 +57,7 @@ $ rb list --match='author.lower contains brian'
 the-fabric-of-the-cosmos.json
 ```
 
-Restish also understands JSON Schema, so if the resources advertise a schema (e.g. via a `describedby` link relation of a `$schema` property) then it can provide useful errors when filtering. Since the example books advertise a schema at https://api.rest.sh/schemas/Book.json we can get warnings about potential expression problems:
+Restish also understands JSON Schema, so if the resources advertise a schema (e.g. via a `describedby` link relation of a `$schema` property) then it can provide useful errors when filtering. Since the example books advertise a schema at <https://api.rest.sh/schemas/Book.json> we can get warnings about potential expression problems:
 
 ```bash
 $ rb list --match='recent_ratings > 5'

--- a/docs/bulk.md
+++ b/docs/bulk.md
@@ -10,7 +10,7 @@ If common response field names and standard conditional update headers are used,
 
 For example, you might have a simple CRUD-style API like this, which fully supports bulk operations:
 
-```
+```text
 GET    /books           List books returns [{url: "...", version: "..."}]
 GET    /books/{book-id} Get book
 PUT    /books/{book-id} Create/update book

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -31,7 +31,7 @@ See how Restish compares to other tools below:
 | Automatic pagination for `next` link relations       | ✅      | ❌            | ❌              |
 | URL & command shell completion hints                 | ✅      | ❌            | ❌              |
 
-## Performance Comparison
+## Performance comparison
 
 Test were run on a Macbook Pro and averages of several requests are reported as latency can and does vary. The general takeaway is that performance is better than HTTPie and very close to cURL but with many more features. Numbers below are in seconds.
 
@@ -66,9 +66,9 @@ time (repeat 10 {https https://httpbin.org/cache/60})
 time (repeat 10 {restish https://httpbin.org/cache/60})
 ```
 
-## Detailed Comparisons
+## Detailed comparisons
 
-### Passing Headers & Query Params
+### Passing headers & query params
 
 This is how you pass parameters to the API.
 
@@ -93,7 +93,7 @@ restish -H Header:value 'api.rest.sh/?a=1&b=true'
 restish -H Header:value api.rest.sh/ -q a=1 -q b=true
 ```
 
-### Input Shorthand
+### Input shorthand
 
 This is one mechanism to generate and pass a request body to the API.
 
@@ -124,7 +124,7 @@ restish post api.rest.sh \
   platform.apps: [Terminal, Desktop, Web, Mobile]
 ```
 
-### Getting Header Values
+### Getting header values
 
 How easy is it to read the output of a header in a shell environment?
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -68,7 +68,7 @@ time (repeat 10 {restish https://httpbin.org/cache/60})
 
 ## Detailed comparisons
 
-### Passing headers & query params
+### Passing headers & query parameters
 
 This is how you pass parameters to the API.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -31,7 +31,7 @@ See how Restish compares to other tools below:
 | Automatic pagination for `next` link relations       | ✅      | ❌            | ❌              |
 | URL & command shell completion hints                 | ✅      | ❌            | ❌              |
 
-# Performance Comparison
+## Performance Comparison
 
 Test were run on a Macbook Pro and averages of several requests are reported as latency can and does vary. The general takeaway is that performance is better than HTTPie and very close to cURL but with many more features. Numbers below are in seconds.
 
@@ -66,9 +66,9 @@ time (repeat 10 {https https://httpbin.org/cache/60})
 time (repeat 10 {restish https://httpbin.org/cache/60})
 ```
 
-# Detailed Comparisons
+## Detailed Comparisons
 
-## Passing Headers & Query Params
+### Passing Headers & Query Params
 
 This is how you pass parameters to the API.
 
@@ -93,7 +93,7 @@ restish -H Header:value 'api.rest.sh/?a=1&b=true'
 restish -H Header:value api.rest.sh/ -q a=1 -q b=true
 ```
 
-## Input Shorthand
+### Input Shorthand
 
 This is one mechanism to generate and pass a request body to the API.
 
@@ -124,7 +124,7 @@ restish post api.rest.sh \
   platform.apps: [Terminal, Desktop, Web, Mobile]
 ```
 
-## Getting Header Values
+### Getting Header Values
 
 How easy is it to read the output of a header in a shell environment?
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ There are two types of configuration in Restish:
 1. Global configuration
 2. API-specific configuration
 
-## Global Configuration
+## Global configuration
 
 Global configuration affects all commands and can be set in one of three ways, going from highest to lowest precedence:
 
@@ -53,7 +53,7 @@ $ restish api.rest.sh/images
 
 Should TTY autodetection for colored output cause any problems, you can manually disable colored output via the `NOCOLOR=1` environment variable.
 
-## API Configuration
+## API configuration
 
 ### Adding an API
 
@@ -105,7 +105,7 @@ $ restish api sync $NAME
 
 ?> This is usually not necessary, as Restish will update the API description every 24 hours. Use this if you want to force an update sooner!
 
-### Persistent Headers & Query Params
+### Persistent headers & query params
 
 Follow the prompts to add or edit persistent headers or query params. These are values that get sent with **every request** when using that profile.
 
@@ -136,7 +136,7 @@ Example:
 }
 ```
 
-### API Auth
+### API auth
 
 The following auth types are supported:
 
@@ -256,7 +256,7 @@ For example, to integrate with a third-party service like [Auth0](https://auth0.
 }
 ```
 
-#### External Tool
+#### External tool
 
 To allow interaction with APIs which have custom signature schemes, a
 third-party tool or script can be used. The script will need to accept
@@ -311,7 +311,7 @@ parameters only will be considered:
 - `uri`: Will replace the destination URL entirely (allowing the
   addition of query arguments if needed).
 
-### Loading From Files or URLs
+### Loading from files or URLs
 
 Sometimes an API won't provide a way to fetch its spec document, or a third-party will provide a spec for an existing public API, for example GitHub or Stripe.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Adding or editing an API is possible via an interactive terminal UI:
 $ restish api configure $NAME [$BASE_URI]
 ```
 
-You should see something like the following, which enables you to create and edit profiles, headers, query params, and auth, eventually saving the data to `~/.restish/apis.json`:
+You should see something like the following, which enables you to create and edit profiles, headers, query parameters, and auth, eventually saving the data to `~/.restish/apis.json`:
 
 <img alt="Screen Shot" src="https://user-images.githubusercontent.com/106826/83099522-79dd3200-a062-11ea-8a78-b03a2fecf030.png">
 
@@ -105,9 +105,9 @@ $ restish api sync $NAME
 
 ?> This is usually not necessary, as Restish will update the API description every 24 hours. Use this if you want to force an update sooner!
 
-### Persistent headers & query params
+### Persistent headers & query parameters
 
-Follow the prompts to add or edit persistent headers or query params. These are values that get sent with **every request** when using that profile.
+Follow the prompts to add or edit persistent headers or query parameters. These are values that get sent with **every request** when using that profile.
 
 Use cases:
 
@@ -173,7 +173,7 @@ HTTP Basic Auth is sent via an `Authorization` HTTP header and requires a `usern
 
 #### API key
 
-API keys are values given to you by the API operator that identify you as the caller. There is no explicit auth support for API keys because they are already handled by persistend headers or query params.
+API keys are values given to you by the API operator that identify you as the caller. There is no explicit auth support for API keys because they are already handled by persistend headers or query parameters.
 
 For example, if your API operator has given you a JWT of `abc123`, you might set a persistent header like `Authorization: bearer abc123` in the default profile.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -94,7 +94,7 @@ $ restish post api.rest.sh <input.json
 $ restish post api.rest.sh name: Kari, tags[]: admin
 ```
 
-Read more about [CLI Shorthand](/shorthand.md). Headers and query params can also be set via environment variables by prefixing with `RSH_`, for example:
+Read more about [CLI Shorthand](/shorthand.md). Headers and query parameters can also be set via environment variables by prefixing with `RSH_`, for example:
 
 ```bash
 # Set via env vars
@@ -102,7 +102,7 @@ $ export RSH_HEADER=header1:value1,header2:value2
 $ restish api.rest.sh
 ```
 
-?> If you have persistent headers or query params you'd like to set, then consider registering the API endpoint with Restish rather than exporting environment variables. Read on to find out how.
+?> If you have persistent headers or query parameters you'd like to set, then consider registering the API endpoint with Restish rather than exporting environment variables. Read on to find out how.
 
 ### Editing resources
 
@@ -206,7 +206,7 @@ APIs are registered with a short nickname. For example the GitHub v3 API might b
 
 Each registered API can have a number of named profiles which can be selected via the `-p` or `--rsh-profile` argument. The default profile is called `default`.
 
-Each profile can have a number of preset headers or query params, a type of auth, and any auth-specific params.
+Each profile can have a number of preset headers or query parameters, a type of auth, and any auth-specific parameters.
 
 Getting started registering an API is easy and uses an interactive prompt to set up profiles, auth, etc. At a minimum you must provide a short nickname and a base URL:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -192,7 +192,7 @@ Accept-Ranges: bytes
 ╚════════╧════════════════════════════╧══════════════╝
 ```
 
-## API operation commands
+## API-specific commands
 
 APIs can be registered in order to provide API description auto-discovery (e.g. OpenAPI 3) with convenience commands and authentication. The following API description formats and versions are supported:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -29,7 +29,7 @@ $ restish --version
 
 ?> If using `zsh` as your shell (the default on macOS), you should set `alias restish="noglob restish"` in your `~/.zshrc` to prevent it from trying to handle `?` in URLs and `[]` in shorthand input. Alternatively you can use quotes around your inputs.
 
-## Basic Usage
+## Basic usage
 
 Generic HTTP verbs require no setup and are easy to use. If no verb is supplied then a GET is assumed. The `https://` is also optional as it is the default.
 
@@ -75,7 +75,7 @@ $ restish api.rest.sh/example
 
 !> Note that the output above is **not** JSON! By default, Restish outputs an HTTP+JSON-like format meant to be more readable. See [output](/output.md) for more info.
 
-### Input Parameters & Body
+### Input parameters & body
 
 Various inputs can be passed in as needed:
 
@@ -90,7 +90,7 @@ $ restish -H Accept:application/json api.rest.sh
 # Pass in a body via a file
 $ restish post api.rest.sh <input.json
 
-# Pass in body via CLI shorthand
+# Pass in body via CLI Shorthand
 $ restish post api.rest.sh name: Kari, tags[]: admin
 ```
 
@@ -104,7 +104,7 @@ $ restish api.rest.sh
 
 ?> If you have persistent headers or query params you'd like to set, then consider registering the API endpoint with Restish rather than exporting environment variables. Read on to find out how.
 
-### Editing Resources
+### Editing resources
 
 If an API supports both a `GET` and a `PUT` for a resource, there is a client-side `edit` convenience operation which allows you to edit the resource similar to how you might use a `PATCH` if the API were available.
 
@@ -120,7 +120,7 @@ To use interactive mode you must have the `VISUAL` or `EDITOR` environment varia
 
 Editing resources will make use of [conditional requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) if any relevant headers are found on the `GET` response. For example, if an `ETag` header is present in the `GET` response then an `If-Match` header will be send on the `PUT` to prevent performing the write operation if the resource was modified by someone else while you are editing.
 
-### Output Filtering
+### Output filtering
 
 Restish includes built-in filtering using [Shorthand queries](shorthand.md#querying) which enable you to filter & project the response data. Using a filter only prints the result of the filter expression. Here are some basic examples:
 
@@ -157,7 +157,7 @@ Sat, 1 Jan 2022 12:00:00 GMT
 
 See [filtering & projection](output.md#filtering--projection) for more info & examples.
 
-### Output Defaults
+### Output defaults
 
 Like some other well-known tools, the output defaults are different depending on whether the command is running in an interactive shell or output is being redirected to a pipe or file.
 
@@ -171,7 +171,7 @@ See [output defaults](output.md#output-defaults) for more information.
 
 !> Use `restish api content-types` to see the avialable content types and output formats you can use.
 
-### Tabular Output
+### Tabular output
 
 Sometimes it's easier to read a response when you can see it in the form of a two-dimentional table. Restish supports the `table` output format for this purpose if the response (or filtered result) is an array of objects. For example:
 
@@ -192,7 +192,7 @@ Accept-Ranges: bytes
 ╚════════╧════════════════════════════╧══════════════╝
 ```
 
-## API Operation Commands
+## API operation commands
 
 APIs can be registered in order to provide API description auto-discovery (e.g. OpenAPI 3) with convenience commands and authentication. The following API description formats and versions are supported:
 
@@ -294,7 +294,7 @@ $ restish example get-image jpeg
 
 For more details, check out [OpenAPI](openapi.md).
 
-### Shell Command Line Completion
+### Shell command line completion
 
 Restish has support for dynamic shell completion built-in. See the help for your shell for how to enable this:
 

--- a/docs/hypermedia.md
+++ b/docs/hypermedia.md
@@ -71,7 +71,7 @@ Link: </images?cursor=abc123>; rel="next", </schemas/ImageItemList.json>; rel="d
 
 ## Links command
 
-The links command provides a shorthand for displaying the available links. All links are normalized to include the full URL. Paginated responses may generate the same link multiple times.
+The `links` command provides a shorthand for displaying the available links. All links are normalized to include the full URL. Paginated responses may generate the same link multiple times.
 
 ```bash
 # Display available links

--- a/docs/hypermedia.md
+++ b/docs/hypermedia.md
@@ -11,7 +11,7 @@ Restish uses a standardized internal representation of hypermedia links to make 
 
 The URI is always resolved so you don't need to worry about absolute or relative paths.
 
-## Automatic Pagination
+## Automatic pagination
 
 Restish uses these standardized links to automatically handle paginated collections, returning the full collection to you whenever possible.
 
@@ -69,7 +69,7 @@ Link: </images?cursor=abc123>; rel="next", </schemas/ImageItemList.json>; rel="d
 ]
 ```
 
-## Links Command
+## Links command
 
 The links command provides a shorthand for displaying the available links. All links are normalized to include the full URL. Paginated responses may generate the same link multiple times.
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -21,7 +21,7 @@ $ restish -H MyHeader:value api.rest.sh
 $ restish -H Header1:val1 -H Header2:val2 api.rest.sh
 ```
 
-?> Note that query params use `=` as a delimiter while haders use `:`, just like with HTTP.
+?> Note that query parameters use `=` as a delimiter while haders use `:`, just like with HTTP.
 
 ## Request body
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -2,7 +2,7 @@
 
 You can set headers, query parameters, and a body for each outgoing request.
 
-## Request Parameters
+## Request parameters
 
 Request headers and query parameters are set via arguments or in the URI itself:
 
@@ -23,14 +23,14 @@ $ restish -H Header1:val1 -H Header2:val2 api.rest.sh
 
 ?> Note that query params use `=` as a delimiter while haders use `:`, just like with HTTP.
 
-## Request Body
+## Request body
 
 A request body can be set in two ways (or a combination of both) for requests that support bodies (e.g. `POST` / `PUT` / `PATCH`):
 
 1. Standard input
 2. CLI shorthand
 
-### Standard Input
+### Standard input
 
 Any stream of data passed to standard input will be sent as the request body.
 
@@ -73,7 +73,7 @@ Host: api.rest.sh
 
 The shorthand supports nested objects, arrays, automatic type coercion, and loading data from files. See the [CLI Shorthand Syntax](shorthand.md) for more info.
 
-### Combined Body Input
+### Combined body input
 
 It's also possible to use standard in as a template and replace or set values via commandline arguments, getting the best of both worlds. For example:
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -46,7 +46,7 @@ $ echo '{"name": "hello"}' | restish put api.rest.sh
 
 ### CLI Shorthand
 
-The [CLI Shorthand](shorthand.md) is a convenient way of providing structured data on the commandline. It is a JSON-like syntax that enables you to easily create nested structured data. For example:
+The [CLI Shorthand](shorthand.md) language is a convenient way of providing structured data on the commandline. It is a JSON-like syntax that enables you to easily create nested structured data. For example:
 
 ```bash
 $ restish post api.rest.sh 'foo.bar[]{baz: 1, hello: world}'

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -2,7 +2,7 @@
 
 In general, OpenAPI 3 just works with Restish. There are a couple of things you can do to make sure your users can more easily use Restish with your API.
 
-## Anatomy of a CLI Command
+## Anatomy of a CLI command
 
 A CLI command generated from an OpenAPI 3 document has the form:
 
@@ -59,11 +59,11 @@ If no such link relations are found, then the OpenAPI loader defaults to looking
 
 If neither one of those returns an OpenAPI spec, then the loader gives up.
 
-### Loading from Files
+### Loading from files
 
 For local testing or an API you don't control or can't update, you can load from OpenAPI files. See [Configuration: Loading from Files](configuration.md#loading-from-files) for an example configuration.
 
-## OpenAPI Extensions
+## OpenAPI extensions
 
 Several extensions properties may be used to change the behavior of the CLI.
 
@@ -140,7 +140,7 @@ x-cli-config:
 
 The above will prompt the user for an `org` and then fill in the params using the value from the user when creating the API configuration profile. Since `exclude` is set, the `org` parameter is never sent to the server and is only used to fill in the param template for `audience`.
 
-#### Auth Parameters
+#### Auth parameters
 
 Each auth scheme has different built-in parameters you can prompt for or provide directly in the API. Please do not put secrets into your API description!
 
@@ -222,7 +222,7 @@ paths:
 
 With the above, you would be able to call `restish my-api my-op --item-id=12`.
 
-## Compatible Frameworks
+## Compatible frameworks
 
 The following work out of the box with Restish:
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -124,7 +124,7 @@ Valid types for the security setting when not using a security scheme defined wi
 | `oauth-client-credentials` | OAuth2 pre-shared client key/secret (m2m) |
 | `oauth-authorization-code` | OAuth2 authorization code (user login)    |
 
-By default, all prompt variables become auth parameters of the same name. This can be disabled by setting `exclude` to `true` if desired. Additionally, a template system can be used to augment the value or create new params. Any value within `{...}` will get replaced by the value of the param with the given name. For example:
+By default, all prompt variables become auth parameters of the same name. This can be disabled by setting `exclude` to `true` if desired. Additionally, a template system can be used to augment the value or create new parameters. Any value within `{...}` will get replaced by the value of the param with the given name. For example:
 
 ```yaml
 x-cli-config:
@@ -138,7 +138,7 @@ x-cli-config:
     some_static_value: foo
 ```
 
-The above will prompt the user for an `org` and then fill in the params using the value from the user when creating the API configuration profile. Since `exclude` is set, the `org` parameter is never sent to the server and is only used to fill in the param template for `audience`.
+The above will prompt the user for an `org` and then fill in the parameters using the value from the user when creating the API configuration profile. Since `exclude` is set, the `org` parameter is never sent to the server and is only used to fill in the param template for `audience`.
 
 #### Auth parameters
 
@@ -205,7 +205,7 @@ paths:
 
 ### Name
 
-You can override the default name for the API, operations, and params:
+You can override the default name for the API, operations, and parameters:
 
 ```yaml
 info:

--- a/docs/output.md
+++ b/docs/output.md
@@ -32,7 +32,7 @@ $ RSH_NO_CACHE=1 restish api.rest.sh/cached/15?private=true
 
 Even if caching is disabled, the local disk cache will get updated. The setting above prevents the _use_ of a cached response.
 
-## Readable Output
+## Readable output
 
 Readable output is a custom format that is similar to JSON or YAML and meant to be easily consumed by humans while supporting both text and binary formats. Here is an example of how various types look:
 
@@ -96,7 +96,7 @@ $ restish rest.sh/logo.png
 $ restish api.rest.sh/images/gif
 ```
 
-## Response Structure
+## Response structure
 
 Internally, the response is structured like this:
 
@@ -131,7 +131,7 @@ The above is the same structure used when setting the output format to something
 $ restish -o json api.rest.sh/images
 ```
 
-## Filtering & Projection
+## Filtering & projection
 
 Restish includes basic response filtering functionality through the [Shorthand Query Syntax](shorthand.md#Querying). It's a language for filtering and projecting the response value that's useful for paring down and massaging the response data for scripts.
 
@@ -148,7 +148,7 @@ $ restish api.rest.sh/images -f 'body.{name}'
 $ restish api.rest.sh/example -f '..url|[@ contains github]'
 ```
 
-## Output Defaults
+## Output defaults
 
 Like some other well-known tools, the output defaults are different depending on whether the command is running in an interactive shell or output is being redirected to a pipe or file.
 
@@ -188,7 +188,7 @@ $ COLOR=1 restish api.rest.sh/types -o readable -f '@' | less
 
 !> Use `restish api content-types` to see the avialable content types and output formats you can use.
 
-## Raw Mode
+## Raw mode
 
 Raw mode, when enabled, will remove JSON formatting from the filtered output if the result matches one of the following:
 
@@ -219,7 +219,7 @@ If the filtered output result doesn't match one of the above types, then `-r` is
 
 This feature is mainly useful for shell scripting, where you don't want to have to parse the JSON and instead just want to loop through a list of IDs and run further commands.
 
-## Downloading Files & Saving Responses
+## Downloading files & saving responses
 
 Output redirection and/or raw mode can be used to download files & save structured responses in various formats (e.g. JSON, CBOR, YAML, etc):
 
@@ -239,7 +239,7 @@ $ restish api.rest.sh/types -H Accept:application/json -r >types.json
 
 ?> Raw mode without filtering will not parse the response, but _will_ decode it if compressed (e.g. with gzip or brotli).
 
-## Exit Status Codes
+## Exit status codes
 
 Restish will exit with the following status codes by default in order to facilitate scripting. The most recent HTTP status code is used when a command makes more than one request.
 

--- a/docs/shorthand.md
+++ b/docs/shorthand.md
@@ -83,7 +83,7 @@ Note:
 - `string` can be quoted (with `"`) or unquoted.
 - The `query` syntax in the diagram above is described below in the [Querying](#querying) section.
 
-## Alternatives & Inspiration
+## Alternatives & inspiration
 
 The CLI shorthand syntax is not the only one you can use to generate data for CLI commands. Here are some alternatives:
 
@@ -110,7 +110,7 @@ It seems reasonable to ask, why create a new syntax?
 3. Syntax is closer to YAML & JSON and mimics how you do queries using tools like `jq` and `jmespath`.
 4. It's _optional_, so you can use your favorite tool/language instead, while at the same time it provides a minimum feature set everyone will have in common.
 
-## Features in Depth
+## Features in depth
 
 You can use the included `j` executable to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or TOML if you prefer.
 
@@ -122,7 +122,7 @@ Also feel free to use this tool to generate structured data for input to other c
 
 ?> Note: for the examples below, you may need to escape or quote the values depending on your shell & settings. Instead of `foo.bar[].baz: 1`, use `'foo.bar[].baz: 1'`. If using `zsh` you can prefix a command with `noglob` to ignore `?` and `[]`.
 
-### Keys & Values
+### Keys & values
 
 At its most basic, a structure is built out of key & value pairs. They are separated by commas:
 
@@ -149,7 +149,7 @@ Shorthand supports the standard JSON types, but adds some of its own as well to 
 | `array`   | JSON array, e.g. `[1, 2, 3]`                                     |
 | `object`  | JSON object, e.g. `{"hello": "world"}`                           |
 
-### Type Coercion
+### Type coercion
 
 Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers, bytes, and times also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. This automatic coercion can be disabled by just wrapping your value in quotes.
 
@@ -251,7 +251,7 @@ $ j a[]: 1, a[]: 2, a[]: 3
 }
 ```
 
-### Loading from Files
+### Loading from files
 
 Sometimes a field makes more sense to load from a file than to be specified on the commandline. The `@` preprocessor lets you load structured data, text, and bytes depending on the file extension and whether all bytes are valid UTF-8:
 
@@ -280,7 +280,7 @@ $ j 'twitter: "@user"'
 }
 ```
 
-### Patch (Partial Update)
+### Patch (partial update)
 
 Partial updates are supported on existing data, which can be used to implement HTTP `PATCH`, templating, and other similar features. The suggested content type for HTTP `PATCH` is `application/shorthand-patch`. This feature combines the best of both:
 

--- a/docs/shorthandv1.md
+++ b/docs/shorthandv1.md
@@ -39,7 +39,7 @@ The shorthand syntax supports the following features, described in more detail w
 - Loading property values from files
   - Supports structured, forced string, and base64 data
 
-## Alternatives & Inspiration
+## Alternatives & inspiration
 
 The built-in CLI shorthand syntax is not the only one you can use to generate data for CLI commands. Here are some alternatives:
 
@@ -65,7 +65,7 @@ It seems reasonable to ask, why create a new syntax?
 2. No need to use sub-shells to build complex structured data.
 3. Syntax is closer to YAML & JSON and mimics how we do queries using tools like `jq` and `jmespath`.
 
-## Features in Depth
+## Features in depth
 
 You can use the `j` executable from the [CLI Shorthand](https://github.com/danielgtaylor/shorthand) project to try out the shorthand format examples below. Examples are shown in JSON, but the shorthand parses into structured data that can be marshalled as other formats, like YAML or CBOR if you prefer.
 
@@ -75,7 +75,7 @@ $ go install github.com/danielgtaylor/shorthand/cmd/j@latest
 
 Also feel free to use this tool to generate structured data for input to other commands.
 
-### Keys & Values
+### Keys & values
 
 At its most basic, a structure is built out of key & value pairs. They are separated by commas:
 
@@ -87,7 +87,7 @@ $ j hello: world, question: how are you?
 }
 ```
 
-### Types and Type Coercion
+### Types and type coercion
 
 Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. If needed, you can disable this automatic coercion by forcing a value to be treated as a string with the `~` operator. **Note**: the `~` modifier must come _directly after_ the colon.
 
@@ -249,7 +249,7 @@ $ j name: foo, tags[]{id: 1, count.clicks: 5, .sales: 1}, []{id: 2, count.clicks
 }
 ```
 
-### Loading from Files
+### Loading from files
 
 Sometimes a field makes more sense to load from a file than to be specified on the commandline. The `@` preprocessor and `~` & `%` modifiers let you load structured data, strings, and base64-encoded data into values.
 

--- a/docs/shorthandv1.md
+++ b/docs/shorthandv1.md
@@ -87,7 +87,7 @@ $ j hello: world, question: how are you?
 }
 ```
 
-### Types and type coercion
+### Types & type coercion
 
 Well-known values like `null`, `true`, and `false` get converted to their respective types automatically. Numbers also get converted. Similar to YAML, anything that doesn't fit one of those is treated as a string. If needed, you can disable this automatic coercion by forcing a value to be treated as a string with the `~` operator. **Note**: the `~` modifier must come _directly after_ the colon.
 


### PR DESCRIPTION
- Add title to license file
- Add .markdownlint.yaml file and fix several violations
- Normalize section heading capitalization to Sentence case
- Consistently spell out 'parameters'
- Various small tweaks

Inspired by #159 :)