### PR TITLE
Ensure getBasePath always checks for a Path.

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -141,15 +141,16 @@ func getBasePath(location *url.URL, servers []*v3.Server) (string, error) {
 
 		for i := range endpoints {
 			if strings.HasPrefix(endpoints[i], prefix) {
-				base, err := url.Parse(endpoints[i])
+				baseURL, err := url.Parse(endpoints[i])
 				if err != nil {
 					return "", err
 				}
-				return strings.TrimSuffix(base.Path, "/"), nil
+				return strings.TrimSuffix(baseURL.Path, "/"), nil
 			}
 		}
 	}
-	return "", nil
+
+	return strings.TrimSuffix(location.Path, "/"), nil
 }
 
 func getRequestInfo(op *v3.Operation) (string, *base.Schema, []interface{}) {

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -224,13 +224,12 @@ func TestLoader(t *testing.T) {
 			require.NoError(t, yaml.Unmarshal(outBytes, &output))
 
 			base, _ := url.Parse("http://api.example.com")
-			spec, _ := url.Parse("/openapi.yaml")
 
 			resp := &http.Response{
 				Body: io.NopCloser(bytes.NewReader(input)),
 			}
 
-			api, err := New().Load(*base, *spec, resp)
+			api, err := New().Load(*base, *base, resp)
 			assert.NoError(t, err)
 
 			sort.Slice(api.Operations, func(i, j int) bool {


### PR DESCRIPTION
Resolving the base path of an endpoint would return empty if a config/apis.json with a base property exists and its value differ from the one defined by the openapi spec. This commit make sure that getBasePath uses the entrypoint base path in case matching prefixes diverge.

It fixes https://github.com/danielgtaylor/restish/issues/158