### PR TITLE
fix: bulk version inconsistency bug

### DIFF
--- a/bulk/metadata.go
+++ b/bulk/metadata.go
@@ -268,7 +268,7 @@ func (m *Meta) Pull() error {
 
 	updates := []*File{}
 	for _, f := range m.Files {
-		if f.VersionLocal == f.VersionRemote {
+		if f.VersionLocal != "" && f.VersionLocal == f.VersionRemote {
 			// No need to redownload this.
 			continue
 		}


### PR DESCRIPTION
This fixes a bug that would sometimes leave dead meta entries and state inconsistency between local & remote, telling you there are diffs and the need to pull when that wasn't the case, particularly for deleted files.