### PR TITLE
docs: use capitalized forms of HTTP verbs

### DIFF
--- a/bulk/commands.go
+++ b/bulk/commands.go
@@ -334,7 +334,7 @@ func Init(cmd *cobra.Command) {
     "version": "..."
   }
 ]
-` + "```\n\nThe following fields will automatically be found and used:\n\n- Resource URL: `url`, `uri`, `self`, `link`\n- Resource version: `version`, `etag`, `last_modified`, `lastModified`, `modified`.\n\nFiltering (if used) runs *before* URL template rendering.\n\nRestish assumes resources have client-generated IDs and use HTTP `PUT`, but if that's not the case then you can still create new resources manually with `restish post ...`.",
+` + "```\n\nThe following fields will automatically be found and used:\n\n- Resource URL: `url`, `uri`, `self`, `link`\n- Resource version: `version`, `etag`, `last_modified`, `lastModified`, `modified`.\n\nFiltering (if used) runs *before* URL template rendering.\n\nRestish assumes resources have client-generated IDs and use HTTP `PUT`, but if that's not the case then you can still create new resources manually with `restish POST ...`.",
 		Args:    cobra.ExactArgs(1),
 		Example: "  " + os.Args[0] + " bulk init api.example.com/users -f 'body.{url, version: last_login}'\n  " + os.Args[0] + " bulk init api.example.com/users -f 'body.{id, version: last_login}' --url-template='/users/{id}'",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Start with the [guide](/guide.md) to learn how to install and configure Restish 
 ## Features
 
 - HTTP/2 ([RFC 7540](https://tools.ietf.org/html/rfc7540)) with TLS by _default_ with fallback to HTTP/1.1
-- Generic head/get/post/put/patch/delete verbs like `curl` or [HTTPie](https://httpie.org/)
+- Generic HEAD/GET/POST/PUT/PATCH/DELETE verbs like `curl` or [HTTPie](https://httpie.org/)
 - Generated commands for CLI operations, e.g. `restish my-api list-users`
   - Automatically discovers API descriptions
     - [RFC 8631](https://tools.ietf.org/html/rfc8631) `service-desc` link relation

--- a/docs/bulk.md
+++ b/docs/bulk.md
@@ -17,7 +17,7 @@ PUT    /books/{book-id} Create/update book
 DELETE /books/{book-id} Delete book
 ```
 
-?> Resource creation via Restish `bulk` requires the use of client-generated identifiers and HTTP `PUT` requests. Use plain old `restish post ...` otherwise.
+?> Resource creation via Restish `bulk` requires the use of client-generated identifiers and HTTP `PUT` requests. Use plain old `restish POST ...` otherwise.
 
 ## Getting started & demo
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -102,7 +102,7 @@ cURL Example: n/a
 HTTPie Example:
 
 ```bash
-https post api.rest.sh \
+https POST api.rest.sh \
   platform[name]=HTTPie \
   platform[about][mission]='Make APIs simple and intuitive' \
   platform[about][homepage]=httpie.io \
@@ -116,7 +116,7 @@ https post api.rest.sh \
 Restish equivalent:
 
 ```bash
-restish post api.rest.sh \
+restish POST api.rest.sh \
   platform.name: HTTPie, \
   platform.about.mission: Make APIs simple and intuitive, \
   platform.about.homepage: httpie.io, \

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -31,14 +31,14 @@ $ restish --version
 
 ## Basic usage
 
-Generic HTTP verbs require no setup and are easy to use. If no verb is supplied then a GET is assumed. The `https://` is also optional as it is the default.
+Generic HTTP verbs require no setup and are easy to use. If no verb is supplied then a `GET` is assumed. The `https://` is also optional as it is the default.
 
 ```bash
 # Perform an HTTP GET request
 $ restish api.rest.sh/types
 
 # Above is equivalent to:
-$ restish get https://api.rest.sh/types
+$ restish GET https://api.rest.sh/types
 ```
 
 You will see a response like:
@@ -88,10 +88,10 @@ $ restish -q active=true api.rest.sh
 $ restish -H Accept:application/json api.rest.sh
 
 # Pass in a body via a file
-$ restish post api.rest.sh <input.json
+$ restish POST api.rest.sh <input.json
 
 # Pass in body via CLI Shorthand
-$ restish post api.rest.sh name: Kari, tags[]: admin
+$ restish POST api.rest.sh name: Kari, tags[]: admin
 ```
 
 Read more about [CLI Shorthand](/shorthand.md). Headers and query parameters can also be set via environment variables by prefixing with `RSH_`, for example:

--- a/docs/input.md
+++ b/docs/input.md
@@ -36,10 +36,10 @@ Any stream of data passed to standard input will be sent as the request body.
 
 ```bash
 # Set body from file
-$ restish put api.rest.sh <input.json
+$ restish PUT api.rest.sh <input.json
 
 # Set body from piped command
-$ echo '{"name": "hello"}' | restish put api.rest.sh
+$ echo '{"name": "hello"}' | restish PUT api.rest.sh
 ```
 
 ?> Don't forget to set the `Content-Type` header if needed. It will default to JSON if unset.
@@ -49,7 +49,7 @@ $ echo '{"name": "hello"}' | restish put api.rest.sh
 The [CLI Shorthand](shorthand.md) language is a convenient way of providing structured data on the commandline. It is a JSON-like syntax that enables you to easily create nested structured data. For example:
 
 ```bash
-$ restish post api.rest.sh 'foo.bar[]{baz: 1, hello: world}'
+$ restish POST api.rest.sh 'foo.bar[]{baz: 1, hello: world}'
 ```
 
 Will send the following request:
@@ -79,8 +79,8 @@ It's also possible to use standard in as a template and replace or set values vi
 
 ```bash
 # Use both a file and override a value
-$ restish post api.rest.sh <template.json id: test1
-$ restish post api.rest.sh <template.json id: test2, tags[]: group1
+$ restish POST api.rest.sh <template.json id: test1
+$ restish POST api.rest.sh <template.json id: test2, tags[]: group1
 ```
 
 If you have a known small set of fields that need to change between calls, this makes it easy to do so without large complex commands.

--- a/docs/shorthandv1.md
+++ b/docs/shorthandv1.md
@@ -10,7 +10,7 @@ For example:
 
 ```bash
 # Make an HTTP POST with a JSON body
-$ restish post api.rest.sh foo.bar[].baz: 1, .hello: world
+$ restish POST api.rest.sh foo.bar[].baz: 1, .hello: world
 ```
 
 Would result in the following body contents being sent on the wire (assuming a JSON content type):
@@ -49,7 +49,7 @@ The built-in CLI shorthand syntax is not the only one you can use to generate da
 For example, the shorthand example given above could be rewritten as:
 
 ```bash
-$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish post api.rest.sh
+$ jo -p foo=$(jo -p bar=$(jo -a $(jo baz=1 hello=world))) | restish POST api.rest.sh
 ```
 
 The built-in shorthand syntax implementation described herein uses those and the following for inspiration:


### PR DESCRIPTION
Following-up from #160, I've edited the docs so they demonstrate usage of the capitalized forms of the HTTP verbs.

I think given the prevalence of that representation, it's acceptable (and desirable, even) to default to that form in the docs. Let me know if you think otherwise, though :)
