### PR TITLE
fix api show doc and add api configure command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,10 +90,18 @@ Read on the learn more about the available API options.
 Showing an API is possible via the following command:
 
 ```bash
-$ restish api configure $NAME
+$ restish api show $NAME
 ```
 
 Output is in JSON by default. It can be displayed as a YAML by using `--rsh-output-format yaml` or `-o yaml`
+
+### Interactive update of an API configuration
+
+Interactive prompt used to create API configuration can be used to update an existing one.
+
+```bash
+$ restish api configure $NAME
+```
 
 ### Syncing an API configuration
 


### PR DESCRIPTION
It seems that `api show` and `api configure` commands are incorrectly documented.

Previously:
* Showing an API: erronously refer to `api configure`
* `api configure`: not present in doc

Fix:
* Showing an API: refer to `api show`
* `api configure`: added
