### PR TITLE
fix: use configured base as base path if no servers present

### DIFF
--- a/openapi/testdata/request/openapi.yaml
+++ b/openapi/testdata/request/openapi.yaml
@@ -4,14 +4,15 @@ info:
   title: Test API
 paths:
   /items/{item-id}:
+    parameters:
+      - name: item-id
+        in: path
+        required: true
+        schema:
+          type: string
     put:
       operationId: put-item
       parameters:
-        - name: item-id
-          in: path
-          required: true
-          schema:
-            type: string
         - name: MyHeader
           in: header
           example: abc123

--- a/openapi/testdata/request/output.yaml
+++ b/openapi/testdata/request/output.yaml
@@ -9,6 +9,9 @@ operations:
       Response has no body
     method: DELETE
     uri_template: http://api.example.com/items/{item-id}
+    path_params:
+      - type: string
+        name: item-id
   - name: put-item
     aliases: []
     short: ""


### PR DESCRIPTION
Fixes #174, #158. The logic is similar to #174 but explicitly uses the base path through the updated resolver interface.