### PR TITLE
Correct occurrences of "Setup" that should say "Set up" instead

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup go
+      - name: Set up go
         uses: actions/setup-go@v1
         with:
           go-version: "1.18"

--- a/cli/interactive.go
+++ b/cli/interactive.go
@@ -135,7 +135,7 @@ func askLoadBaseAPI(a asker, config *APIConfig) {
 				params[name] = rendered
 			}
 
-			// Setup auth for the profile based on the rendered params.
+			// Set up auth for the profile based on the rendered params.
 			auth = APIAuth{
 				Name:   ac.Auth.Name,
 				Params: params,
@@ -152,7 +152,7 @@ func askLoadBaseAPI(a asker, config *APIConfig) {
 			config.Profiles = map[string]*APIProfile{}
 		}
 
-		// Setup the default profile, taking care not to blast away any existing
+		// Set up the default profile, taking care not to blast away any existing
 		// custom configuration if we are just updating the values.
 		def := config.Profiles["default"]
 
@@ -246,7 +246,7 @@ func askEditProfile(a asker, name string, profile *APIProfile) {
 			options = append(options, "Remove custom base URL")
 		}
 
-		options = append(options, "Setup auth", "Finished with profile")
+		options = append(options, "Set up auth", "Finished with profile")
 
 		choice := a.askSelect("Select option for profile `"+name+"`", options, nil, "")
 
@@ -275,7 +275,7 @@ func askEditProfile(a asker, name string, profile *APIProfile) {
 			if a.askConfirm("Are you sure you want to delete the "+q+" query param?", false, "") {
 				delete(profile.Query, q)
 			}
-		case choice == "Setup auth":
+		case choice == "Set up auth":
 			if profile.Auth == nil {
 				profile.Auth = &APIAuth{}
 			}

--- a/cli/interactive_test.go
+++ b/cli/interactive_test.go
@@ -61,7 +61,7 @@ func TestInteractive(t *testing.T) {
 			"Add query param",
 			"search",
 			"bar",
-			"Setup auth",
+			"Set up auth",
 			"http-basic",
 			"u",
 			"p",


### PR DESCRIPTION
"Setup", as a single word, represents a noun (i.e. a configuration). The verb usage requires splitting the two words: "set up".
