### PR TITLE
feat: add gron greppable output format

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -670,6 +670,7 @@ func Defaults() {
 	AddContentType("text", "text/*", 0.2, &Text{})
 	AddContentType("table", "", -1, &Table{})
 	AddContentType("readable", "", -1, &Readable{})
+	AddContentType("gron", "", -1, &Gron{})
 
 	// Add link relation parsers
 	AddLinkParser(&LinkHeaderParser{})

--- a/cli/content.go
+++ b/cli/content.go
@@ -90,7 +90,7 @@ func MarshalShort(name string, pretty bool, value any) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if encoded[len(encoded)-1] != '\n' {
+		if len(encoded) > 0 && encoded[len(encoded)-1] != '\n' {
 			encoded = append(encoded, '\n')
 		}
 	} else {
@@ -244,6 +244,28 @@ func setTable(data []interface{}) ([]byte, error) {
 
 	ret := []byte(table.String())
 	return ret, nil
+}
+
+// Gron describes an output format for easier grepping. This is based on the
+// excellent https://github.com/tomnomnom/gron tool, but makes the format
+// available as a built-in Restish output option.
+type Gron struct{}
+
+// Detect if the content type is gron.
+func (t Gron) Detect(contentType string) bool {
+	return false
+}
+
+// Marshal the value to a gron string.
+func (t Gron) Marshal(value interface{}) ([]byte, error) {
+	pb := NewPathBuffer([]byte("body"), 4)
+	out := make([]byte, 0, 1024)
+	return marshalGron(pb, value, false, out)
+}
+
+// Unmarshal the value from a gron string.
+func (t Gron) Unmarshal(data []byte, value interface{}) error {
+	return fmt.Errorf("unimplemented")
 }
 
 // JSON describes content types like `application/json` or

--- a/cli/gron.go
+++ b/cli/gron.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PathBuffer is a low-allocation helper for building a path string like
+// `foo.bar[2].baz`. It is not goroutine-safe, but the underlying buffer can
+// be re-used within the same goroutine or via a `sync.Pool`.
+type PathBuffer struct {
+	buf []byte
+	off int
+}
+
+func (b *PathBuffer) Push(s string) {
+	if b.off > 0 && s[0] != '[' {
+		b.buf = append(b.buf, '.')
+		b.off++
+	}
+	b.buf = append(b.buf, s...)
+	b.off += len(s)
+}
+
+func (b *PathBuffer) Pop() {
+	for b.off > 0 {
+		b.off--
+		if b.buf[b.off] == '.' || b.buf[b.off] == '[' {
+			break
+		}
+	}
+	b.buf = b.buf[:b.off]
+}
+
+func (b *PathBuffer) Bytes() []byte {
+	return b.buf[:b.off]
+}
+
+// NewPathBuffer creates a new path buffer with the given underlying byte slice
+// and offset within that slice (for pre-loading with some path data).
+func NewPathBuffer(buf []byte, offset int) *PathBuffer {
+	return &PathBuffer{buf: buf, off: offset}
+}
+
+// identifier returns a JS-safe identifier string.
+func identifier(s string) string {
+	if len(s) > 0 {
+		if (s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z') || s[0] == '_' || s[0] == '$' {
+			return s
+		}
+	}
+
+	return fmt.Sprintf(`["%s"]`, s)
+}
+
+// keyStr returns a string representation of a map key.
+func keyStr(v reflect.Value) string {
+	if v.Kind() == reflect.String {
+		return v.String()
+	}
+	return fmt.Sprintf(`%v`, v.Interface())
+}
+
+// apnd appends any number of strings or byte slices to a byte slice.
+func apnd(buf []byte, what ...any) []byte {
+	for _, b := range what {
+		if v, ok := b.([]byte); ok {
+			buf = append(buf, v...)
+		} else if v, ok := b.(string); ok {
+			buf = append(buf, v...)
+		}
+	}
+	return buf
+}
+
+func marshalGron(pb *PathBuffer, data any, isAnon bool, out []byte) ([]byte, error) {
+	var err error
+
+	v := reflect.Indirect(reflect.ValueOf(data))
+	switch v.Kind() {
+	case reflect.Struct:
+		// Special case: time.Time!
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			out = apnd(out, pb.Bytes(), " = \"", v.Interface().(time.Time).Format(time.RFC3339Nano), "\";\n")
+			break
+		}
+
+		if !isAnon {
+			// Special case: anonymous embedded structs should not result in
+			// redefinition of the parent's base type.
+			out = apnd(out, pb.Bytes(), " = {};\n")
+		}
+
+		// Fields are output in definition order, including embedded structs. Field
+		// overrides are not supported and will result in multiple output
+		// definitions. The `omitempty` tag is ignored just to make grepping
+		// for zero values easier.
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			ft := v.Type().Field(i)
+			if !ft.IsExported() {
+				// Ignore unexported (i.e. private) fields.
+				continue
+			}
+			anon := false
+			if ft.Anonymous {
+				anon = true
+			} else {
+				// Try to determine the name using the standard Go rules.
+				name := ft.Name
+				if tag := ft.Tag.Get("json"); tag != "" {
+					if tag == "-" {
+						continue
+					}
+					name = strings.Split(tag, ",")[0]
+				}
+				pb.Push(identifier(name))
+			}
+			if out, err = marshalGron(pb, field.Interface(), anon, out); err != nil {
+				return nil, err
+			}
+			if !anon {
+				pb.Pop()
+			}
+		}
+	case reflect.Map:
+		out = apnd(out, pb.Bytes(), " = {};\n")
+		keys := v.MapKeys()
+		// Maps are output in sorted alphanum order.
+		sort.Slice(keys, func(i, j int) bool {
+			return keyStr(keys[i]) < keyStr(keys[j])
+		})
+		for _, key := range keys {
+			pb.Push(identifier(keyStr(key)))
+			if out, err = marshalGron(pb, v.MapIndex(key).Interface(), false, out); err != nil {
+				return nil, err
+			}
+			pb.Pop()
+		}
+	case reflect.Slice:
+		// Special case: []byte
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			out = apnd(out, pb.Bytes(), " = \"", base64.StdEncoding.EncodeToString(v.Bytes()), "\";\n")
+			break
+		}
+
+		out = apnd(out, pb.Bytes(), " = [];\n")
+		for i := 0; i < v.Len(); i++ {
+			pb.Push(fmt.Sprintf("[%d]", i))
+			if out, err = marshalGron(pb, v.Index(i).Interface(), false, out); err != nil {
+				return nil, err
+			}
+			pb.Pop()
+		}
+	default:
+		// This is a primitive type, just take the JSON representation.
+		v, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		out = apnd(out, pb.Bytes(), " = ", v, ";\n")
+	}
+
+	return out, nil
+}

--- a/cli/gron_test.go
+++ b/cli/gron_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGronMarshal(t *testing.T) {
+	type D struct {
+		D []map[string]any `json:"d"`
+	}
+
+	type T struct {
+		A string `json:"a"`
+		B int    `json:"b"`
+		C bool   `json:"c"`
+		D
+		E       bool `json:"-"`
+		private bool
+	}
+
+	value := T{
+		A: "hello",
+		B: 42,
+		C: true,
+		D: D{[]map[string]any{
+			{"e": "world"},
+			{"f": []any{1, 2}, "g": time.Time{}, "h": []byte("foo")},
+			{"for": map[int]int{1: 2}},
+		}},
+		private: true,
+	}
+
+	g := Gron{}
+	b, err := g.Marshal(value)
+	assert.NoError(t, err)
+	assert.Equal(t, `body = {};
+body.a = "hello";
+body.b = 42;
+body.c = true;
+body.d = [];
+body.d[0] = {};
+body.d[0].e = "world";
+body.d[1] = {};
+body.d[1].f = [];
+body.d[1].f[0] = 1;
+body.d[1].f[1] = 2;
+body.d[1].g = "0001-01-01T00:00:00Z";
+body.d[1].h = "Zm9v";
+body.d[2] = {};
+body.d[2].for = {};
+body.d[2].for["1"] = 2;
+`, string(b))
+
+	// Invalid types should result in an error!
+	_, err = g.Marshal(T{
+		D: D{[]map[string]any{
+			{"foo": make(chan int)},
+		}},
+	})
+	assert.Error(t, err)
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -148,6 +148,35 @@ $ restish api.rest.sh/images -f 'body.{name}'
 $ restish api.rest.sh/example -f '..url|[@ contains github]'
 ```
 
+## Greppable Output
+
+Sometimes you may not know the response structure or may be looking for a specific value and would like to know where it is within some large API response. Piping the output to `grep` is okay, but it's not that useful. Restish includes a built-in output format based on [Gron](https://github.com/tomnomnom/gron) to facilitate better grepping. It prints out the path to each value along with the value itself in a Javascript-style format.
+
+```bash
+# Find anything dealing with REST
+$ restish api.rest.sh/example -o gron | grep -i rest
+body["$schema"] = "https://api.rest.sh/schemas/Resume.json";
+body.volunteer[0].organization = "Restish";
+body.volunteer[0].summary = "A CLI for interacting with REST-ish HTTP APIs with OpenAPI 3 support built-in.";
+body.volunteer[0].url = "https://rest.sh/";
+```
+
+Each line is a path to a value and the value itself. The path is a Javascript-style path and can mostly be used with the `-f` option to filter the response. Now that we know we should care about `body.volunteer[0]` we can filter it to see all the fields:
+
+```bash
+# Filter the response to just the volunteer object
+$ restish api.rest.sh/example -f 'body.volunteer[0]'
+{
+  organization: "Restish"
+  position: "Owner / Maintainer"
+  startDate: 2018-09-29
+  summary: "A CLI for interacting with REST-ish HTTP APIs with OpenAPI 3 support built-in."
+  url: "https://rest.sh/"
+}
+```
+
+The combination of greppable output with filtering & projection is an extremely powerful tool for exploring APIs and writing scripts.
+
 ## Output defaults
 
 Like some other well-known tools, the output defaults are different depending on whether the command is running in an interactive shell or output is being redirected to a pipe or file.


### PR DESCRIPTION
This PR adds the awesome [gron](https://github.com/tomnomnom/gron) format as a built-in output format for Restish. It makes it easy to explore new or rarely used APIs right from the terminal by enabling easy grepping that includes structured path information in the output. Use it via:

```sh
# Gron output example
$ restish api.rest.sh/types -o gron
HTTP/2.0 200 OK
...

body = {};
body.$schema = "https://api.rest.sh/schemas/TypesModel.json";
body.boolean = true;
body.integer = 42;
body.nullable = null;
body.number = 123.45;
body.object = {};
body.object.binary = "3q3A3g==";
body.object.binary_long = "AAECAwQFBgcICQoLDA0ODw==";
body.object.date = "2023-06-17T00:00:00Z";
body.object.date_time = "2023-06-17T16:16:35.74384951Z";
body.object.url = "https://rest.sh/";
body.string = "Hello, world!";
body.tags = [];
body.tags[0] = "example";
body.tags[1] = "short";

# Easy to grep and see the path/structure
$ restish api.rest.sh/types -o gron | grep date
body.object.date = "2023-06-17T00:00:00Z";
body.object.date_time = "2023-06-17T16:16:48.840596241Z";
```
