### PR TITLE
Expand installation instructions; add Nixpkgs option

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -4,21 +4,38 @@ This guide will help you to get started installing and using Restish.
 
 ## Installation
 
-You can install in one of three ways: Homebrew tap, GitHub release, or via `go get`.
+You can install Restish via Homebrew, Nixpkgs, GitHub releases, or `go get`.
 
-If you have [Homebrew](https://brew.sh/) then install via the official tap:
+### Install via Homebrew
+
+If you have [Homebrew](https://brew.sh/), you can install Restish via the [official tap](https://github.com/danielgtaylor/homebrew-restish):
 
 ```bash
-# Install directly through the Homebrew tap
 $ brew install danielgtaylor/restish/restish
 ```
 
-If you don't have Homebrew, you can grab a [release](https://github.com/danielgtaylor/restish/releases) for your platform and manually copy the executable to the right location (e.g. `/usr/local/bin/restish`), otherwise if you have Go installed:
+### Install via Nixpkgs
+
+If you use Nixpkgs, you can install the [Restish derivation](https://search.nixos.org/packages?channel=unstable&query=restish), e.g. using `nix-env`:
 
 ```bash
-# Download / build / install
+$ nix-env --install --attr nixpkgs.restish
+```
+
+### Install by downloading a GitHub release
+
+You can grab a [release](https://github.com/danielgtaylor/restish/releases) for your platform,
+and manually copy the executable to a location in your `$PATH` (e.g. `/usr/local/bin/restish`).
+
+### Install via `go get`
+
+If you have Go set up, you can install the [restish package](https://pkg.go.dev/github.com/danielgtaylor/restish):
+
+```bash
 $ go install github.com/danielgtaylor/restish@latest
 ```
+
+### Validate the installation
 
 You can confirm the installation worked by trying to run Restish:
 


### PR DESCRIPTION
Restish has been added to the Nixpkgs directory with <https://github.com/NixOS/nixpkgs/pull/243465> (Thanks @fabaff!) , so now there's an additional method to install it.

This PR expands the installation instructions and includes a mention of Nixpkgs as another way to install Restish.

By the way, we might want to link to [Repology](https://repology.org/project/restish/versions) for even more installation methods (e.g. there's AUR for ArchLinuz, MacPorts for macOS, pkgsrc for netbsd, Scoop for Windows, and even Termux for Android.
