### PR TITLE
Support remote references in openapi

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -167,10 +167,8 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 				return API{}, err
 			}
 
-			uriSpec, err := url.Parse(filename)
-			if err != nil {
-				uriSpec = &url.URL{Scheme: "file", Path: filename}
-			}
+			// No need to check error, it was checked above in `fromFileOrUrl`.
+			uriSpec, _ := url.Parse(filename)
 
 			for _, l := range loaders {
 				// Reset the body

--- a/cli/api.go
+++ b/cli/api.go
@@ -167,6 +167,11 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 				return API{}, err
 			}
 
+			uriSpec, err := url.Parse(filename)
+			if err != nil {
+				uriSpec = &url.URL{Scheme: "file", Path: filename}
+			}
+
 			for _, l := range loaders {
 				// Reset the body
 				resp.Body = io.NopCloser(bytes.NewReader(body))
@@ -174,7 +179,7 @@ func Load(entrypoint string, root *cobra.Command) (API, error) {
 				if l.Detect(resp) {
 					found = true
 					resp.Body = io.NopCloser(bytes.NewReader(body))
-					tmp, err := load(root, *uri, *uri, resp, name, l)
+					tmp, err := load(root, *uri, *uriSpec, resp, name, l)
 					if err != nil {
 						return API{}, err
 					}

--- a/cli/api_test.go
+++ b/cli/api_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type overrideLoader struct {
+	detect        func(resp *http.Response) bool
+	load          func(entrypoint, spec url.URL, resp *http.Response) (API, error)
+	locationHints func() []string
+}
+
+func (l *overrideLoader) Detect(resp *http.Response) bool {
+	if l.detect != nil {
+		return l.detect(resp)
+	}
+	return true
+}
+
+func (l *overrideLoader) Load(entrypoint url.URL, spec url.URL, resp *http.Response) (API, error) {
+	if l.load != nil {
+		return l.load(entrypoint, spec, resp)
+	}
+	return API{}, nil
+}
+func (l *overrideLoader) LocationHints() []string {
+	if l.locationHints != nil {
+		return l.locationHints()
+	}
+	return []string{}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	reset(false)
+	viper.Set("rsh-no-cache", true)
+	AddLoader(&overrideLoader{
+		load: func(entrypoint, spec url.URL, resp *http.Response) (API, error) {
+			assert.Equal(t, "testdata/petstore.json", spec.String())
+			return API{}, nil
+		},
+	})
+
+	configs["file-load-test"] = &APIConfig{
+		Base:      "https://api.example.com",
+		SpecFiles: []string{"testdata/petstore.json"},
+	}
+
+	_, err := Load("https://api.example.com", &cobra.Command{})
+
+	assert.NoError(t, err)
+}
+
+func TestBadSpecURL(t *testing.T) {
+	reset(false)
+	viper.Set("rsh-no-cache", true)
+	AddLoader(&overrideLoader{
+		load: func(entrypoint, spec url.URL, resp *http.Response) (API, error) {
+			assert.Equal(t, "testdata/petstore.json", spec.String())
+			return API{}, nil
+		},
+	})
+
+	configs["bad-spec-url-test"] = &APIConfig{
+		Base:      "https://api.example.com",
+		SpecFiles: []string{"http://abc{def@ghi}"},
+	}
+
+	_, err := Load("https://api.example.com", &cobra.Command{})
+	assert.Error(t, err)
+}

--- a/cli/testdata/petstore.json
+++ b/cli/testdata/petstore.json
@@ -1,0 +1,791 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": { "email": "apiteam@swagger.io" },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.17"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [{ "url": "/api/v3" }],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    { "name": "user", "description": "Operations about user" }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": ["pet"],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            },
+            "application/xml": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" },
+          "405": { "description": "Validation exception" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            },
+            "application/xml": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": { "$ref": "#/components/schemas/Pet" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          },
+          "405": { "description": "Invalid input" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": ["available", "pending", "sold"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid status value" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": false,
+            "explode": true,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid tag value" }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Pet not found" }
+        },
+        "security": [
+          { "api_key": [] },
+          { "petstore_auth": ["write:pets", "read:pets"] }
+        ]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name of pet that needs to be updated",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status of pet that needs to be updated",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "405": { "description": "Invalid input" } },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": { "400": { "description": "Invalid pet value" } },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "query",
+            "description": "Additional Metadata",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": { "type": "string", "format": "binary" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiResponse" }
+              }
+            }
+          }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "api_key": [] }]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/Order" }
+            },
+            "application/xml": {
+              "schema": { "$ref": "#/components/schemas/Order" }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": { "$ref": "#/components/schemas/Order" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Order" }
+              }
+            }
+          },
+          "405": { "description": "Invalid input" }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/Order" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Order" }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Order not found" }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid ID supplied" },
+          "404": { "description": "Order not found" }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            },
+            "application/xml": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              },
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "description": "Creates list of users with given input array",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "$ref": "#/components/schemas/User" }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              }
+            }
+          },
+          "default": { "description": "successful operation" }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": { "type": "integer", "format": "int32" }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": { "type": "string", "format": "date-time" }
+              }
+            },
+            "content": {
+              "application/xml": { "schema": { "type": "string" } },
+              "application/json": { "schema": { "type": "string" } }
+            }
+          },
+          "400": { "description": "Invalid username/password supplied" }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": { "default": { "description": "successful operation" } }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              },
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              }
+            }
+          },
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "description": "Update an existent user in the store",
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            },
+            "application/xml": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": { "$ref": "#/components/schemas/User" }
+            }
+          }
+        },
+        "responses": { "default": { "description": "successful operation" } }
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid username supplied" },
+          "404": { "description": "User not found" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "petId": { "type": "integer", "format": "int64", "example": 198772 },
+          "quantity": { "type": "integer", "format": "int32", "example": 7 },
+          "shipDate": { "type": "string", "format": "date-time" },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "example": "approved",
+            "enum": ["placed", "approved", "delivered"]
+          },
+          "complete": { "type": "boolean" }
+        },
+        "xml": { "name": "order" }
+      },
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 100000 },
+          "username": { "type": "string", "example": "fehguy" },
+          "address": {
+            "type": "array",
+            "xml": { "name": "addresses", "wrapped": true },
+            "items": { "$ref": "#/components/schemas/Address" }
+          }
+        },
+        "xml": { "name": "customer" }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": { "type": "string", "example": "437 Lytton" },
+          "city": { "type": "string", "example": "Palo Alto" },
+          "state": { "type": "string", "example": "CA" },
+          "zip": { "type": "string", "example": "94301" }
+        },
+        "xml": { "name": "address" }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 1 },
+          "name": { "type": "string", "example": "Dogs" }
+        },
+        "xml": { "name": "category" }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "username": { "type": "string", "example": "theUser" },
+          "firstName": { "type": "string", "example": "John" },
+          "lastName": { "type": "string", "example": "James" },
+          "email": { "type": "string", "example": "john@email.com" },
+          "password": { "type": "string", "example": "12345" },
+          "phone": { "type": "string", "example": "12345" },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "format": "int32",
+            "example": 1
+          }
+        },
+        "xml": { "name": "user" }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        },
+        "xml": { "name": "tag" }
+      },
+      "Pet": {
+        "required": ["name", "photoUrls"],
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64", "example": 10 },
+          "name": { "type": "string", "example": "doggie" },
+          "category": { "$ref": "#/components/schemas/Category" },
+          "photoUrls": {
+            "type": "array",
+            "xml": { "wrapped": true },
+            "items": { "type": "string", "xml": { "name": "photoUrl" } }
+          },
+          "tags": {
+            "type": "array",
+            "xml": { "wrapped": true },
+            "items": { "$ref": "#/components/schemas/Tag" }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        },
+        "xml": { "name": "pet" }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer", "format": "int32" },
+          "type": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "xml": { "name": "##default" }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Pet" }
+          },
+          "application/xml": {
+            "schema": { "$ref": "#/components/schemas/Pet" }
+          }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": { "$ref": "#/components/schemas/User" }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": { "type": "apiKey", "name": "api_key", "in": "header" }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.9.3
+	github.com/pb33f/libopenapi v0.9.7
 	github.com/schollz/progressbar/v3 v3.12.2
 	github.com/shamaton/msgpack/v2 v2.1.1
 	github.com/spf13/afero v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pb33f/libopenapi v0.4.18-0.20230121110523-de1a42c72ff4
+	github.com/pb33f/libopenapi v0.9.3
 	github.com/schollz/progressbar/v3 v3.12.2
 	github.com/shamaton/msgpack/v2 v2.1.1
 	github.com/spf13/afero v1.9.3
@@ -84,6 +84,7 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/image v0.5.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/pb33f/libopenapi v0.4.18-0.20230121110523-de1a42c72ff4 h1:EjxnLsplJtrXKu/HHha3q4+KjwwE1SwVjejK9/fCCoI=
 github.com/pb33f/libopenapi v0.4.18-0.20230121110523-de1a42c72ff4/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
+github.com/pb33f/libopenapi v0.9.3 h1:63klY8vaNk0Sas7Sy/TbW/j0z5gGheWPvvsa0crZIvE=
+github.com/pb33f/libopenapi v0.9.3/go.mod h1:8lr9sjsI5uZxtiEvHgg1A9/p/70briQ5WUGoJiuTFPc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
@@ -455,6 +457,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -264,10 +264,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/pb33f/libopenapi v0.4.18-0.20230121110523-de1a42c72ff4 h1:EjxnLsplJtrXKu/HHha3q4+KjwwE1SwVjejK9/fCCoI=
-github.com/pb33f/libopenapi v0.4.18-0.20230121110523-de1a42c72ff4/go.mod h1:UcUNPQcwq4ojgQgthV+zbeUs25lhDlD4bM9Da8n2vdU=
-github.com/pb33f/libopenapi v0.9.3 h1:63klY8vaNk0Sas7Sy/TbW/j0z5gGheWPvvsa0crZIvE=
-github.com/pb33f/libopenapi v0.9.3/go.mod h1:8lr9sjsI5uZxtiEvHgg1A9/p/70briQ5WUGoJiuTFPc=
+github.com/pb33f/libopenapi v0.9.7 h1:HbuWB9PPZKsRtheYbRBQkhF//Ay2Bfgg0f6gw3qq7qs=
+github.com/pb33f/libopenapi v0.9.7/go.mod h1:8lr9sjsI5uZxtiEvHgg1A9/p/70briQ5WUGoJiuTFPc=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -519,7 +520,17 @@ func loadOpenAPI3(cfg Resolver, cmd *cobra.Command, location *url.URL, resp *htt
 		return cli.API{}, err
 	}
 
-	doc, err := libopenapi.NewDocumentWithConfiguration(data, datamodel.NewOpenDocumentConfiguration())
+	config := datamodel.NewOpenDocumentConfiguration()
+	schemeLower := strings.ToLower(location.Scheme)
+	if schemeLower == "http" || schemeLower == "https" {
+		// Set the base URL to resolve relative references.
+		config.BaseURL = &url.URL{Scheme: location.Scheme, Host: location.Host, Path: path.Dir(location.Path)}
+	} else {
+		// Set the base local directory path to resolve relative references.
+		config.BasePath = path.Dir(location.Path)
+	}
+
+	doc, err := libopenapi.NewDocumentWithConfiguration(data, config)
 	if err != nil {
 		return cli.API{}, err
 	}

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -17,6 +17,7 @@ import (
 	"github.com/danielgtaylor/shorthand/v2"
 	"github.com/gosimple/slug"
 	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/resolver"
@@ -518,7 +519,7 @@ func loadOpenAPI3(cfg Resolver, cmd *cobra.Command, location *url.URL, resp *htt
 		return cli.API{}, err
 	}
 
-	doc, err := libopenapi.NewDocument(data)
+	doc, err := libopenapi.NewDocumentWithConfiguration(data, datamodel.NewOpenDocumentConfiguration())
 	if err != nil {
 		return cli.API{}, err
 	}

--- a/openapi/openapi_test.go
+++ b/openapi/openapi_test.go
@@ -224,7 +224,7 @@ func TestLoader(t *testing.T) {
 			require.NoError(t, yaml.Unmarshal(outBytes, &output))
 
 			base, _ := url.Parse("http://api.example.com")
-			spec, _ := url.Parse("/openapi.yaml")
+			spec, _ := url.Parse("http://api.example.com/openapi.yaml")
 
 			resp := &http.Response{
 				Body: io.NopCloser(bytes.NewReader(input)),

--- a/openapi/schema.go
+++ b/openapi/schema.go
@@ -106,9 +106,9 @@ func renderSchemaInternal(s *base.Schema, indent string, mode schemaMode, known 
 			if s.ExclusiveMinimum != nil && s.ExclusiveMinimum.IsA() && s.ExclusiveMinimum.A {
 				key = "exclusiveMin"
 			}
-			tags = append(tags, fmt.Sprintf("%s:%d", key, *s.Minimum))
+			tags = append(tags, fmt.Sprintf("%s:%0.f", key, *s.Minimum))
 		} else if s.ExclusiveMinimum != nil && s.ExclusiveMinimum.IsB() {
-			tags = append(tags, fmt.Sprintf("exclusiveMin:%d", s.ExclusiveMinimum.B))
+			tags = append(tags, fmt.Sprintf("exclusiveMin:%0.f", s.ExclusiveMinimum.B))
 		}
 
 		if s.Maximum != nil {
@@ -116,13 +116,13 @@ func renderSchemaInternal(s *base.Schema, indent string, mode schemaMode, known 
 			if s.ExclusiveMaximum != nil && s.ExclusiveMaximum.IsA() && s.ExclusiveMaximum.A {
 				key = "exclusiveMax"
 			}
-			tags = append(tags, fmt.Sprintf("%s:%d", key, *s.Maximum))
+			tags = append(tags, fmt.Sprintf("%s:%0.f", key, *s.Maximum))
 		} else if s.ExclusiveMaximum != nil && s.ExclusiveMaximum.IsB() {
-			tags = append(tags, fmt.Sprintf("exclusiveMax:%d", s.ExclusiveMaximum.B))
+			tags = append(tags, fmt.Sprintf("exclusiveMax:%0.f", s.ExclusiveMaximum.B))
 		}
 
 		if s.MultipleOf != nil && *s.MultipleOf != 0 {
-			tags = append(tags, fmt.Sprintf("multiple:%d", *s.MultipleOf))
+			tags = append(tags, fmt.Sprintf("multiple:%0.f", *s.MultipleOf))
 		}
 
 		if s.Default != nil {

--- a/openapi/schema.go
+++ b/openapi/schema.go
@@ -106,9 +106,9 @@ func renderSchemaInternal(s *base.Schema, indent string, mode schemaMode, known 
 			if s.ExclusiveMinimum != nil && s.ExclusiveMinimum.IsA() && s.ExclusiveMinimum.A {
 				key = "exclusiveMin"
 			}
-			tags = append(tags, fmt.Sprintf("%s:%0.f", key, *s.Minimum))
+			tags = append(tags, fmt.Sprintf("%s:%g", key, *s.Minimum))
 		} else if s.ExclusiveMinimum != nil && s.ExclusiveMinimum.IsB() {
-			tags = append(tags, fmt.Sprintf("exclusiveMin:%0.f", s.ExclusiveMinimum.B))
+			tags = append(tags, fmt.Sprintf("exclusiveMin:%g", s.ExclusiveMinimum.B))
 		}
 
 		if s.Maximum != nil {
@@ -116,13 +116,13 @@ func renderSchemaInternal(s *base.Schema, indent string, mode schemaMode, known 
 			if s.ExclusiveMaximum != nil && s.ExclusiveMaximum.IsA() && s.ExclusiveMaximum.A {
 				key = "exclusiveMax"
 			}
-			tags = append(tags, fmt.Sprintf("%s:%0.f", key, *s.Maximum))
+			tags = append(tags, fmt.Sprintf("%s:%g", key, *s.Maximum))
 		} else if s.ExclusiveMaximum != nil && s.ExclusiveMaximum.IsB() {
-			tags = append(tags, fmt.Sprintf("exclusiveMax:%0.f", s.ExclusiveMaximum.B))
+			tags = append(tags, fmt.Sprintf("exclusiveMax:%g", s.ExclusiveMaximum.B))
 		}
 
 		if s.MultipleOf != nil && *s.MultipleOf != 0 {
-			tags = append(tags, fmt.Sprintf("multiple:%0.f", *s.MultipleOf))
+			tags = append(tags, fmt.Sprintf("multiple:%g", *s.MultipleOf))
 		}
 
 		if s.Default != nil {


### PR DESCRIPTION
This supercedes #202. It has the following changes built on top of it:

1. Merge in the latest from `main`
2. Set the base URL or path to allow resolving relative references. This was required to get e.g. the DigitalOcean API working.
3. Fix printing of min/max/etc now that they are floats using `%g`. I ran into an example where a max of `0.1` incorrectly rendered as `0` and using just `%f` has too many default digits for human readability.

Tested with various public and private APIs, including:

```json
{
  "do": {
    "base": "https://api.digitalocean.com/v2",
    "profiles": {
      "default": {
        "headers": {
          "authorization": "** REMOVED **"
        }
      }
    },
    "spec_files": [
      "https://raw.githubusercontent.com/digitalocean/openapi/main/specification/DigitalOcean-public.v2.yaml"
    ]
  },
  "github": {
    "base": "https://api.github.com",
    "profiles": {
      "default": {
        "headers": {
          "accept": "application/vnd.github.v3+json",
          "authorization": "** REMOVED **"
        }
      }
    },
    "spec_files": [
      "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml"
    ]
  },
}
```

Unfortunately I can't share the private APIs, but with these changes everything seems to work fine. The OpenAPI parses, operations & params match when doing diffs with `--help` output, and I'm still able to hit the services successfully. I was able to use `spec_files` to point to local files with local relative `$ref` pointers and they loaded successfully.

@zak905, this could use a quick review / sanity check.