### PR TITLE
feat: document args/options schemas, fixes #157

### DIFF
--- a/openapi/testdata/extensions/output.yaml
+++ b/openapi/testdata/extensions/output.yaml
@@ -7,6 +7,22 @@ operations:
       - gi
     short: ""
     long: |
+      ## Argument Schema:
+      ```schema
+      {
+        item-id: (string)
+      }
+      ```
+
+      ## Option Schema:
+      ```schema
+      {
+        --query: [
+          (string)
+        ]
+      }
+      ```
+
       ## Response 200 (application/json)
 
       CLI-specific description override

--- a/openapi/testdata/long_example/output.yaml
+++ b/openapi/testdata/long_example/output.yaml
@@ -4,6 +4,13 @@ operations:
     aliases: []
     short: ""
     long: |
+      ## Argument Schema:
+      ```schema
+      {
+        item-id: (string)
+      }
+      ```
+
       ## Input Example
 
       ```json

--- a/openapi/testdata/petstore/output.yaml
+++ b/openapi/testdata/petstore/output.yaml
@@ -28,6 +28,13 @@ operations:
       - listpets
     short: List all pets
     long: |
+      ## Option Schema:
+      ```schema
+      {
+        --limit: (integer format:int32)
+      }
+      ```
+
       ## Response 200 (application/json)
 
       A paged array of pets
@@ -66,6 +73,13 @@ operations:
       - showpetbyid
     short: Info for a specific pet
     long: |
+      ## Argument Schema:
+      ```schema
+      {
+        pet-id: (string)
+      }
+      ```
+
       ## Response 200 (application/json)
 
       Expected response to a valid request

--- a/openapi/testdata/request/output.yaml
+++ b/openapi/testdata/request/output.yaml
@@ -4,6 +4,13 @@ operations:
     aliases: []
     short: ""
     long: |
+      ## Argument Schema:
+      ```schema
+      {
+        item-id: (string)
+      }
+      ```
+
       ## Response 204
 
       Response has no body
@@ -16,6 +23,20 @@ operations:
     aliases: []
     short: ""
     long: |
+      ## Argument Schema:
+      ```schema
+      {
+        item-id: (string)
+      }
+      ```
+
+      ## Option Schema:
+      ```schema
+      {
+        --my-header: (string)
+      }
+      ```
+
       ## Input Example
 
       ```json


### PR DESCRIPTION
Since the built-in `--help` generator only gives a name of each argument and a short text description of each option, this PR adds schema information for both to the generated description. There are two groups: 1. path parameter arguments and 2. query param / header arguments. Each is rendered as an object where the keys are the parameter name and the schema for each is shown next to it, similar to how the request/response body schemas work.

To take the example in #157, it now produces this to describe the image type argument:

<img width="354" alt="Screenshot 2023-08-03 at 22 21 33" src="https://github.com/danielgtaylor/restish/assets/106826/00969546-ac41-417f-9cef-5b6e779758d9">

