### PR TITLE
fix: generate operation ID if not present, fixes #201

### DIFF
--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -309,9 +309,12 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 	aliases := getExtSlice(op.Extensions, ExtAliases, []string{})
 
 	name := casing.Kebab(op.OperationId)
+	if name == "" {
+		name = casing.Kebab(method + "-" + strings.Trim(uriTemplate.Path, "/"))
+	}
 	if override := getExt(op.Extensions, ExtName, ""); override != "" {
 		name = override
-	} else if oldName := slug.Make(op.OperationId); oldName != name {
+	} else if oldName := slug.Make(op.OperationId); oldName != "" && oldName != name {
 		// For backward-compatibility, add the old naming scheme as an alias
 		// if it is different. See https://github.com/danielgtaylor/restish/issues/29
 		// for additional context; we prefer kebab casing for readability.

--- a/openapi/testdata/request/openapi.yaml
+++ b/openapi/testdata/request/openapi.yaml
@@ -43,7 +43,6 @@ paths:
                   foo:
                     type: string
     delete:
-      operationId: delete-item
       responses:
         "204":
           description: ""

--- a/openapi/testdata/request/output.yaml
+++ b/openapi/testdata/request/output.yaml
@@ -1,6 +1,6 @@
 short: Test API
 operations:
-  - name: delete-item
+  - name: delete-items-item-id
     aliases: []
     short: ""
     long: |


### PR DESCRIPTION
If an OpenAPI operation has no operation ID, then generate it using the method+path, converted to kebab casing. For example, `GET /users/{user-id}/friends` → `get-users-user-id-friends`. No attempt is made to infer what arguments might mean or whether something is a list vs get.