### PR TITLE
feat: bulk command resiliency improvements

### DIFF
--- a/bulk/commands.go
+++ b/bulk/commands.go
@@ -229,13 +229,19 @@ func diff(originalPath, modifiedPath string, original, modified []byte) {
 	var err error
 
 	if len(original) > 0 {
-		json.Unmarshal(original, &parsedOrig)
+		if err := json.Unmarshal(original, &parsedOrig); err != nil {
+			cli.LogWarning("Unable to parse %s: %s", originalPath, err)
+			return
+		}
 		original, err = cli.MarshalShort("json", true, parsedOrig)
 		panicOnErr(err)
 	}
 
 	if len(modified) > 0 {
-		json.Unmarshal(modified, &parsedMod)
+		if err := json.Unmarshal(modified, &parsedMod); err != nil {
+			cli.LogWarning("Unable to parse %s: %s", modifiedPath, err)
+			return
+		}
 		modified, err = cli.MarshalShort("json", true, parsedMod)
 		panicOnErr(err)
 	}
@@ -429,7 +435,7 @@ func Init(cmd *cobra.Command) {
 			meta := mustLoadMeta()
 			match, _ := cmd.Flags().GetString("match")
 			for _, name := range collectFiles(meta, args, match, true) {
-				if f, ok := meta.Files[name]; ok {
+				if f, ok := meta.Files[name]; ok && f.VersionLocal != "" {
 					panicOnErr(f.Reset())
 				}
 			}


### PR DESCRIPTION
This change makes some relatively minor changes to help with bulk command resiliency, particularly around the management of the bulk checkout state when dealing with partial failures and killed commands. Combined with #219 retries & timeouts this should now be resilient against HTTP 502 Bad Gateway and HTTP 429 Too Many Requests from rate limiting, as well as HTTP 422 Unprocessable Content on pushes which fail validation, leaving the metadata state in a reasonable place for subsequent commands.

Note that it's still possible to kill the commands mid-run, but rather than having many files not match their metadata you should now e.g. be able to safely kill pulls and pushes with no ill effects or with just one file showing as modified because a write was in progress while it was killed. This is *much* easier to fix up with a reset than previously.

Specifically, this PR does the following:

- Bulk pull improvements
  - Save metadata state after each file is fetched (slower but safer)
  - Log errors and continue rather than exiting
  - Log if file deleting fails for removals
- Bulk push improvements
  - After each file is pushed, mark it as unmodified locally and save the metadata state. If the subsequent fetch is successful it will have its version updated to match the latest on the server. If not, then the next pull should update it automatically.
  - Log errors and continue rather than exiting
  - When finished pushing, only files which were successful are updated to the latest version on the server in the metadata state.
- Bulk status improvements
  - Order remote changes alphanumerically
- Bulk diff improvements
  - Log a warning when JSON parsing fails along with which file needs to be fixed