### PR TITLE
fix: gron output with special chars

### DIFF
--- a/cli/content.go
+++ b/cli/content.go
@@ -263,7 +263,7 @@ func (t Gron) Detect(contentType string) bool {
 
 // Marshal the value to a gron string.
 func (t Gron) Marshal(value interface{}) ([]byte, error) {
-	pb := NewPathBuffer([]byte("body"), 4)
+	pb := NewPathBuffer([][]byte{[]byte("body")})
 	out := make([]byte, 0, 1024)
 	return marshalGron(pb, value, false, out)
 }

--- a/cli/gron_test.go
+++ b/cli/gron_test.go
@@ -29,6 +29,9 @@ func TestGronMarshal(t *testing.T) {
 			{"e": "world & i <3 restish"},
 			{"f": []any{1, 2}, "g": time.Time{}, "h": []byte("foo")},
 			{"for": map[int]int{1: 2}},
+			{"dotted.name": "foo"},
+			{"name[with]brackets": "bar"},
+			{"name\"with": "quote"},
 		}},
 		private: true,
 	}
@@ -52,6 +55,12 @@ body.d[1].h = "Zm9v";
 body.d[2] = {};
 body.d[2].for = {};
 body.d[2].for["1"] = 2;
+body.d[3] = {};
+body.d[3]["dotted.name"] = "foo";
+body.d[4] = {};
+body.d[4]["name[with]brackets"] = "bar";
+body.d[5] = {};
+body.d[5]["name\"with"] = "quote";
 `, string(b))
 
 	// Invalid types should result in an error!


### PR DESCRIPTION
This simplifies the `PathBuffer` (and makes it a bit more inefficient) to generally lower complexity and ensure the correct output for fields containing `.`, `]`, or `"` characters in their name.

Fixes #217 