### PR TITLE
feat: add command to clear auth token cache

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -171,6 +171,27 @@ func initAPIConfig() {
 	})
 
 	apiCommand.AddCommand(&cobra.Command{
+		Use:   "clear-auth-cache short-name",
+		Short: "Clear API auth token cache",
+		Long:  "Clear the API auth token cache for the current profile. This will force a re-authentication the next time you make a request.",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			apiName := args[0]
+			api := configs[apiName]
+			if api == nil {
+				panic("API " + apiName + " not found")
+			}
+
+			// Remove the cache entry.
+			Cache.Set(apiName+":"+viper.GetString("rsh-profile"), "")
+
+			if err := Cache.WriteConfig(); err != nil {
+				panic(fmt.Errorf("Unable to write cache file: %w", err))
+			}
+		},
+	})
+
+	apiCommand.AddCommand(&cobra.Command{
 		Use:   "show short-name",
 		Short: "Show API config",
 		Long:  "Show an API configuration as JSON/YAML.",

--- a/cli/apiconfig_test.go
+++ b/cli/apiconfig_test.go
@@ -24,6 +24,43 @@ func TestAPIShow(t *testing.T) {
 	assert.Equal(t, captured, "\x1b[38;5;247m{\x1b[0m\n  \x1b[38;5;74m\"base\"\x1b[0m\x1b[38;5;247m:\x1b[0m \x1b[38;5;150m\"https://api.example.com\"\x1b[0m\n\x1b[38;5;247m}\x1b[0m\n")
 }
 
+func TestAPIClearCache(t *testing.T) {
+	reset(false)
+
+	configs["test"] = &APIConfig{
+		name: "test",
+		Base: "https://api.example.com",
+	}
+	Cache.Set("test:default.token", "abc123")
+
+	runNoReset("api clear-auth-cache test")
+
+	assert.Equal(t, "", Cache.GetString("test:default.token"))
+}
+
+func TestAPIClearCacheProfile(t *testing.T) {
+	reset(false)
+
+	configs["test"] = &APIConfig{
+		name: "test",
+		Base: "https://api.example.com",
+	}
+	Cache.Set("test:default.token", "abc123")
+	Cache.Set("test:other.token", "def456")
+
+	runNoReset("api clear-auth-cache test -p other")
+
+	assert.Equal(t, "abc123", Cache.GetString("test:default.token"))
+	assert.Equal(t, "", Cache.GetString("test:other.token"))
+}
+
+func TestAPIClearCacheMissing(t *testing.T) {
+	reset(false)
+
+	captured := runNoReset("api clear-auth-cache missing-api")
+	assert.Contains(t, captured, "API missing-api not found")
+}
+
 func TestEditAPIsMissingEditor(t *testing.T) {
 	os.Setenv("EDITOR", "")
 	os.Setenv("VISUAL", "")


### PR DESCRIPTION
This adds a basic profile-aware command to clear the auth token cache, so you don't have to try and find the `cache.json` file, find the right line, and delete it in order to force e.g. OAuth2 re-auth. Now it's a simple:

```sh
$ restish api clear-auth-cache $NAME`
```

Pass `--rsh-profile=$PROFILE` or `-p $PROFILE` to clear the cache for a specific profile instead of `default`.