### PR TITLE
update default return url

### DIFF
--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -196,7 +196,7 @@ type AuthorizationCodeTokenSource struct {
 
 func (ac *AuthorizationCodeTokenSource) getRedirectUrl() string {
 	if ac.RedirectURL == "" {
-		return "http://localhost:8484"
+		return "http://localhost:8484/"
 	}
 
 	return ac.RedirectURL


### PR DESCRIPTION
hello

this merge request may be misguided but i created issue #249 . i discovered that if i set
```
            "redirect_url": "http://localhost:8484"
```
in `~/.config/restish/apis.json` i experience the issue but if i set
```
            "redirect_url": "http://localhost:8484/"
```
it works just fine. when i looked i discovered that this was changed in https://github.com/danielgtaylor/restish/commit/ac559b95dc5a4432103107ec621d2568f102499e and the trailing `/` was omitted. i'm assuming this was an error but if it's intentional please just disregard this merge request