### PR TITLE
Escape '&' for Windows command line oAuth flow

### DIFF
--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -135,6 +135,7 @@ func open(url string) error {
 	case "windows":
 		cmd = "cmd"
 		args = []string{"/c", "start"}
+		url = encodeUrlWindows(url)
 	case "darwin": // mac, ios
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
@@ -142,6 +143,25 @@ func open(url string) error {
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()
+}
+
+// Windows OS need strings to be encoded
+// for proper command line interface handling.
+func encodeUrlWindows(url string) string {
+	// escape '&'
+	sp := strings.Split(url, "&")
+	var escaped string
+	for i, p := range sp {
+		// Skip adding escape at the beginning
+		if i == 0 {
+			escaped += p
+			continue
+		}
+		escaped += "^&" + p
+	}
+
+	// keep protocol
+	return escaped
 }
 
 // getInput waits for user input and sends it to the input channel with the

--- a/oauth/authcode_test.go
+++ b/oauth/authcode_test.go
@@ -1,0 +1,20 @@
+package oauth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeUrlWindowsSuccess(t *testing.T) {
+	u := "https://mydomain.auth.us-east-1.amazoncognito.com/oauth2/authorize?response_type=code&client_id=1example23456789&redirect_uri=https://www.example.com&state=abcdefg&scope=openid+profile"
+
+	r := encodeUrlWindows(u)
+	//t.Log(r)
+
+	assert.NotEqual(t, u, r)
+	assert.Contains(t, r, "^&")
+	assert.False(t, strings.HasPrefix(r, "^&"))
+	assert.False(t, strings.HasSuffix(r, "^&"))
+}


### PR DESCRIPTION
Fixes #248.

PR escapes '&' character to enable oAuth flow for Windows operating systems.
Aside of the test @DominicBortmes as able to verify the fix for his context.