### PR TITLE
docs: improve link accuracy

### DIFF
--- a/docs/bulk.md
+++ b/docs/bulk.md
@@ -66,7 +66,7 @@ recent_ratings > 5
 ...............^^^^
 ```
 
-Additionally, you can use the `-f` flag to apply a [Shorthand Query](./shorthand.md#querying) filter to each matched file and print out the result, enabling a quick way to get specific values from a set of matched files:
+Additionally, you can use the `-f` flag to apply a [Shorthand Query](shorthand.md#querying) filter to each matched file and print out the result, enabling a quick way to get specific values from a set of matched files:
 
 ```bash
 # Get the most recent rating of each matched book
@@ -134,7 +134,7 @@ Alias: `i`
 | Param / Option       | Description & Example                                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `URL`                | The URL to list resources<br/>Example: `api.rest.sh/books`                                                                                                                     |
-| `-f`, `--rsh-filter` | Filter the response via [Shorthand Query](./shorthand.md#querying)<br/>Example: `-f 'body.{id, version: last_modified_dt}'`                                                    |
+| `-f`, `--rsh-filter` | Filter the response via [Shorthand Query](shorthand.md#querying)<br/>Example: `-f 'body.{id, version: last_modified_dt}'`                                                    |
 | `--url-template`     | Template string to build URLs from list response items. If a filter is passed, it is processed _before_ rendering the URL template.<br/>Example: `--url-template='/items/{id}` |
 
 #### Automatically recognized fields
@@ -189,7 +189,7 @@ Alias: `ls`
 | Param / Option       | Description & Example                                                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `-m`, `--match`      | Match resources using [mexpr](https://github.com/danielgtaylor/mexpr) expressions<br/>Example: `-m 'rating_average >= 4.8'`           |
-| `-f`, `--rsh-filter` | Filter each resource via [Shorthand Query](./shorthand.md#querying) and print the result<br/>Example: `-f 'recent_ratings[0].rating'` |
+| `-f`, `--rsh-filter` | Filter each resource via [Shorthand Query](shorthand.md#querying) and print the result<br/>Example: `-f 'recent_ratings[0].rating'` |
 
 ?> Match expressions show any resource whose expression result is "truthy" (meaning a non-zero scalar or non-empty map/slice). `false`, `0`, `""`, `[]`, and `{}` are considered "falsey".
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -172,7 +172,7 @@ $ restish api.rest.sh -f headers.Date -r
 Sat, 1 Jan 2022 12:00:00 GMT
 ```
 
-See [filtering & projection](output.md#filtering--projection) for more info & examples.
+See [filtering & projection](output.md#filtering-amp-projection) for more info & examples.
 
 ### Output defaults
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -61,7 +61,7 @@ If neither one of those returns an OpenAPI spec, then the loader gives up.
 
 ### Loading from files
 
-For local testing or an API you don't control or can't update, you can load from OpenAPI files. See [Configuration: Loading from Files](configuration.md#loading-from-files) for an example configuration.
+For local testing or an API you don't control or can't update, you can load from OpenAPI files. See [Configuration: Loading from files or URLs](configuration.md#loading-from-files-or-urls) for an example configuration.;
 
 ## OpenAPI extensions
 


### PR DESCRIPTION
### Summary of Changes

This PR fixes several links in the docs. Some of them didn't quite get you to the right section of the page, or they added some unnecessary characters to the URL.

### Just so you know:

None of these links were broken, but their navigation wasn't spot-on, which might have caused some confusion. Also, a few links had an extra `./` after the URL's fragment identifier but before the page identifier (e.g. `rest.sh/#/./shorthand?id=querying`).