### PR TITLE
support api config from cwd

### DIFF
--- a/cli/apiconfig.go
+++ b/cli/apiconfig.go
@@ -97,6 +97,12 @@ func initAPIConfig() {
 	apis = viper.New()
 
 	apis.SetConfigName("apis")
+	// set cwd config path
+	cwd, err := os.Getwd()
+	if err == nil {
+		apis.AddConfigPath(filepath.Join(cwd, ".restish"))
+	}
+
 	apis.AddConfigPath(viper.GetString("config-directory"))
 
 	// Write a blank cache if no file is already there. Later you can use
@@ -108,7 +114,7 @@ func initAPIConfig() {
 		}
 	}
 
-	err := apis.ReadInConfig()
+	err = apis.ReadInConfig()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### Proposed Changes

> thank you @danielgtaylor for creating a very useful project :)

if i am working on a project that involves openapi files, most likely it would keep changing especially when working in team environment with different git branches, this PR adds support for current working directory apis.json file support basically in a git project if we add a api defination file like `.restish/apis.json` it will take preference over the one in config directory thus allowing to use restish with branch specific openapi files

> this has been very helpful to me because it is one of the feature even postman doesn't support without external/custom tooling
