### PR TITLE
docs: include command for fish completion help

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -335,6 +335,7 @@ Restish has support for dynamic shell completion built-in. See the help for your
 $ restish completion bash --help
 $ restish completion zsh --help
 $ restish completion powershell --help
+$ restish completion fish --help
 ```
 
 If using Homebrew, you may need one additional step to [include the Homebrew completions path](https://docs.brew.sh/Shell-Completion) for your shell.


### PR DESCRIPTION
`restish completion --help` already lists all supported shells, but including it in the docs clarifies for any newcomers (who may not have installed restish yet) that fish also has completion support.