### PR TITLE
Add Content-Type: identity support

### DIFF
--- a/cli/encoding.go
+++ b/cli/encoding.go
@@ -40,7 +40,7 @@ func buildAcceptEncodingHeader() string {
 func DecodeResponse(resp *http.Response) error {
 	contentEncoding := resp.Header.Get("content-encoding")
 
-	if contentEncoding == "" {
+	if contentEncoding == "" || contentEncoding == "identity" {
 		// Nothing to do!
 		return nil
 	}


### PR DESCRIPTION
Java runtime Quarkus adds this : https://github.com/quarkusio/quarkus/blob/c0ce55eb12e761c4a4b50bdafc0f58f2d4b94b2e/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/VertxHttpRecorder.java#L660