### PR TITLE
Add PKCS11 related flags: --rsh-pkcs11-label, --rsh-pkcs11-path

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -549,6 +549,8 @@ Not after (expires): %s (%s)
 	AddGlobalFlag("rsh-insecure", "", "Disable SSL verification", false, false)
 	AddGlobalFlag("rsh-client-cert", "", "Path to a PEM encoded client certificate", "", false)
 	AddGlobalFlag("rsh-client-key", "", "Path to a PEM encoded private key", "", false)
+	AddGlobalFlag("rsh-pkcs11-label", "", "Label of the PKCS11 token", "", false)
+	AddGlobalFlag("rsh-pkcs11-path", "", "Path to the PKCS11 library", "", false)
 	AddGlobalFlag("rsh-ca-cert", "", "Path to a PEM encoded CA cert", "", false)
 	AddGlobalFlag("rsh-ignore-status-code", "", "Do not set exit code from HTTP status code", false, false)
 	AddGlobalFlag("rsh-retry", "", "Number of times to retry on certain failures", 2, false)
@@ -763,6 +765,12 @@ func Run() (returnErr error) {
 	}
 	if caCert, _ := GlobalFlags.GetString("rsh-ca-cert"); caCert != "" {
 		viper.Set("rsh-ca-cert", caCert)
+	}
+	if pkcs11Label, _ := GlobalFlags.GetString("rsh-pkcs11-label"); pkcs11Label != "" {
+		viper.Set("rsh-pkcs11-label", pkcs11Label)
+	}
+	if pkcs11Path, _ := GlobalFlags.GetString("rsh-pkcs11-path"); pkcs11Path != "" {
+		viper.Set("rsh-pkcs11-path", pkcs11Path)
 	}
 	if query, _ := GlobalFlags.GetStringArray("rsh-query"); len(query) > 0 {
 		viper.Set("rsh-query", query)

--- a/cli/request.go
+++ b/cli/request.go
@@ -205,6 +205,16 @@ func MakeRequest(req *http.Request, options ...requestOption) (*http.Response, e
 		if caCert := viper.GetString("rsh-ca-cert"); caCert != "" {
 			config.TLS.CACert = caCert
 		}
+		if pkcs11Label := viper.GetString("rsh-pkcs11-label"); pkcs11Label != "" {
+			config.TLS.PKCS11 = &PKCS11Config{
+				Label: pkcs11Label,
+			}
+		}
+		if pkcs11Path := viper.GetString("rsh-pkcs11-path"); pkcs11Path != "" {
+			if config.TLS.PKCS11 != nil && config.TLS.PKCS11.Label != "" {
+				config.TLS.PKCS11.Path = pkcs11Path
+			}
+		}
 
 		if config.TLS.InsecureSkipVerify {
 			LogWarning("Disabling TLS security checks")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,21 +25,23 @@ You can quickly determine which is being used via `restish localhost -v 2>&1 | g
 
 The global options in addition to `--help` and `--version` are:
 
-| Argument                    | Env Var             | Example             | Description                                                                                |
-| --------------------------- | ------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
-| `-f`, `--rsh-filter`        | `RSH_FILTER`        | `body.users[].id`   | Filter response via [Shorthand query](https://github.com/danielgtaylor/shorthand#querying) |
-| `-H`, `--rsh-header`        | `RSH_HEADER`        | `Version:2020-05`   | Set a header name/value                                                                    |
-| `--rsh-insecure`            | `RSH_INSECURE`      |                     | Disable TLS certificate checks                                                             |
-| `--rsh-client-cert`         | `RSH_CLIENT_CERT`   | `/etc/ssl/cert.pem` | Path to a PEM encoded client certificate                                                   |
-| `--rsh-client-key`          | `RSH_CLIENT_KEY`    | `/etc/ssl/key.pem`  | Path to a PEM encoded private key                                                          |
-| `--rsh-ca-cert`             | `RSH_CA_CERT`       | `/etc/ssl/ca.pem`   | Path to a PEM encoded CA certificate                                                       |
-| `--rsh-no-paginate`         | `RSH_NO_PAGINATE`   |                     | Disable automatic `next` link pagination                                                   |
-| `-o`, `--rsh-output-format` | `RSH_OUTPUT_FORMAT` | `json`              | [Output format](/output.md), defaults to `auto`                                            |
-| `-p`, `--rsh-profile`       | `RSH_PROFILE`       | `testing`           | Auth profile name, defaults to `default`                                                   |
-| `-q`, `--rsh-query`         | `RSH_QUERY`         | `search=foo`        | Set a query parameter                                                                      |
-| `-r`, `--rsh-raw`           | `RSH_RAW`           |                     | Raw output for shell processing                                                            |
-| `-s`, `--rsh-server`        | `RSH_SERVER`        | `https://foo.com`   | Override API server base URL                                                               |
-| `-v`, `--rsh-verbose`       | `RSH_VERBOSE`       |                     | Enable verbose output                                                                      |
+| Argument                    | Env Var             | Example                               | Description                                                                                |
+| --------------------------- | ------------------- | --------------------------------------| ------------------------------------------------------------------------------------------ |
+| `-f`, `--rsh-filter`        | `RSH_FILTER`        | `body.users[].id`                     | Filter response via [Shorthand query](https://github.com/danielgtaylor/shorthand#querying) |
+| `-H`, `--rsh-header`        | `RSH_HEADER`        | `Version:2020-05`                     | Set a header name/value                                                                    |
+| `--rsh-insecure`            | `RSH_INSECURE`      |                                       | Disable TLS certificate checks                                                             |
+| `--rsh-client-cert`         | `RSH_CLIENT_CERT`   | `/etc/ssl/cert.pem`                   | Path to a PEM encoded client certificate                                                   |
+| `--rsh-client-key`          | `RSH_CLIENT_KEY`    | `/etc/ssl/key.pem`                    | Path to a PEM encoded private key                                                          |
+| `--rsh-ca-cert`             | `RSH_CA_CERT`       | `/etc/ssl/ca.pem`                     | Path to a PEM encoded CA certificate                                                       |
+| `--rsh-pkcs11-label`        | `RSH_PKCS11_LABEL`  |                                       | Label of the PKCS11 token                                                                  |
+| `--rsh-pkcs11-path`         | `RSH_PKCS11_PATH`   | `/usr/lib/pkcs11/opensc-pkcs11.so`    | Path to the PKCS11 library                                                                 |
+| `--rsh-no-paginate`         | `RSH_NO_PAGINATE`   |                                       | Disable automatic `next` link pagination                                                   |
+| `-o`, `--rsh-output-format` | `RSH_OUTPUT_FORMAT` | `json`                                | [Output format](/output.md), defaults to `auto`                                            |
+| `-p`, `--rsh-profile`       | `RSH_PROFILE`       | `testing`                             | Auth profile name, defaults to `default`                                                   |
+| `-q`, `--rsh-query`         | `RSH_QUERY`         | `search=foo`                          | Set a query parameter                                                                      |
+| `-r`, `--rsh-raw`           | `RSH_RAW`           |                                       | Raw output for shell processing                                                            |
+| `-s`, `--rsh-server`        | `RSH_SERVER`        | `https://foo.com`                     | Override API server base URL                                                               |
+| `-v`, `--rsh-verbose`       | `RSH_VERBOSE`       |                                       | Enable verbose output                                                                      | 
 
 Configuration file keys are the same as long-form arguments without the `--` prefix.
 


### PR DESCRIPTION
Made it possible to overwrite the default PKCS11 Label/Path set by the config using flags.

This has been tested with a Yubikey and the OpenSC PKCS#11 interface on Linux.