### PR TITLE
ci: Unquarantine unsigned binaries from Homebrew Cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,6 +80,12 @@ homebrew_casks:
     commit_author:
       name: Restish Releaser
       email: release@rest.sh
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/restish"]
+          end
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Since we do not have an Apple developer account or signing certificate, binaries published via Homebrew are quarantined by default. This change adds a post-install hook to un-quarantine the installed `restish` binary.

For reference, this is suggested by the GoReleaser documentation: https://goreleaser.com/customization/homebrew_casks/#signing-and-notarizing

The locally-generated `restish.rb` file output after this change looks like:

```ruby
$ cat restish.rb
# This file was generated by GoReleaser. DO NOT EDIT.
cask "restish" do
  name "restish"
  desc "Restish is a CLI for interacting with REST-ish HTTP APIs with some nice features built-in."
  homepage "https://rest.sh"
  version "v0.0.0-next"

# ...

  postflight do
    if OS.mac?
      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/restish"]
    end
  end

  # No zap stanza required
end
```