### PR TITLE
chore: Replace interface{} with any

### DIFF
--- a/cli/autoconfig.go
+++ b/cli/autoconfig.go
@@ -5,8 +5,8 @@ package cli
 type AutoConfigVar struct {
 	Description string        `json:"description,omitempty" yaml:"description,omitempty"`
 	Example     string        `json:"example,omitempty" yaml:"example,omitempty"`
-	Default     interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-	Enum        []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default     any   `json:"default,omitempty" yaml:"default,omitempty"`
+	Enum        []any `json:"enum,omitempty" yaml:"enum,omitempty"`
 
 	// Exclude the value from being sent to the server. This essentially makes
 	// it a value which is only used in param templates.

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -376,7 +376,7 @@ func Init(name string, version string) {
 		Run: func(cmd *cobra.Command, args []string) {
 			switch *editFormat {
 			case "json":
-				edit(args[0], args[1:], *interactive, *noPrompt, os.Exit, func(v interface{}) ([]byte, error) {
+				edit(args[0], args[1:], *interactive, *noPrompt, os.Exit, func(v any) ([]byte, error) {
 					return json.MarshalIndent(v, "", "  ")
 				}, json.Unmarshal, ".json")
 			case "yaml":
@@ -501,7 +501,7 @@ Not after (expires): %s (%s)
 				panic(err)
 			}
 
-			var output interface{} = resp.Links
+			var output any = resp.Links
 
 			if len(args) > 1 {
 				tmp := []*Link{}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -63,7 +63,7 @@ func expectExitCode(t *testing.T, expected int) {
 func TestGetURI(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Get("/foo").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://example.com").Get("/foo").Reply(200).JSON(map[string]any{
 		"Hello": "World",
 	})
 
@@ -76,7 +76,7 @@ func TestGetURI(t *testing.T) {
 func TestPostURI(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Post("/foo").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://example.com").Post("/foo").Reply(200).JSON(map[string]any{
 		"id":    1,
 		"value": 123,
 	})
@@ -90,7 +90,7 @@ func TestPostURI(t *testing.T) {
 func TestPutURI400(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Put("/foo/1").Reply(422).JSON(map[string]interface{}{
+	gock.New("http://example.com").Put("/foo/1").Reply(422).JSON(map[string]any{
 		"detail": "Invalid input",
 	})
 
@@ -103,7 +103,7 @@ func TestPutURI400(t *testing.T) {
 func TestIgnoreStatusCodeExit(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Put("/foo/1").Reply(400).JSON(map[string]interface{}{
+	gock.New("http://example.com").Put("/foo/1").Reply(400).JSON(map[string]any{
 		"detail": "Invalid input",
 	})
 
@@ -185,7 +185,7 @@ func TestLinks(t *testing.T) {
 func TestDefaultOutput(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("http://example.com").Get("/foo").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://example.com").Get("/foo").Reply(200).JSON(map[string]any{
 		"hello": "world",
 	})
 
@@ -220,7 +220,7 @@ func TestLoadCache(t *testing.T) {
 	// Only *one* set of remote requests should be made. After that it should be
 	// using the cache.
 	gock.New("https://example.com/").Reply(404)
-	gock.New("https://example.com/openapi.json").Reply(200).JSON(map[string]interface{}{
+	gock.New("https://example.com/openapi.json").Reply(200).JSON(map[string]any{
 		"openapi": "3.0.0",
 	})
 

--- a/cli/content_test.go
+++ b/cli/content_test.go
@@ -30,7 +30,7 @@ func TestContentTypes(parent *testing.T) {
 
 			assert.False(t, tt.ct.Detect("bad-content-type"))
 
-			var data interface{}
+			var data any
 			err := tt.ct.Unmarshal(tt.data, &data)
 			assert.NoError(t, err)
 

--- a/cli/edit.go
+++ b/cli/edit.go
@@ -34,7 +34,7 @@ func getEditor() string {
 	return editor
 }
 
-func edit(addr string, args []string, interactive, noPrompt bool, exitFunc func(int), editMarshal func(interface{}) ([]byte, error), editUnmarshal func([]byte, interface{}) error, ext string) {
+func edit(addr string, args []string, interactive, noPrompt bool, exitFunc func(int), editMarshal func(any) ([]byte, error), editUnmarshal func([]byte, any) error, ext string) {
 	if !interactive && len(args) == 0 {
 		fmt.Fprintln(os.Stderr, "No arguments passed to modify the resource. Use `-i` to enable interactive mode.")
 		exitFunc(1)
@@ -62,8 +62,8 @@ export EDITOR="vim"`)
 	}
 
 	// Convert from CBOR or other formats which might allow map[any]any to the
-	// constraints of JSON (i.e. map[string]interface{}).
-	var data interface{} = resp.Map()
+	// constraints of JSON (i.e. map[string]any).
+	var data any = resp.Map()
 	data = makeJSONSafe(data)
 
 	filter := viper.GetString("rsh-filter")
@@ -71,7 +71,7 @@ export EDITOR="vim"`)
 		filter = "body"
 	}
 
-	var logger func(format string, a ...interface{})
+	var logger func(format string, a ...any)
 	if enableVerbose {
 		logger = LogDebug
 	}
@@ -81,7 +81,7 @@ export EDITOR="vim"`)
 	panicOnErr(err)
 	data = filtered
 
-	if _, ok := data.(map[string]interface{}); !ok {
+	if _, ok := data.(map[string]any); !ok {
 		fmt.Fprintln(os.Stderr, "Resource didn't return an object.")
 		exitFunc(1)
 		return
@@ -102,7 +102,7 @@ export EDITOR="vim"`)
 	// 2. Get and then analyse the response schema for that operation.
 	// 3. Remove corresponding fields from `data`.
 
-	var modified interface{} = data
+	var modified any = data
 
 	if len(args) > 0 {
 		modified, err = shorthand.Unmarshal(strings.Join(args, " "), shorthand.ParseOptions{EnableFileInput: true, EnableObjectDetection: true}, modified)

--- a/cli/edit_test.go
+++ b/cli/edit_test.go
@@ -17,7 +17,7 @@ func TestEditSuccess(t *testing.T) {
 		Get("/items/foo").
 		Reply(http.StatusOK).
 		SetHeader("Etag", "abc123").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"foo": 123,
 		})
 
@@ -76,7 +76,7 @@ func TestEditNoChange(t *testing.T) {
 		Get("/items/foo").
 		Reply(http.StatusOK).
 		SetHeader("Etag", "abc123").
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"foo": 123,
 		})
 
@@ -95,7 +95,7 @@ func TestEditNotObject(t *testing.T) {
 		Get("/items/foo").
 		Reply(http.StatusOK).
 		SetHeader("Etag", "abc123").
-		JSON([]interface{}{
+		JSON([]any{
 			123,
 		})
 

--- a/cli/flag.go
+++ b/cli/flag.go
@@ -9,7 +9,7 @@ import (
 )
 
 // AddGlobalFlag will make a new global flag on the root command.
-func AddGlobalFlag(name, short, description string, defaultValue interface{}, multi bool) {
+func AddGlobalFlag(name, short, description string, defaultValue any, multi bool) {
 	viper.SetDefault(name, defaultValue)
 
 	flags := Root.PersistentFlags()

--- a/cli/formatter.go
+++ b/cli/formatter.go
@@ -287,9 +287,9 @@ var MarkdownStyle = ansi.StyleConfig{
 
 // makeJSONSafe walks an interface to ensure all maps use string keys so that
 // encoding to JSON (or YAML) works. Some unmarshallers (e.g. CBOR) will
-// create map[interface{}]interface{} which causes problems marshalling.
+// create map[any]any which causes problems marshalling.
 // See https://github.com/fxamacker/cbor/issues/206
-func makeJSONSafe(obj interface{}) interface{} {
+func makeJSONSafe(obj any) any {
 	value := reflect.ValueOf(obj)
 
 	for value.Kind() == reflect.Ptr {
@@ -304,13 +304,13 @@ func makeJSONSafe(obj interface{}) interface{} {
 			// encoding for JSON and gives you an array of integers instead.
 			return obj
 		}
-		returnSlice := make([]interface{}, value.Len())
+		returnSlice := make([]any, value.Len())
 		for i := 0; i < value.Len(); i++ {
 			returnSlice[i] = makeJSONSafe(value.Index(i).Interface())
 		}
 		return returnSlice
 	case reflect.Map:
-		tmpData := make(map[string]interface{})
+		tmpData := make(map[string]any)
 		for _, k := range value.MapKeys() {
 			kStr := ""
 			if s, ok := k.Interface().(string); ok {
@@ -341,7 +341,7 @@ func makeJSONSafe(obj interface{}) interface{} {
 // based on displayable unicode character ranges and whitespace. If true,
 // then the body is also returned as a byte slice ready to be written to
 // stdout.
-func printable(body interface{}) ([]byte, bool) {
+func printable(body any) ([]byte, bool) {
 	if s, ok := body.(string); ok {
 		return []byte(s), true
 	}
@@ -469,7 +469,7 @@ func (f *DefaultFormatter) formatRaw(data any) ([]byte, string, bool) {
 			return encoded, lexer, true
 		}
 
-		for _, item := range data.([]interface{}) {
+		for _, item := range data.([]any) {
 			switch item.(type) {
 			case nil, bool, int, int64, float64, string:
 				// The above are scalars used by decoders
@@ -483,7 +483,7 @@ func (f *DefaultFormatter) formatRaw(data any) ([]byte, string, bool) {
 
 		if scalars {
 			var encoded []byte
-			for _, item := range data.([]interface{}) {
+			for _, item := range data.([]any) {
 				if item == nil {
 					encoded = append(encoded, []byte("null\n")...)
 				} else if f, ok := item.(float64); ok && f == float64(int64(f)) {

--- a/cli/formatter_test.go
+++ b/cli/formatter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPrintable(t *testing.T) {
 	// Printable with BOM
-	var body interface{} = []byte("\uFEFF\t\r\n Just a tést!.$%^{}/")
+	var body any = []byte("\uFEFF\t\r\n Just a tést!.$%^{}/")
 	_, ok := printable(body)
 	assert.True(t, ok)
 
@@ -151,7 +151,7 @@ var formatterTests = []struct {
 		name:   "raw-large-json-num",
 		raw:    true,
 		filter: "body",
-		body: []interface{}{
+		body: []any{
 			nil,
 			float64(1000000000000000),
 			float64(1.2e5),

--- a/cli/interactive.go
+++ b/cli/interactive.go
@@ -16,7 +16,7 @@ var surveyOpts = []survey.AskOpt{}
 type asker interface {
 	askConfirm(message string, def bool, help string) bool
 	askInput(message string, def string, required bool, help string) string
-	askSelect(message string, options []string, def interface{}, help string) string
+	askSelect(message string, options []string, def any, help string) string
 }
 
 type defaultAsker struct{}
@@ -58,7 +58,7 @@ func (a defaultAsker) askInput(message string, def string, required bool, help s
 	return resp
 }
 
-func (a defaultAsker) askSelect(message string, options []string, def interface{}, help string) string {
+func (a defaultAsker) askSelect(message string, options []string, def any, help string) string {
 	resp := ""
 	err := survey.AskOne(&survey.Select{
 		Message: message,
@@ -186,7 +186,7 @@ func askAuth(a asker, auth *APIAuth) {
 		authTypes = append(authTypes, k)
 	}
 
-	var name interface{}
+	var name any
 	if auth.Name != "" {
 		name = auth.Name
 	}

--- a/cli/interactive_test.go
+++ b/cli/interactive_test.go
@@ -28,7 +28,7 @@ func (a *mockAsker) askInput(message string, def string, required bool, help str
 	return a.responses[a.pos-1]
 }
 
-func (a *mockAsker) askSelect(message string, options []string, def interface{}, help string) string {
+func (a *mockAsker) askSelect(message string, options []string, def any, help string) string {
 	a.pos++
 	a.t.Log("select", a.responses[a.pos-1])
 	return a.responses[a.pos-1]
@@ -43,7 +43,7 @@ func TestInteractive(t *testing.T) {
 
 	defer gock.Off()
 
-	gock.New("http://api.example.com").Get("/").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://api.example.com").Get("/").Reply(200).JSON(map[string]any{
 		"Hello": "World",
 	})
 
@@ -182,7 +182,7 @@ func TestInteractiveAutoConfig(t *testing.T) {
 
 	defer gock.Off()
 
-	gock.New("http://api2.example.com").Get("/").Reply(200).JSON(map[string]interface{}{
+	gock.New("http://api2.example.com").Get("/").Reply(200).JSON(map[string]any{
 		"Hello": "World",
 	})
 

--- a/cli/links.go
+++ b/cli/links.go
@@ -91,8 +91,8 @@ type HALParser struct{}
 
 // ParseLinks processes the links in a parsed response.
 func (h HALParser) ParseLinks(resp *Response) error {
-	entries := []interface{}{}
-	if l, ok := resp.Body.([]interface{}); ok {
+	entries := []any{}
+	if l, ok := resp.Body.([]any); ok {
 		entries = l
 	} else {
 		entries = append(entries, resp.Body)
@@ -127,7 +127,7 @@ func (t TerrificallySimpleJSONParser) ParseLinks(resp *Response) error {
 }
 
 // walk the response body recursively to find any `self` links.
-func (t TerrificallySimpleJSONParser) walk(resp *Response, key string, value interface{}) error {
+func (t TerrificallySimpleJSONParser) walk(resp *Response, key string, value any) error {
 	v := reflect.ValueOf(value)
 
 	switch v.Kind() {
@@ -201,7 +201,7 @@ func (s SirenParser) ParseLinks(resp *Response) error {
 	return nil
 }
 
-func getJSONAPIlinks(links map[string]interface{}, resp *Response, isItem bool) {
+func getJSONAPIlinks(links map[string]any, resp *Response, isItem bool) {
 	for k, v := range links {
 		rel := k
 		if isItem && k == "self" {
@@ -215,7 +215,7 @@ func getJSONAPIlinks(links map[string]interface{}, resp *Response, isItem bool) 
 			})
 		}
 
-		if m, ok := v.(map[string]interface{}); ok {
+		if m, ok := v.(map[string]any); ok {
 			if s, ok := m["href"].(string); ok {
 				resp.Links[rel] = append(resp.Links[rel], &Link{
 					Rel: rel,
@@ -231,17 +231,17 @@ type JSONAPIParser struct{}
 
 // ParseLinks processes the links in a parsed response.
 func (j JSONAPIParser) ParseLinks(resp *Response) error {
-	if b, ok := resp.Body.(map[string]interface{}); ok {
+	if b, ok := resp.Body.(map[string]any); ok {
 		// Find top-level links
-		if l, ok := b["links"].(map[string]interface{}); ok {
+		if l, ok := b["links"].(map[string]any); ok {
 			getJSONAPIlinks(l, resp, false)
 		}
 
 		// Find collection item links
-		if d, ok := b["data"].([]interface{}); ok {
+		if d, ok := b["data"].([]any); ok {
 			for _, item := range d {
-				if m, ok := item.(map[string]interface{}); ok {
-					if l, ok := m["links"].(map[string]interface{}); ok {
+				if m, ok := item.(map[string]any); ok {
+					if l, ok := m["links"].(map[string]any); ok {
 						getJSONAPIlinks(l, resp, true)
 					}
 				}

--- a/cli/links_test.go
+++ b/cli/links_test.go
@@ -50,13 +50,13 @@ func TestLinkHeaderParser(t *testing.T) {
 func TestHALParser(t *testing.T) {
 	r := &Response{
 		Links: Links{},
-		Body: map[string]interface{}{
-			"_links": map[string]interface{}{
+		Body: map[string]any{
+			"_links": map[string]any{
 				"curies": nil,
-				"self": map[string]interface{}{
+				"self": map[string]any{
 					"href": "/self",
 				},
-				"item": map[string]interface{}{
+				"item": map[string]any{
 					"href": "/item",
 				},
 			},
@@ -73,17 +73,17 @@ func TestHALParser(t *testing.T) {
 func TestHALParserArray(t *testing.T) {
 	r := &Response{
 		Links: Links{},
-		Body: []interface{}{
-			map[string]interface{}{
-				"_links": map[string]interface{}{
-					"self": map[string]interface{}{
+		Body: []any{
+			map[string]any{
+				"_links": map[string]any{
+					"self": map[string]any{
 						"href": "/one",
 					},
 				},
 			},
-			map[string]interface{}{
-				"_links": map[string]interface{}{
-					"self": map[string]interface{}{
+			map[string]any{
+				"_links": map[string]any{
+					"self": map[string]any{
 						"href": "/two",
 					},
 				},
@@ -101,27 +101,27 @@ func TestHALParserArray(t *testing.T) {
 func TestTerrificallySimpleJSONParser(t *testing.T) {
 	r := &Response{
 		Links: Links{},
-		Body: map[string]interface{}{
+		Body: map[string]any{
 			"self": "/self",
-			"things": []interface{}{
-				map[string]interface{}{
+			"things": []any{
+				map[string]any{
 					"self": "/foo",
 					"name": "Foo",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"self": "/bar",
 					"name": "Bar",
 				},
 				// Weird object with int keys instead of strings? Possible with binary
 				// formats but not JSON itself.
-				&map[int]interface{}{
-					5: map[string]interface{}{
+				&map[int]any{
+					5: map[string]any{
 						"self": "/weird",
 					},
 				},
 			},
-			"other": map[string]interface{}{
-				"self": map[string]interface{}{
+			"other": map[string]any{
+				"self": map[string]any{
 					"foo": "bar",
 				},
 			},
@@ -142,8 +142,8 @@ func TestTerrificallySimpleJSONParser(t *testing.T) {
 func TestSirenParser(t *testing.T) {
 	r := &Response{
 		Links: Links{},
-		Body: map[string]interface{}{
-			"links": []map[string]interface{}{
+		Body: map[string]any{
+			"links": []map[string]any{
 				{"rel": []string{"self"}, "href": "/self"},
 				{"rel": []string{"one", "two"}, "href": "/multi"},
 				{"rel": []string{"invalid"}},
@@ -162,14 +162,14 @@ func TestSirenParser(t *testing.T) {
 func TestJSONAPIParser(t *testing.T) {
 	r := &Response{
 		Links: Links{},
-		Body: map[string]interface{}{
-			"links": map[string]interface{}{
+		Body: map[string]any{
+			"links": map[string]any{
 				"self": "/self",
 			},
-			"data": []interface{}{
-				map[string]interface{}{
-					"links": map[string]interface{}{
-						"self": map[string]interface{}{
+			"data": []any{
+				map[string]any{
+					"links": map[string]any{
+						"self": map[string]any{
 							"href": "/item",
 						},
 					},

--- a/cli/logger.go
+++ b/cli/logger.go
@@ -13,7 +13,7 @@ import (
 var enableVerbose bool
 
 // LogDebug logs a debug message if --rsh-verbose (-v) was passed.
-func LogDebug(format string, values ...interface{}) {
+func LogDebug(format string, values ...any) {
 	if enableVerbose {
 		fmt.Fprintf(Stderr, "%s %s\n", au.Index(243, "DEBUG:"), fmt.Sprintf(format, values...))
 	}
@@ -58,17 +58,17 @@ func LogDebugResponse(start time.Time, resp *http.Response) {
 }
 
 // LogInfo logs an info message.
-func LogInfo(format string, values ...interface{}) {
+func LogInfo(format string, values ...any) {
 	fmt.Fprintf(Stderr, "%s %s\n", au.Index(74, "INFO:"), fmt.Sprintf(format, values...))
 }
 
 // LogWarning logs a warning message.
-func LogWarning(format string, values ...interface{}) {
+func LogWarning(format string, values ...any) {
 	fmt.Fprintf(Stderr, "%s %s\n", au.Index(222, "WARN:"), fmt.Sprintf(format, values...))
 }
 
 // LogError logs an error message.
-func LogError(format string, values ...interface{}) {
+func LogError(format string, values ...any) {
 	// TODO: stack traces?
 	fmt.Fprintf(Stderr, "%s %s\n", au.BgIndex(204, "ERROR:").White().Bold(), fmt.Sprintf(format, values...))
 }

--- a/cli/operation.go
+++ b/cli/operation.go
@@ -33,7 +33,7 @@ type Operation struct {
 
 // command returns a Cobra command instance for this operation.
 func (o Operation) command() *cobra.Command {
-	flags := map[string]interface{}{}
+	flags := map[string]any{}
 
 	use := slug.Make(o.Name)
 	for _, p := range o.PathParams {

--- a/cli/operation_test.go
+++ b/cli/operation_test.go
@@ -20,7 +20,7 @@ func TestOperation(t *testing.T) {
 		MatchParam("def3", "abc").
 		MatchHeader("Accept", "application/json").
 		Reply(200).
-		JSON(map[string]interface{}{
+		JSON(map[string]any{
 			"hello": "world",
 		})
 

--- a/cli/param.go
+++ b/cli/param.go
@@ -20,7 +20,7 @@ const (
 	StyleForm
 )
 
-func typeConvert(from, to interface{}) interface{} {
+func typeConvert(from, to any) any {
 	return reflect.ValueOf(from).Convert(reflect.TypeOf(to)).Interface()
 }
 
@@ -32,19 +32,19 @@ type Param struct {
 	Description string      `json:"description,omitempty" yaml:"description,omitempty"`
 	Style       Style       `json:"style,omitempty" yaml:"style,omitempty"`
 	Explode     bool        `json:"explode,omitempty" yaml:"explide,omitempty"`
-	Default     interface{} `json:"default,omitempty" yaml:"default,omitempty"`
-	Example     interface{} `json:"example,omitempty" yaml:"example,omitempty"`
+	Default     any `json:"default,omitempty" yaml:"default,omitempty"`
+	Example     any `json:"example,omitempty" yaml:"example,omitempty"`
 }
 
 // Parse the parameter from a string input (e.g. command line argument)
-func (p Param) Parse(value string) (interface{}, error) {
+func (p Param) Parse(value string) (any, error) {
 	// TODO: parse based on the type, used mostly for path parameter parsing
 	// which is almost always a string anyway.
 	return value, nil
 }
 
 // Serialize the parameter based on the type/style/explode configuration.
-func (p Param) Serialize(value interface{}) []string {
+func (p Param) Serialize(value any) []string {
 	v := reflect.ValueOf(value)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()
@@ -105,7 +105,7 @@ func (p Param) OptionName() string {
 }
 
 // AddFlag adds a new option flag to a command's flag set for this parameter.
-func (p Param) AddFlag(flags *pflag.FlagSet) interface{} {
+func (p Param) AddFlag(flags *pflag.FlagSet) any {
 	name := p.OptionName()
 	def := p.Default
 
@@ -153,7 +153,7 @@ func (p Param) AddFlag(flags *pflag.FlagSet) interface{} {
 			def = []string{}
 		} else {
 			tmp := []string{}
-			for _, item := range def.([]interface{}) {
+			for _, item := range def.([]any) {
 				tmp = append(tmp, item.(string))
 			}
 			def = tmp

--- a/cli/param_test.go
+++ b/cli/param_test.go
@@ -12,7 +12,7 @@ var paramInputs = []struct {
 	Type     string
 	Style    Style
 	Explode  bool
-	Value    interface{}
+	Value    any
 	Expected []string
 }{
 	{"bool-simple", "boolean", StyleSimple, false, true, []string{"true"}},

--- a/cli/readable.go
+++ b/cli/readable.go
@@ -12,11 +12,11 @@ import (
 )
 
 // MarshalReadable marshals a value into a human-friendly readable format.
-func MarshalReadable(v interface{}) ([]byte, error) {
+func MarshalReadable(v any) ([]byte, error) {
 	return marshalReadable("", v)
 }
 
-func marshalReadable(indent string, v interface{}) ([]byte, error) {
+func marshalReadable(indent string, v any) ([]byte, error) {
 	rv := reflect.ValueOf(v)
 	switch rv.Kind() {
 	case reflect.Invalid:

--- a/cli/readable_test.go
+++ b/cli/readable_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestReadableMarshal(t *testing.T) {
 	created, _ := time.Parse(time.RFC3339, "2020-01-01T12:34:56Z")
-	data := map[string]interface{}{
+	data := map[string]any{
 		"binary":     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		"created":    created,
 		"date":       created.Truncate(24 * time.Hour),
 		"id":         "test",
-		"emptyMap":   map[string]interface{}{},
+		"emptyMap":   map[string]any{},
 		"emptyArray": []string{},
-		"nested": map[string]interface{}{
+		"nested": map[string]any{
 			"saved": true,
 			"self":  "https://example.com/nested",
 		},
@@ -47,8 +47,8 @@ func TestReadableMarshal(t *testing.T) {
 }
 
 func TestSingleItemWithNewlines(t *testing.T) {
-	data := []interface{}{
-		map[string]interface{}{
+	data := []any{
+		map[string]any{
 			"id":      1234,
 			"created": "2020-08-12",
 		},

--- a/cli/request.go
+++ b/cli/request.go
@@ -451,7 +451,7 @@ type Response struct {
 	Status  int               `json:"status"`
 	Headers map[string]string `json:"headers"`
 	Links   Links             `json:"links"`
-	Body    interface{}       `json:"body"`
+	Body    any               `json:"body"`
 }
 
 // Map returns a map representing this response matching the encoded JSON.
@@ -491,7 +491,7 @@ func (r Response) Map() map[string]any {
 // ParseResponse takes an HTTP response and tries to parse it using the
 // registered content types. It returns a map representing the request,
 func ParseResponse(resp *http.Response) (Response, error) {
-	var parsed interface{}
+	var parsed any
 
 	// Handle content encodings
 	defer resp.Body.Close()
@@ -569,7 +569,7 @@ func GetParsedResponse(req *http.Request, options ...requestOption) (Response, e
 
 		LogDebug("Found pagination via rel=next link: %s", links["next"][0].URI)
 
-		if _, ok := parsed.Body.([]interface{}); !ok {
+		if _, ok := parsed.Body.([]any); !ok {
 			// TODO: support non-list formats like JSON:API
 			LogWarning("Skipping auto-pagination: response body not a list, not sure how to merge")
 			break
@@ -591,14 +591,14 @@ func GetParsedResponse(req *http.Request, options ...requestOption) (Response, e
 			return Response{}, err
 		}
 
-		if l, ok := parsedNext.Body.([]interface{}); ok {
+		if l, ok := parsedNext.Body.([]any); ok {
 			// The last request in the chain will be the one that gets displayed
 			// for the proto/status/headers, plus the merged body/links.
 			parsed.Proto = parsedNext.Proto
 			parsed.Status = parsedNext.Status
 			parsed.Headers = parsedNext.Headers
 			parsed.Links = parsedNext.Links
-			parsed.Body = append(parsed.Body.([]interface{}), l...)
+			parsed.Body = append(parsed.Body.([]any), l...)
 
 			for name, links := range parsedNext.Links {
 				allLinks[name] = append(allLinks[name], links...)

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -33,19 +33,19 @@ func TestRequestPagination(t *testing.T) {
 		// Page 1 links to page 2
 		SetHeader("Link", "</paginated2>; rel=\"next\"").
 		SetHeader("Content-Length", "7").
-		JSON([]interface{}{1, 2, 3})
+		JSON([]any{1, 2, 3})
 	gock.New("http://example.com").
 		Get("/paginated2").
 		Reply(http.StatusOK).
 		// Page 2 links to page 3
 		SetHeader("Link", "</paginated3>; rel=\"next\"").
 		SetHeader("Content-Length", "5").
-		JSON([]interface{}{4, 5})
+		JSON([]any{4, 5})
 	gock.New("http://example.com").
 		Get("/paginated3").
 		Reply(http.StatusOK).
 		SetHeader("Content-Length", "3").
-		JSON([]interface{}{6})
+		JSON([]any{6})
 
 	req, _ := http.NewRequest(http.MethodGet, "http://example.com/paginated", nil)
 	resp, err := GetParsedResponse(req)
@@ -57,7 +57,7 @@ func TestRequestPagination(t *testing.T) {
 	assert.Equal(t, resp.Headers["Content-Length"], "15")
 
 	// Response body should be a concatenation of all pages.
-	assert.Equal(t, []interface{}{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, resp.Body)
+	assert.Equal(t, []any{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, resp.Body)
 }
 
 type authHookFailure struct{}

--- a/openapi/example.go
+++ b/openapi/example.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GenExample creates a dummy example from a given schema.
-func GenExample(schema *base.Schema, mode schemaMode) interface{} {
+func GenExample(schema *base.Schema, mode schemaMode) any {
 	example, err := genExampleInternal(schema, mode, map[[32]byte]bool{})
 	if err != nil {
 		log.Fatal(err)

--- a/openapi/openapi.go
+++ b/openapi/openapi.go
@@ -167,8 +167,8 @@ func getBasePath(location *url.URL, servers []*v3.Server) (string, error) {
 	return location.Path, nil
 }
 
-func getRequestInfo(op *v3.Operation) (string, *base.Schema, []interface{}) {
-	mts := make(map[string][]interface{})
+func getRequestInfo(op *v3.Operation) (string, *base.Schema, []any) {
+	mts := make(map[string][]any)
 
 	if op.RequestBody != nil {
 		for mt, item := range op.RequestBody.Content.FromOldest() {
@@ -212,7 +212,7 @@ func getRequestInfo(op *v3.Operation) (string, *base.Schema, []interface{}) {
 	for _, short := range []string{"json", "yaml", "*"} {
 		for mt, item := range mts {
 			if strings.Contains(mt, short) || short == "*" {
-				return mt, item[0].(*base.Schema), item[1].([]interface{})
+				return mt, item[0].(*base.Schema), item[1].([]any)
 			}
 		}
 	}
@@ -253,8 +253,8 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 			continue
 		}
 
-		var def interface{}
-		var example interface{}
+		var def any
+		var example any
 
 		typ := "string"
 		var schema *base.Schema
@@ -398,7 +398,7 @@ func openapiOperation(cmd *cobra.Command, method string, uriTemplate *url.URL, p
 				} else {
 					// Not a string, so it's structured data. Let's marshal it to the
 					// shorthand syntax if we can.
-					if m, ok := ex.(map[string]interface{}); ok {
+					if m, ok := ex.(map[string]any); ok {
 						exs := shorthand.MarshalCLI(m)
 
 						if len(exs) < 150 {


### PR DESCRIPTION
The `any` type was introduced in Go 1.18, and is a more readable alternative to `interface{}`. Let's use it.