### PR TITLE
fix: Warn about CLI extensions in OpenAPI spec

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -553,6 +553,7 @@ Not after (expires): %s (%s)
 	AddGlobalFlag("rsh-ignore-status-code", "", "Do not set exit code from HTTP status code", false, false)
 	AddGlobalFlag("rsh-retry", "", "Number of times to retry on certain failures", 2, false)
 	AddGlobalFlag("rsh-timeout", "t", "Timeout for HTTP requests", time.Duration(0), false)
+	AddGlobalFlag("rsh-blindly-accept-cli-extensions", "", "Accept x-cli-* extensions without prompting (for automation)", false, false)
 
 	Root.RegisterFlagCompletionFunc("rsh-output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "json", "yaml"}, cobra.ShellCompDirectiveNoFileComp
@@ -777,6 +778,9 @@ func Run() (returnErr error) {
 	}
 	if timeout, _ := GlobalFlags.GetDuration("rsh-timeout"); timeout > 0 {
 		viper.Set("rsh-timeout", timeout)
+	}
+	if blindlyAccept, _ := GlobalFlags.GetBool("rsh-blindly-accept-cli-extensions"); blindlyAccept {
+		viper.Set("rsh-blindly-accept-cli-extensions", true)
 	}
 
 	// Now that global flags are parsed we can enable verbose mode if requested.

--- a/openapi/testdata/auto_config/output.yaml
+++ b/openapi/testdata/auto_config/output.yaml
@@ -27,3 +27,13 @@ auto_config:
       authorize_url: https://example.com/authorize
       client_id: ""
       token_url: https://example.com/token
+cli_extensions:
+  extensions:
+    - location: document
+      name: x-cli-config
+      value:
+        security: default
+        prompt:
+          client_id:
+            description: Client identifier
+            example: abc123

--- a/openapi/testdata/extensions/output.yaml
+++ b/openapi/testdata/extensions/output.yaml
@@ -41,3 +41,26 @@ operations:
       - type: "array[string]"
         name: q
         display_name: query
+cli_extensions:
+  extensions:
+    - location: "operation:get:/items/{item-id}"
+      name: x-cli-name
+      value: getItem
+    - location: "operation:get:/items/{item-id}"
+      name: x-cli-aliases
+      value:
+        - get-item
+        - getitem
+        - gi
+    - location: "operation:get:/items/{item-id}:param:q"
+      name: x-cli-name
+      value: query
+    - location: "operation:get:/items/{item-id}:param:MyHeader"
+      name: x-cli-ignore
+      value: true
+    - location: "operation:get:/items/{item-id}:response:200"
+      name: x-cli-description
+      value: CLI-specific description override
+    - location: "operation:delete:/items/{item-id}"
+      name: x-cli-ignore
+      value: true


### PR DESCRIPTION
The `x-cli-*` OpenAPI specification extensions recognized by Restish can be abused. To prevent this, this change:
1. Prints a notification describing the `x-cli-*` extensions found in an OpenAPI specification
2. Requires the user to interactively agree to using the extensions

This behavior can be disabled by passing the global `--blindly-accept-cli-extensions` flag.

Addresses https://github.com/rest-sh/restish/issues/316.