### PR TITLE
Pass along stderr from failed external auth helper invocations

### DIFF
--- a/cli/auth.go
+++ b/cli/auth.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -138,7 +139,11 @@ func (a *ExternalToolAuth) OnRequest(req *http.Request, key string, params map[s
 	stdin.Close()
 	outBytes, err := cmd.Output()
 	if err != nil {
-		return err
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return fmt.Errorf("external auth tool failed: %s: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return fmt.Errorf("external auth tool failed: %w", err)
 	}
 	if len(outBytes) <= 0 {
 		return nil

--- a/cli/auth_test.go
+++ b/cli/auth_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"net/http"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExternalToolAuthStderrOnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses /bin/sh")
+	}
+
+	auth := &ExternalToolAuth{}
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+
+	err := auth.OnRequest(req, "test", map[string]string{
+		"commandline": "echo 'token expired, please re-authenticate' >&2; exit 1",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "external auth tool failed")
+	assert.Contains(t, err.Error(), "token expired, please re-authenticate")
+}
+
+func TestExternalToolAuthStderrEmptyOnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses /bin/sh")
+	}
+
+	auth := &ExternalToolAuth{}
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+
+	err := auth.OnRequest(req, "test", map[string]string{
+		"commandline": "exit 1",
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "external auth tool failed")
+}


### PR DESCRIPTION
This change passes along the stderr from an external auth helper, if the helper exits with a non-zero exit status. It also makes the message reported for external auth tool invocation failures more descriptive.

Today, when an external auth helper exits with a non-zero exit code, restish shows an error like this:

With this entry in `apis.json`:

```
  "example": {
    "base": "https://httpbin.org",
    "profiles": {
      "default": {
        "auth": {
          "name": "external-tool",
          "params": {
            "commandline": "echo 'bad news' >&2 && exit 1"
          }
        }
      }
    },
```

... attempting to use this API yields

```
❯ restish example /status/200
panic: exit status 1

goroutine 1 [running]:
github.com/rest-sh/restish/cli.MakeRequest(0x14000001900, {0x1400069fc30, 0x2, 0x1016be803?})
	/workspace/cli/request.go:244 +0x1298
github.com/rest-sh/restish/cli.Load({0x1400013ed08, 0x13}, 0x140000dec08)
	/workspace/cli/api.go:209 +0x4bc
github.com/rest-sh/restish/cli.Run()
	/workspace/cli/cli.go:821 +0xef4
main.main()
	/workspace/main.go:40 +0x2f4
```

Which notably lacks the error message produced by the external auth helper. This is obviously a contrived example, but given how finicky auth can be, those errors are often critical to debugging. 

Here's how this looks after the change:

```
❯ restish  example /status/200
panic: external auth tool failed: exit status 1: bad news

... snip ...
```