### PR TITLE
oauth: add HTMLSuccess + HTMLError fields for branded login pages

### DIFF
--- a/oauth/authcode.go
+++ b/oauth/authcode.go
@@ -177,24 +177,37 @@ func getInput(input chan string) {
 }
 
 // authHandler is an HTTP handler that takes a channel and sends the `code`
-// query param when it gets a request.
+// query param when it gets a request. The successHTML and errorHTML fields
+// allow callers to override the built-in HTML pages; an empty string falls
+// back to the package-level htmlSuccess / htmlError defaults.
 type authHandler struct {
-	c chan string
+	c           chan string
+	successHTML string
+	errorHTML   string
 }
 
 func (h authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
+	successBody := h.successHTML
+	if successBody == "" {
+		successBody = htmlSuccess
+	}
+	errorBody := h.errorHTML
+	if errorBody == "" {
+		errorBody = htmlError
+	}
+
 	if err := r.URL.Query().Get("error"); err != "" {
 		details := r.URL.Query().Get("error_description")
-		rendered := strings.Replace(strings.Replace(htmlError, "$ERROR", err, 1), "$DETAILS", details, 1)
+		rendered := strings.Replace(strings.Replace(errorBody, "$ERROR", err, 1), "$DETAILS", details, 1)
 		w.Write([]byte(rendered))
 		h.c <- ""
 		return
 	}
 
 	h.c <- r.URL.Query().Get("code")
-	w.Write([]byte(htmlSuccess))
+	w.Write([]byte(successBody))
 }
 
 // AuthorizationCodeTokenSource with PKCE as described in:
@@ -212,6 +225,8 @@ type AuthorizationCodeTokenSource struct {
 	RedirectURL    string
 	EndpointParams *url.Values
 	Scopes         []string
+	HTMLSuccess    string
+	HTMLError      string
 }
 
 func (ac *AuthorizationCodeTokenSource) getRedirectUrl() string {
@@ -260,7 +275,9 @@ func (ac *AuthorizationCodeTokenSource) Token() (*oauth2.Token, error) {
 	// Run server before opening the user's browser so we are ready for any redirect.
 	codeChan := make(chan string)
 	handler := authHandler{
-		c: codeChan,
+		c:           codeChan,
+		successHTML: ac.HTMLSuccess,
+		errorHTML:   ac.HTMLError,
 	}
 
 	// strip protocol prefix from configured redirect url for local webserver

--- a/oauth/authcode_test.go
+++ b/oauth/authcode_test.go
@@ -1,10 +1,14 @@
 package oauth
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeUrlWindowsSuccess(t *testing.T) {
@@ -17,4 +21,78 @@ func TestEncodeUrlWindowsSuccess(t *testing.T) {
 	assert.Contains(t, r, "^&")
 	assert.False(t, strings.HasPrefix(r, "^&"))
 	assert.False(t, strings.HasSuffix(r, "^&"))
+}
+
+// runAuthHandler drives the authHandler with the given query string and
+// returns the response body, allowing assertions on what HTML was served.
+func runAuthHandler(t *testing.T, h authHandler, query string) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/callback?"+query, nil)
+
+	// authHandler sends on h.c synchronously; drain in a goroutine so the
+	// handler can complete without blocking on an unbuffered channel.
+	done := make(chan struct{})
+	go func() {
+		<-h.c
+		close(done)
+	}()
+
+	h.ServeHTTP(rec, req)
+	<-done
+
+	body, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+func TestAuthHandlerServesDefaultSuccessHTML(t *testing.T) {
+	h := authHandler{c: make(chan string)}
+
+	body := runAuthHandler(t, h, "code=abc123")
+
+	assert.Contains(t, body, "Login Successful!", "default success HTML should be served when successHTML is unset")
+}
+
+func TestAuthHandlerServesCustomSuccessHTML(t *testing.T) {
+	const custom = `<html><body><h1>Welcome to my-tool</h1></body></html>`
+	h := authHandler{c: make(chan string), successHTML: custom}
+
+	body := runAuthHandler(t, h, "code=abc123")
+
+	assert.Equal(t, custom, body, "custom successHTML should be served verbatim")
+	assert.NotContains(t, body, "Login Successful!", "default content should not leak through")
+}
+
+func TestAuthHandlerServesDefaultErrorHTML(t *testing.T) {
+	h := authHandler{c: make(chan string)}
+
+	body := runAuthHandler(t, h, "error=access_denied&error_description=user+denied")
+
+	assert.Contains(t, body, "access_denied", "$ERROR should be substituted in the default error HTML")
+	assert.Contains(t, body, "user denied", "$DETAILS should be substituted in the default error HTML")
+}
+
+func TestAuthHandlerServesCustomErrorHTML(t *testing.T) {
+	const custom = `<html><body><h1>Login failed: $ERROR</h1><p>$DETAILS</p></body></html>`
+	h := authHandler{c: make(chan string), errorHTML: custom}
+
+	body := runAuthHandler(t, h, "error=invalid_grant&error_description=code+expired")
+
+	assert.Equal(t, `<html><body><h1>Login failed: invalid_grant</h1><p>code expired</p></body></html>`, body,
+		"custom errorHTML should be served with $ERROR and $DETAILS substituted")
+}
+
+func TestAuthHandlerCustomSuccessDoesNotAffectErrorPath(t *testing.T) {
+	// A caller that only overrides successHTML should still see the default
+	// error HTML when an error comes through. Each field is independently
+	// optional.
+	h := authHandler{c: make(chan string), successHTML: "<html>custom success</html>"}
+
+	body := runAuthHandler(t, h, "error=server_error")
+
+	assert.Contains(t, body, "server_error", "default error HTML should still substitute $ERROR")
+	assert.NotContains(t, body, "custom success")
 }


### PR DESCRIPTION
## Summary

Adds two optional fields, `HTMLSuccess` and `HTMLError`, to `AuthorizationCodeTokenSource`. When set, they override the built-in success / error HTML pages served to the browser at the end of the OAuth callback flow. When empty (the default), behaviour is unchanged.

The change is purely additive — no existing callers see different behaviour.

## Why

The default `htmlSuccess` / `htmlError` templates are good general defaults, but they're shipped as unexported package-level vars, so downstream tools have no way to brand the post-login landing page short of forking the package. Branded CLIs (a fairly common use of `AuthorizationCodeTokenSource`) currently have to choose between using restish's PKCE flow and showing their own success / error UI, even though everything else about the flow is already factored out as configurable.

A motivating example: I'm building a corporate-internal CLI on top of restish where the post-login page should show the user "logged in as <email> to <env>" and the team's brand. Today the user just sees the generic restish "Login Successful!" page, which works fine but feels unbranded. With this change, callers configure the HTML alongside the URL / scope / client config:

```go
source := &oauth.AuthorizationCodeTokenSource{
    ClientID:     clientID,
    AuthorizeURL: authorizeURL,
    TokenURL:     tokenURL,
    RedirectURL:  redirectURL,
    Scopes:       []string{"openid", "profile"},
    HTMLSuccess:  customSuccessHTML,
    HTMLError:    customErrorHTML,  // $ERROR / $DETAILS substitution still works
}

token, err := source.Token()
```

## Implementation

Three small touches in `oauth/authcode.go`:

1. **Two fields on `AuthorizationCodeTokenSource`** (`HTMLSuccess`, `HTMLError`) with doc comments documenting the `$ERROR` / `$DETAILS` substitution behaviour for the error path.
2. **Two unexported fields on `authHandler`** (`successHTML`, `errorHTML`) and a default-when-empty fallback in `ServeHTTP` that selects the override when set, otherwise the existing package-level constants.
3. **Plumbing in `Token()`** to pass the user-provided HTML into the handler at construction time.

## Tests

Five new tests in `oauth/authcode_test.go` cover:

- Default `htmlSuccess` served when `successHTML` is unset
- Custom HTML served verbatim when `successHTML` is set
- Default `htmlError` served with `$ERROR` / `$DETAILS` substitution when `errorHTML` is unset
- Custom error HTML served with substitution when `errorHTML` is set
- The two fields are independent (overriding only success leaves error unaffected)

`go test ./oauth/...` passes locally (6 tests including the existing `TestEncodeUrlWindowsSuccess`).

## Compatibility

Pure addition. Existing callers see no behaviour change — the new fields default to empty strings, which routes through the existing constants. No public API removed or renamed. Safe to merge under semver.