### PR TITLE
[docs] Generate docs social preview images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
       - name: Check generated docs
         run: go run ./cmd/restish-docgen --check
 
+      - name: Generate social preview images
+        working-directory: site
+        run: npm run social-images
+
       - name: Build docs site
         run: |
           hugo --source site --quiet --gc --minify \

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Check generated docs
         run: go run ./cmd/restish-docgen --check
 
+      - name: Generate social preview images
+        working-directory: site
+        run: npm run social-images
+
       - name: Build site
         if: ${{ vars.DOCS_SITE_DEPLOY_ENABLED != 'true' }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ site/.astro/
 site/.vitepress/
 site/public/
 site/resources/
+site/static/images/social/
 site/.hugo_build.lock
 dist/
 /tmp/

--- a/site/README.md
+++ b/site/README.md
@@ -5,21 +5,29 @@ the Docsy theme.
 
 ## Commands
 
-If `hugo` is installed locally, run the site with:
+If `hugo` is installed locally, install dependencies once:
 
 ```bash
-hugo server
+npm ci
+```
+
+Run the site with:
+
+```bash
+npm run dev
 ```
 
 Build the static site:
 
 ```bash
-hugo
+npm run build
 ```
 
 ## Notes
 
 - Content lives under `content/en/docs/`.
 - The theme is provided through Hugo Modules.
+- Social preview images are generated into `static/images/social/` before
+  Hugo runs. That directory is ignored because CI regenerates it for deploys.
 - Generated output goes under `public/` and Hugo's resource cache; both are
   ignored.

--- a/site/layouts/_partials/opengraph.html
+++ b/site/layouts/_partials/opengraph.html
@@ -1,0 +1,29 @@
+{{- $imageAlt := cond .IsHome .Site.Title (printf "%s | %s" .Title .Site.Title) -}}
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:title" content="{{ cond .IsHome .Site.Title .Title }}">
+<meta property="og:description" content="{{ partial "page-description.html" . }}">
+{{- with .Site.Language.LanguageCode }}
+<meta property="og:locale" content="{{ replace . "-" "_" }}">
+{{- end }}
+{{- if .IsPage }}
+<meta property="og:type" content="article">
+{{- with .Section }}
+<meta property="article:section" content="{{ . }}">
+{{- end }}
+{{- with .PublishDate }}
+<meta property="article:published_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
+{{- end }}
+{{- with .Lastmod }}
+<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
+{{- end }}
+{{- else }}
+<meta property="og:type" content="website">
+{{- end }}
+{{- with partial "social-image.html" . }}
+<meta property="og:image" content="{{ . }}">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ $imageAlt }}">
+{{- end }}

--- a/site/layouts/_partials/social-image.html
+++ b/site/layouts/_partials/social-image.html
@@ -1,0 +1,12 @@
+{{- $image := "" -}}
+{{- with .Params.social_image -}}
+  {{- $image = . -}}
+{{- else with .File -}}
+  {{- $stem := replaceRE "\\.md$" "" .Path -}}
+  {{- $stem = replaceRE "/_index$" "" $stem -}}
+  {{- if or (eq $stem "") (eq $stem "_index") -}}
+    {{- $stem = "index" -}}
+  {{- end -}}
+  {{- $image = printf "/images/social/%s.png" $stem -}}
+{{- end -}}
+{{- with $image -}}{{ . | absURL }}{{- end -}}

--- a/site/layouts/_partials/twitter_cards.html
+++ b/site/layouts/_partials/twitter_cards.html
@@ -1,0 +1,8 @@
+{{- $title := cond .IsHome .Site.Title (printf "%s | %s" .Title .Site.Title) -}}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ partial "page-description.html" . }}">
+{{- with partial "social-image.html" . }}
+<meta name="twitter:image" content="{{ . }}">
+<meta name="twitter:image:alt" content="{{ $title }}">
+{{- end }}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,9 +8,250 @@
       "name": "restish-docs-hugo",
       "version": "0.1.0",
       "devDependencies": {
+        "@fontsource/space-grotesk": "^5.2.10",
+        "@resvg/resvg-js": "^2.6.2",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
-        "postcss-cli": "^11.0.1"
+        "postcss-cli": "^11.0.1",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/ansi-regex": {
@@ -890,9 +1131,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/site/package.json
+++ b/site/package.json
@@ -3,12 +3,16 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "hugo server",
-    "build": "hugo"
+    "social-images": "node scripts/generate-social-images.mjs",
+    "dev": "npm run social-images && hugo server",
+    "build": "npm run social-images && hugo"
   },
   "devDependencies": {
+    "@fontsource/space-grotesk": "^5.2.10",
+    "@resvg/resvg-js": "^2.6.2",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
-    "postcss-cli": "^11.0.1"
+    "postcss-cli": "^11.0.1",
+    "yaml": "^2.9.0"
   }
 }

--- a/site/scripts/generate-social-images.mjs
+++ b/site/scripts/generate-social-images.mjs
@@ -1,0 +1,266 @@
+import {mkdir, readFile, readdir, rm, writeFile} from "node:fs/promises";
+
+import {Resvg} from "@resvg/resvg-js";
+import YAML from "yaml";
+import {fileURLToPath} from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siteDir = path.resolve(__dirname, "..");
+const contentDir = path.join(siteDir, "content", "en");
+const outputDir = path.join(siteDir, "static", "images", "social");
+const fontDir = path.join(
+  siteDir,
+  "node_modules",
+  "@fontsource",
+  "space-grotesk",
+  "files",
+);
+const spaceGroteskFonts = [400, 500, 600, 700].map((weight) =>
+  path.join(fontDir, `space-grotesk-latin-${weight}-normal.woff`),
+);
+
+const width = 1200;
+const height = 630;
+const fallbackDescription =
+  "API-aware HTTP from your terminal, with OpenAPI commands, auth, output shaping, and plugin support.";
+
+const escapeXml = (value) =>
+  String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+const humanize = (value) =>
+  value
+    .replace(/^_index$/, "documentation")
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const textWidth = (value, fontSize) => {
+  let units = 0;
+  for (const char of value) {
+    if (char === " ") units += 0.34;
+    else if (/[il.,:;|!]/.test(char)) units += 0.28;
+    else if (/[A-Z0-9{}()[\]/]/.test(char)) units += 0.68;
+    else units += 0.56;
+  }
+  return units * fontSize;
+};
+
+const wrapText = (value, maxWidth, fontSize, maxLines) => {
+  const words = String(value ?? "")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const lines = [];
+  let current = "";
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (textWidth(candidate, fontSize) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+    if (current) lines.push(current);
+    current = word;
+    if (lines.length === maxLines) break;
+  }
+
+  if (current && lines.length < maxLines) lines.push(current);
+
+  if (lines.length === maxLines) {
+    const usedWords = lines.join(" ").split(/\s+/).length;
+    if (usedWords < words.length) {
+      let last = lines[lines.length - 1];
+      while (last.length > 1 && textWidth(`${last}...`, fontSize) > maxWidth) {
+        last = last.replace(/\s+\S*$/, "");
+        if (!last.includes(" ")) last = last.slice(0, -1);
+      }
+      lines[lines.length - 1] = `${last.trim()}...`;
+    }
+  }
+
+  return lines;
+};
+
+const parsePage = async (file) => {
+  const source = await readFile(file, "utf8");
+  if (!source.startsWith("---\n")) return {};
+
+  const end = source.indexOf("\n---", 4);
+  if (end === -1) return {};
+
+  const frontMatter = source.slice(4, end);
+  return YAML.parse(frontMatter) ?? {};
+};
+
+const listMarkdown = async (dir) => {
+  const entries = await readdir(dir, {withFileTypes: true});
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return listMarkdown(fullPath);
+      if (entry.isFile() && entry.name.endsWith(".md")) return [fullPath];
+      return [];
+    }),
+  );
+  return files.flat().sort();
+};
+
+const socialPathFor = (contentPath) => {
+  const relative = path
+    .relative(contentDir, contentPath)
+    .replaceAll(path.sep, "/");
+  let stem = relative.replace(/\.md$/, "").replace(/\/_index$/, "");
+  if (stem === "_index" || stem === "") stem = "index";
+  return `${stem}.png`;
+};
+
+const sectionFor = (socialPath) => {
+  const segments = socialPath.replace(/\.png$/, "").split("/");
+  if (segments[0] === "docs" && segments[1]) return humanize(segments[1]);
+  if (segments[0] === "docs") return "Documentation";
+  return "Restish";
+};
+
+const renderSvg = ({
+  title,
+  description,
+  section,
+  command = "$ restish docs",
+  descMaxLines = 3,
+}) => {
+  const titleLines = wrapText(title, 710, 68, 3);
+  const descLines = wrapText(description, 690, 30, descMaxLines);
+  const titleY = 214;
+  const descY = titleY + titleLines.length * 78 + 30;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020617"/>
+      <stop offset="0.58" stop-color="#111827"/>
+      <stop offset="1" stop-color="#0f2a33"/>
+    </linearGradient>
+    <filter id="terminalGlow" x="-14%" y="-10%" width="128%" height="142%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="2" dy="17" stdDeviation="10" flood-color="#ff4dbd" flood-opacity="0.17"/>
+      <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#ff4dbd" flood-opacity="0.08"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <path d="M0 510 C180 462 276 548 438 494 C622 432 698 510 874 450 C1028 398 1118 422 1200 366 L1200 630 L0 630 Z" fill="#2dd4bf" opacity="0.10"/>
+  <path d="M0 94 H1200 M0 188 H1200 M0 282 H1200 M0 376 H1200 M0 470 H1200 M172 0 V630 M344 0 V630 M516 0 V630 M688 0 V630 M860 0 V630 M1032 0 V630" stroke="#94a3b8" stroke-opacity="0.08" stroke-width="1"/>
+
+  <g transform="translate(78 74)">
+    <text x="0" y="0" dominant-baseline="hanging" fill="#5eead4" font-family="Space Grotesk, Arial, Helvetica, sans-serif" font-size="24" font-weight="700" letter-spacing="3">${escapeXml(section.toUpperCase())}</text>
+    <text x="0" y="44" dominant-baseline="hanging" fill="#fbbf24" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="22" font-weight="700">${escapeXml(command)}</text>
+  </g>
+
+  <g transform="translate(78 0)">
+    ${titleLines
+      .map(
+        (line, index) =>
+          `<text x="0" y="${titleY + index * 78}" fill="#f8fafc" font-family="Space Grotesk, Arial, Helvetica, sans-serif" font-size="68" font-weight="700">${escapeXml(line)}</text>`,
+      )
+      .join("\n    ")}
+    ${descLines
+      .map(
+        (line, index) =>
+          `<text x="0" y="${descY + index * 40}" fill="#cbd5e1" font-family="Space Grotesk, Arial, Helvetica, sans-serif" font-size="30" font-weight="400">${escapeXml(line)}</text>`,
+      )
+      .join("\n    ")}
+  </g>
+
+  <g transform="translate(770 150)">
+    <rect x="0" y="0" width="350" height="330" rx="18" fill="#020617" filter="url(#terminalGlow)" opacity="0.98"/>
+    <rect x="0" y="0" width="350" height="330" rx="18" fill="#020617" stroke="#334155" stroke-width="2"/>
+    <rect x="0" y="0" width="350" height="58" rx="18" fill="#0f172a"/>
+    <path d="M0 40 Q0 58 18 58 H332 Q350 58 350 40 V58 H0 Z" fill="#0f172a"/>
+    <circle cx="32" cy="29" r="8" fill="#ff4dbd"/>
+    <circle cx="58" cy="29" r="8" fill="#fbbf24"/>
+    <circle cx="84" cy="29" r="8" fill="#2dd4bf"/>
+    <text x="213" y="38" text-anchor="middle" font-family="Space Grotesk, Arial, Helvetica, sans-serif" font-size="26" font-weight="700">
+      <tspan fill="#5eead4" font-size="33">{</tspan><tspan dx="0.22em" fill="#f8fafc">rest</tspan><tspan dx="0.08em" fill="#ff4dbd">!</tspan><tspan dx="0.04em" fill="#f8fafc">sh</tspan><tspan dx="0.12em" fill="#5eead4" font-size="33">}</tspan>
+    </text>
+    <g transform="translate(30 92)">
+      <rect x="0" y="0" width="80" height="14" rx="7" fill="#5eead4"/>
+      <rect x="98" y="0" width="178" height="14" rx="7" fill="#475569"/>
+      <rect x="0" y="40" width="240" height="14" rx="7" fill="#e2e8f0"/>
+      <rect x="258" y="40" width="38" height="14" rx="7" fill="#ff4dbd"/>
+      <rect x="0" y="80" width="132" height="14" rx="7" fill="#fbbf24"/>
+      <rect x="150" y="80" width="118" height="14" rx="7" fill="#475569"/>
+      <rect x="0" y="120" width="274" height="14" rx="7" fill="#64748b"/>
+      <rect x="0" y="160" width="92" height="14" rx="7" fill="#ff4dbd"/>
+      <rect x="110" y="160" width="156" height="14" rx="7" fill="#e2e8f0"/>
+      <rect x="0" y="200" width="220" height="14" rx="7" fill="#2dd4bf"/>
+    </g>
+  </g>
+</svg>`;
+};
+
+const renderPng = async (socialPath, svg) => {
+  const png = new Resvg(svg, {
+    fitTo: {mode: "width", value: width},
+    font: {
+      defaultFontFamily: "Space Grotesk",
+      fontFiles: spaceGroteskFonts,
+      loadSystemFonts: true,
+    },
+  })
+    .render()
+    .asPng();
+
+  const destination = path.join(outputDir, socialPath);
+  await mkdir(path.dirname(destination), {recursive: true});
+  await writeFile(destination, png);
+  return socialPath;
+};
+
+const renderPage = async (file) => {
+  const frontMatter = await parsePage(file);
+  if (frontMatter.draft === true) return null;
+
+  const socialPath = socialPathFor(file);
+  const title =
+    frontMatter.title ?? humanize(path.basename(socialPath, ".png"));
+  const description = frontMatter.description ?? fallbackDescription;
+  const section = sectionFor(socialPath);
+  return renderPng(socialPath, renderSvg({title, description, section}));
+};
+
+const renderGithubOverview = () =>
+  renderPng(
+    "github.png",
+    renderSvg({
+      title: "Restish CLI",
+      description:
+        "Explore REST-ish APIs with generic HTTP verbs, generated OpenAPI commands, shorthand input, auth, response filtering & projection, pagination, and plugins.",
+      section: "Always Free. Always Open Source.",
+      command: "$ brew install rest-sh/tap/restish",
+      descMaxLines: 4,
+    }),
+  );
+
+const main = async () => {
+  const files = await listMarkdown(contentDir);
+  await rm(outputDir, {recursive: true, force: true});
+
+  const rendered = [];
+  for (const file of files) {
+    const socialPath = await renderPage(file);
+    if (socialPath) rendered.push(socialPath);
+  }
+  rendered.push(await renderGithubOverview());
+
+  console.log(
+    `Generated ${rendered.length} social preview images in ${path.relative(siteDir, outputDir)}`,
+  );
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Generate per-page 1200x630 social preview images for the Hugo docs site
- Add Open Graph and Twitter image metadata partials
- Wire social image generation into local docs commands and CI/deploy builds
- Generate a reusable GitHub social overview image

## Validation
- npm run build
- scripts/check-doc-links.rb
- git diff --check