### PR TITLE
feat(auth): theme and customize OAuth callback pages

### DIFF
--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -23,6 +23,10 @@ import (
 const defaultRedirectPort = "8484"
 const authTimeout = 5 * time.Minute
 const callbackPageResultWait = 200 * time.Millisecond
+const defaultCallbackSuccessColor = "#5fafd7"
+const defaultCallbackFailureColor = "#E94F37"
+const callbackSuccessHTMLParam = "callback_success_html"
+const callbackErrorHTMLParam = "callback_error_html"
 
 // AuthorizationCode implements the OAuth2 authorization code flow with PKCE
 // (RFC 7636). On first use it opens a browser and waits for the redirect
@@ -47,6 +51,19 @@ type AuthorizationCode struct {
 	NoBrowser bool
 	// Verbose prints the full authorization URL before browser launch.
 	Verbose bool
+	// CallbackSuccessColor customizes the browser callback success background.
+	// Invalid values fall back to the built-in v1 callback color.
+	CallbackSuccessColor string
+	// CallbackFailureColor customizes the browser callback failure background.
+	// Invalid values fall back to the built-in v1 callback color.
+	CallbackFailureColor string
+	// CallbackSuccessHTML customizes the browser callback success page. When
+	// empty, Restish renders the built-in animated page.
+	CallbackSuccessHTML string
+	// CallbackErrorHTML customizes the browser callback failure page. When
+	// empty, Restish renders the built-in animated page. $ERROR, $TITLE, and
+	// $DETAILS placeholders are replaced with escaped callback values.
+	CallbackErrorHTML string
 }
 
 func (h *AuthorizationCode) Parameters() []Param {
@@ -60,6 +77,8 @@ func (h *AuthorizationCode) Parameters() []Param {
 		{Name: "scopes", Description: "Space-separated OAuth2 scopes to request; some providers require offline_access for refresh tokens", Required: false},
 		{Name: "redirect_port", Description: fmt.Sprintf("Local port for the redirect callback (default %s)", defaultRedirectPort), Required: false},
 		{Name: "redirect_path", Description: "Local path for the redirect callback (default /)", Required: false},
+		{Name: callbackSuccessHTMLParam, Description: "Custom HTML for the successful browser callback page", Required: false},
+		{Name: callbackErrorHTMLParam, Description: "Custom HTML for the failed browser callback page; supports $ERROR, $TITLE, and $DETAILS placeholders", Required: false},
 	})
 }
 
@@ -125,14 +144,18 @@ func (h *AuthorizationCode) resolveToken(ctx context.Context, params map[string]
 
 func (h *AuthorizationCode) Authenticate(ctx context.Context, req *http.Request, ac AuthContext) error {
 	h2 := &AuthorizationCode{
-		Cache:       h.Cache,
-		HTTPClient:  h.HTTPClient,
-		OpenBrowser: h.OpenBrowser,
-		Stderr:      h.Stderr,
-		Prompt:      h.Prompt,
-		CanPrompt:   h.CanPrompt,
-		NoBrowser:   h.NoBrowser,
-		Verbose:     h.Verbose,
+		Cache:                h.Cache,
+		HTTPClient:           h.HTTPClient,
+		OpenBrowser:          h.OpenBrowser,
+		Stderr:               h.Stderr,
+		Prompt:               h.Prompt,
+		CanPrompt:            h.CanPrompt,
+		NoBrowser:            h.NoBrowser,
+		Verbose:              h.Verbose,
+		CallbackSuccessColor: h.CallbackSuccessColor,
+		CallbackFailureColor: h.CallbackFailureColor,
+		CallbackSuccessHTML:  h.CallbackSuccessHTML,
+		CallbackErrorHTML:    h.CallbackErrorHTML,
 	}
 	if ac.TokenStore != nil {
 		h2.Cache = ac.TokenStore
@@ -227,6 +250,7 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		return CachedToken{}, err
 	}
 	redirectURI := "http://localhost:" + port + redirectPath
+	callbackPages := h.oauthCallbackPages(params)
 
 	// Build authorization URL.
 	q := url.Values{
@@ -241,13 +265,15 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		q.Set("scope", scopes)
 	}
 	for key, value := range extraOAuthParams(params, map[string]bool{
-		"_cache_key":    true,
-		"authorize_url": true,
-		"cache_key":     true,
-		"issuer_url":    true,
-		"redirect_path": true,
-		"redirect_port": true,
-		"token_url":     true,
+		"_cache_key":             true,
+		"authorize_url":          true,
+		"cache_key":              true,
+		"issuer_url":             true,
+		callbackErrorHTMLParam:   true,
+		callbackSuccessHTMLParam: true,
+		"redirect_path":          true,
+		"redirect_port":          true,
+		"token_url":              true,
 	}) {
 		if q.Get(key) == "" {
 			q.Set(key, value)
@@ -280,27 +306,33 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 				return
 			}
 
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			q := r.URL.Query()
 			if q.Get("state") != state {
-				http.Error(w, "state mismatch", http.StatusBadRequest)
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, callbackPages.errorPage("Authentication failed", "State mismatch in OAuth callback. Return to the terminal to try again.", "state_mismatch"))
 				trySendErr(errCh, fmt.Errorf("state mismatch in callback"))
+				return
+			}
+			if callbackErr := q.Get("error"); callbackErr != "" {
+				detail := q.Get("error_description")
+				if detail == "" {
+					detail = "The OAuth provider rejected the authorization request."
+				}
+				fmt.Fprint(w, callbackPages.errorPage("Error: "+callbackErr, detail, callbackErr))
+				trySendErr(errCh, fmt.Errorf("oauth callback error: %s", callbackErr))
 				return
 			}
 			code := q.Get("code")
 			if code == "" {
-				http.Error(w, "missing code", http.StatusBadRequest)
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, callbackPages.errorPage("Authentication failed", "No authorization code was included in the OAuth callback.", "missing_code"))
 				trySendErr(errCh, fmt.Errorf("no code in callback"))
 				return
 			}
 			if !receivedCode.CompareAndSwap(false, true) {
-				w.Header().Set("Content-Type", "text/html")
-				fmt.Fprint(w, "<html><body><h2>Authentication already received</h2><p>You can close this tab.</p></body></html>")
+				fmt.Fprint(w, callbackPages.successPage("Authentication already received", "You can close this tab."))
 				return
-			}
-			w.Header().Set("Content-Type", "text/html")
-			fmt.Fprint(w, "<html><body><h2>Authorization code received</h2><p>Return to the terminal while Restish finishes authentication.</p></body></html>")
-			if flusher, ok := w.(http.Flusher); ok {
-				flusher.Flush()
 			}
 			select {
 			case codeCh <- code:
@@ -309,13 +341,14 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 			select {
 			case exchangeErr := <-doneCh:
 				if exchangeErr != nil {
-					fmt.Fprintf(w, "<html><body><h2>Authentication failed</h2><p>%s</p></body></html>", html.EscapeString(exchangeErr.Error()))
+					fmt.Fprint(w, callbackPages.errorPage("Authentication failed", exchangeErr.Error(), "token_exchange_failed"))
 					return
 				}
-				fmt.Fprint(w, "<html><body><h2>Authentication successful</h2><p>You can close this tab.</p></body></html>")
+				fmt.Fprint(w, callbackPages.successPage("Login Successful!", "Please return to the terminal. You may now close this window."))
 			case <-time.After(callbackPageResultWait):
+				fmt.Fprint(w, callbackPages.successPage("Authorization code received", "Return to the terminal while Restish finishes authentication."))
 			case <-ctx2.Done():
-				fmt.Fprint(w, "<html><body><h2>Authentication timed out</h2></body></html>")
+				fmt.Fprint(w, callbackPages.errorPage("Authentication timed out", "Return to the terminal to try again.", "timed_out"))
 			}
 		})}
 		go func() {
@@ -391,6 +424,244 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		return CachedToken{}, err
 	}
 	return ct, nil
+}
+
+func (h *AuthorizationCode) oauthCallbackSuccessPage(title, detail string) string {
+	return h.oauthCallbackPages(nil).successPage(title, detail)
+}
+
+func (h *AuthorizationCode) oauthCallbackErrorPage(title, detail string) string {
+	return h.oauthCallbackPages(nil).errorPage(title, detail, "")
+}
+
+type oauthCallbackPages struct {
+	successColor string
+	failureColor string
+	successHTML  string
+	errorHTML    string
+}
+
+type oauthCallbackTemplateData struct {
+	Title   string
+	Details string
+	Error   string
+}
+
+func (h *AuthorizationCode) oauthCallbackPages(params map[string]string) oauthCallbackPages {
+	pages := oauthCallbackPages{
+		successColor: h.CallbackSuccessColor,
+		failureColor: h.CallbackFailureColor,
+		successHTML:  h.CallbackSuccessHTML,
+		errorHTML:    h.CallbackErrorHTML,
+	}
+	if params != nil {
+		if html := params[callbackSuccessHTMLParam]; html != "" {
+			pages.successHTML = html
+		}
+		if html := params[callbackErrorHTMLParam]; html != "" {
+			pages.errorHTML = html
+		}
+	}
+	return pages
+}
+
+func (p oauthCallbackPages) successPage(title, detail string) string {
+	if p.successHTML != "" {
+		return renderOAuthCallbackTemplate(p.successHTML, oauthCallbackTemplateData{
+			Title:   title,
+			Details: detail,
+		})
+	}
+	return oauthCallbackSuccessPage(title, detail, p.successColor)
+}
+
+func (p oauthCallbackPages) errorPage(title, detail, errorCode string) string {
+	if p.errorHTML != "" {
+		return renderOAuthCallbackTemplate(p.errorHTML, oauthCallbackTemplateData{
+			Title:   title,
+			Details: detail,
+			Error:   errorCode,
+		})
+	}
+	return oauthCallbackErrorPage(title, detail, p.failureColor)
+}
+
+func renderOAuthCallbackTemplate(template string, data oauthCallbackTemplateData) string {
+	errorText := data.Error
+	if errorText == "" {
+		errorText = data.Title
+	}
+	replacer := strings.NewReplacer(
+		"$ERROR", html.EscapeString(errorText),
+		"$TITLE", html.EscapeString(data.Title),
+		"$DETAILS", html.EscapeString(data.Details),
+	)
+	return replacer.Replace(template)
+}
+
+func oauthCallbackSuccessPage(title, detail, color string) string {
+	return oauthCallbackPage("success", title, detail, callbackPageColor(color, defaultCallbackSuccessColor))
+}
+
+func oauthCallbackErrorPage(title, detail, color string) string {
+	return oauthCallbackPage("failure", title, detail, callbackPageColor(color, defaultCallbackFailureColor))
+}
+
+func oauthCallbackPage(kind, title, detail, background string) string {
+	title = html.EscapeString(title)
+	detail = html.EscapeString(detail)
+	detailHTML := ""
+	if detail != "" {
+		detailHTML = "<p>" + detail + "</p>"
+	}
+	iconHTML := `<div class="check"></div>`
+	if kind == "failure" {
+		iconHTML = `<div class="x-wrap"><div class="x"></div></div>`
+	}
+	return fmt.Sprintf(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Restish OAuth</title>
+    <style>
+      @keyframes success-bg {
+        from { background: white; }
+        to { background: %s; }
+      }
+      @keyframes failure-bg {
+        from { background: white; }
+        to { background: %s; }
+      }
+      @keyframes check {
+        from { transform: rotate(0deg) skew(30deg, 20deg); }
+        to { transform: rotate(-45deg); }
+      }
+      @keyframes x {
+        from { transform: scaleY(0); }
+        to { transform: scaleY(1) rotate(-90deg); }
+      }
+      @keyframes fade {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+      html {
+        min-height: 100%%;
+      }
+      body {
+        min-height: 100vh;
+        margin: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: sans-serif;
+        animation-duration: 1.5s;
+        animation-timing-function: ease-out;
+        animation-fill-mode: forwards;
+      }
+      body.success {
+        animation-name: success-bg;
+      }
+      body.failure {
+        animation-name: failure-bg;
+      }
+      main {
+        width: min(520px, calc(100%% - 48px));
+        text-align: left;
+      }
+      .check {
+        width: 160px;
+        height: 96px;
+        margin: 0 auto 76px;
+        border-left: 16px solid white;
+        border-bottom: 16px solid white;
+        animation: check 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+        animation-fill-mode: forwards;
+      }
+      .x-wrap {
+        margin: 0 auto 116px;
+        transform: rotate(-45deg);
+      }
+      .x,
+      .x:after {
+        width: 180px;
+        height: 16px;
+        margin: auto;
+        background: white;
+        border-radius: 3px;
+        transform: rotate(-45deg);
+        animation: x 0.7s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+        animation-fill-mode: forwards;
+      }
+      .x:after {
+        content: "";
+        display: block;
+        width: 100%%;
+        transform: rotate(90deg);
+      }
+      .msg {
+        background: white;
+        padding: 20px 32px;
+        border-radius: 10px;
+        animation: fade 2s;
+        animation-fill-mode: forwards;
+        box-shadow: 0 15px 15px -15px rgba(0, 0, 0, 0.5);
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: 32px;
+        line-height: 1.15;
+      }
+      p {
+        margin: 0;
+        font-size: 16px;
+        line-height: 1.5;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        body,
+        .check,
+        .x,
+        .x:after,
+        .msg {
+          animation-duration: 1ms;
+        }
+      }
+    </style>
+  </head>
+  <body class="%s">
+    <main>
+      %s
+      <div class="msg">
+        <h1>%s</h1>
+        %s
+      </div>
+    </main>
+  </body>
+</html>`, background, background, kind, iconHTML, title, detailHTML)
+}
+
+func callbackPageColor(color, fallback string) string {
+	color = strings.TrimSpace(color)
+	if isCSSHexColor(color) {
+		return color
+	}
+	return fallback
+}
+
+func isCSSHexColor(color string) bool {
+	if len(color) != 4 && len(color) != 7 {
+		return false
+	}
+	if color[0] != '#' {
+		return false
+	}
+	for _, r := range color[1:] {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func oauthRedirectPath(value string) (string, error) {

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -704,7 +704,7 @@ func TestAuthCode_CallbackPageReflectsTokenExchangeResult(t *testing.T) {
 		if err != nil {
 			t.Fatalf("OnRequest: %v", err)
 		}
-		if body := <-bodyCh; !strings.Contains(body, "Authorization code received") || !strings.Contains(body, "Authentication successful") {
+		if body := <-bodyCh; !strings.Contains(body, "Login Successful!") || !strings.Contains(body, `class="check"`) || !strings.Contains(body, "@keyframes success-bg") {
 			t.Fatalf("callback body = %q", body)
 		}
 	})
@@ -740,10 +740,128 @@ func TestAuthCode_CallbackPageReflectsTokenExchangeResult(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected token exchange error")
 		}
-		if body := <-bodyCh; !strings.Contains(body, "Authorization code received") || !strings.Contains(body, "Authentication failed") {
+		if body := <-bodyCh; !strings.Contains(body, "Authentication failed") || !strings.Contains(body, `class="x"`) || !strings.Contains(body, "@keyframes failure-bg") {
 			t.Fatalf("callback body = %q", body)
 		}
 	})
+}
+
+func TestOAuthCallbackErrorPageEscapesDetail(t *testing.T) {
+	body := oauthCallbackErrorPage("Authentication failed", `<script>alert("nope")</script>`, "")
+	if strings.Contains(body, "<script>") {
+		t.Fatalf("callback body includes raw script: %q", body)
+	}
+	if !strings.Contains(body, `&lt;script&gt;alert(&#34;nope&#34;)&lt;/script&gt;`) {
+		t.Fatalf("callback body does not include escaped detail: %q", body)
+	}
+}
+
+func TestOAuthCallbackPageUsesConfiguredBackgroundColor(t *testing.T) {
+	body := oauthCallbackSuccessPage("Login Successful!", "Done.", "#50fa7b")
+	if !strings.Contains(body, "to { background: #50fa7b; }") {
+		t.Fatalf("callback body does not use configured color: %q", body)
+	}
+}
+
+func TestOAuthCallbackPageRejectsInvalidBackgroundColor(t *testing.T) {
+	body := oauthCallbackErrorPage("Authentication failed", "Nope.", `red; background: url("bad")`)
+	if strings.Contains(body, "url(") {
+		t.Fatalf("callback body includes invalid CSS color: %q", body)
+	}
+	if !strings.Contains(body, "to { background: #E94F37; }") {
+		t.Fatalf("callback body did not fall back to default failure color: %q", body)
+	}
+}
+
+func TestOAuthCallbackPagesUseCustomHTMLFields(t *testing.T) {
+	h := &AuthorizationCode{
+		CallbackSuccessHTML: `<html><body><h1>Welcome to my-tool</h1></body></html>`,
+		CallbackErrorHTML:   `<html><body><h1>$ERROR</h1><p>$DETAILS</p></body></html>`,
+	}
+	if got, want := h.oauthCallbackSuccessPage("Login Successful!", "Done."), h.CallbackSuccessHTML; got != want {
+		t.Fatalf("custom success body = %q, want %q", got, want)
+	}
+	got := h.oauthCallbackErrorPage("Authentication failed", `<script>alert("nope")</script>`)
+	want := `<html><body><h1>Authentication failed</h1><p>&lt;script&gt;alert(&#34;nope&#34;)&lt;/script&gt;</p></body></html>`
+	if got != want {
+		t.Fatalf("custom error body = %q, want %q", got, want)
+	}
+}
+
+func TestOAuthCallbackPagesUseCustomHTMLParams(t *testing.T) {
+	h := &AuthorizationCode{
+		CallbackSuccessHTML: `<html>field success</html>`,
+		CallbackErrorHTML:   `<html>field error</html>`,
+	}
+	pages := h.oauthCallbackPages(map[string]string{
+		callbackSuccessHTMLParam: `<html><body><h1>$TITLE</h1><p>$DETAILS</p></body></html>`,
+		callbackErrorHTMLParam:   `<html><body><h1>$ERROR</h1><p>$DETAILS</p></body></html>`,
+	})
+	if got, want := pages.successPage("Login Successful!", "Done."), `<html><body><h1>Login Successful!</h1><p>Done.</p></body></html>`; got != want {
+		t.Fatalf("custom success body = %q, want %q", got, want)
+	}
+	got := pages.errorPage("Error: access_denied", `bad <reason>`, "access_denied")
+	want := `<html><body><h1>access_denied</h1><p>bad &lt;reason&gt;</p></body></html>`
+	if got != want {
+		t.Fatalf("custom error body = %q, want %q", got, want)
+	}
+}
+
+func TestAuthCode_CustomCallbackHTMLParamsAreNotForwarded(t *testing.T) {
+	h := &AuthorizationCode{
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			if got := r.FormValue(callbackSuccessHTMLParam); got != "" {
+				t.Fatalf("%s forwarded to token endpoint: %q", callbackSuccessHTMLParam, got)
+			}
+			if got := r.FormValue(callbackErrorHTMLParam); got != "" {
+				t.Fatalf("%s forwarded to token endpoint: %q", callbackErrorHTMLParam, got)
+			}
+			return testResponse(200, "application/json", `{"access_token":"custom-html-token","token_type":"bearer","expires_in":3600}`), nil
+		}),
+		OpenBrowser: func(raw string) error {
+			go func() {
+				authorizeURL, err := url.Parse(raw)
+				if err != nil {
+					t.Errorf("parse authorize URL: %v", err)
+					return
+				}
+				if got := authorizeURL.Query().Get(callbackSuccessHTMLParam); got != "" {
+					t.Errorf("%s forwarded to authorize endpoint: %q", callbackSuccessHTMLParam, got)
+					return
+				}
+				if got := authorizeURL.Query().Get(callbackErrorHTMLParam); got != "" {
+					t.Errorf("%s forwarded to authorize endpoint: %q", callbackErrorHTMLParam, got)
+					return
+				}
+				callbackURL, state := mustCallbackURL(t, raw)
+				resp, err := http.Get(fmt.Sprintf("%s/?state=%s&code=good-code", callbackURL, url.QueryEscape(state)))
+				if err != nil {
+					t.Errorf("callback request failed: %v", err)
+					return
+				}
+				resp.Body.Close()
+			}()
+			return nil
+		},
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+	err := h.OnRequest(req, map[string]string{
+		"client_id":              "id1",
+		"authorize_url":          "https://auth.example.com/authorize",
+		"token_url":              "https://auth.example.com/token",
+		"redirect_port":          availablePort(t),
+		callbackSuccessHTMLParam: `<html>success</html>`,
+		callbackErrorHTMLParam:   `<html>error</html>`,
+	})
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer custom-html-token" {
+		t.Fatalf("Authorization = %q, want custom HTML token", got)
+	}
 }
 
 func TestAuthCode_ManualCodeFallback(t *testing.T) {

--- a/internal/auth/oauth_common.go
+++ b/internal/auth/oauth_common.go
@@ -451,10 +451,12 @@ func applyTokenAuthHeader(req *http.Request, params map[string]string) {
 
 func applyOAuthTokenExtraParams(form url.Values, params map[string]string) {
 	for key, value := range extraOAuthParams(params, map[string]bool{
-		"_cache_key":    true,
-		"authorize_url": true,
-		"cache_key":     true,
-		"issuer_url":    true,
+		"_cache_key":             true,
+		"authorize_url":          true,
+		"cache_key":              true,
+		callbackErrorHTMLParam:   true,
+		callbackSuccessHTMLParam: true,
+		"issuer_url":             true,
 		// TODO(openapi-3.2): use oauth2_metadata_url for RFC 8414 metadata
 		// discovery in place of, or alongside, issuer_url.
 		"oauth2_metadata_url": true,

--- a/internal/auth/oauth_common_test.go
+++ b/internal/auth/oauth_common_test.go
@@ -272,11 +272,19 @@ func TestApplyTokenAuthHeaderPercentEncodesBasicCredentials(t *testing.T) {
 func TestApplyOAuthTokenExtraParamsOmitsMetadataURL(t *testing.T) {
 	form := url.Values{}
 	applyOAuthTokenExtraParams(form, map[string]string{
-		"audience":            "https://api.example.com/",
-		"oauth2_metadata_url": "https://auth.example.com/.well-known/oauth-authorization-server",
+		"audience":               "https://api.example.com/",
+		callbackErrorHTMLParam:   "<html>error</html>",
+		callbackSuccessHTMLParam: "<html>success</html>",
+		"oauth2_metadata_url":    "https://auth.example.com/.well-known/oauth-authorization-server",
 	})
 	if got := form.Get("audience"); got != "https://api.example.com/" {
 		t.Fatalf("audience = %q", got)
+	}
+	if got := form.Get(callbackSuccessHTMLParam); got != "" {
+		t.Fatalf("%s should not be forwarded, got %q", callbackSuccessHTMLParam, got)
+	}
+	if got := form.Get(callbackErrorHTMLParam); got != "" {
+		t.Fatalf("%s should not be forwarded, got %q", callbackErrorHTMLParam, got)
 	}
 	if got := form.Get("oauth2_metadata_url"); got != "" {
 		t.Fatalf("oauth2_metadata_url should not be forwarded, got %q", got)

--- a/internal/auth/oauth_device_code.go
+++ b/internal/auth/oauth_device_code.go
@@ -248,6 +248,8 @@ func (h *DeviceCode) requestDeviceAuthorization(ctx context.Context, params map[
 		"_cache_key":               true,
 		"authorize_url":            true,
 		"cache_key":                true,
+		callbackErrorHTMLParam:     true,
+		callbackSuccessHTMLParam:   true,
 		"device_authorization_url": true,
 		"issuer_url":               true,
 		"redirect_port":            true,

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -82,12 +82,14 @@ func (c *CLI) authHandlerFor(ac *config.AuthConfig, opts authHandlerOptions) (au
 		}, nil
 	case "oauth-authorization-code":
 		return &auth.AuthorizationCode{
-			Cache:      auth.NewTokenCache(c.tokenCachePath()),
-			HTTPClient: &http.Client{Transport: c.baseHTTPTransport()},
-			Stderr:     c.Stderr,
-			CanPrompt:  c.canPromptCode(),
-			NoBrowser:  opts.NoBrowser,
-			Verbose:    opts.Verbose,
+			Cache:                auth.NewTokenCache(c.tokenCachePath()),
+			HTTPClient:           &http.Client{Transport: c.baseHTTPTransport()},
+			Stderr:               c.Stderr,
+			CanPrompt:            c.canPromptCode(),
+			NoBrowser:            opts.NoBrowser,
+			Verbose:              opts.Verbose,
+			CallbackSuccessColor: output.ThemeTokenColor("status_2xx"),
+			CallbackFailureColor: output.ThemeTokenColor("status_error"),
 		}, nil
 	case "oauth-device-code":
 		return &auth.DeviceCode{

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rest-sh/restish/v2/internal/auth"
 	"github.com/rest-sh/restish/v2/internal/config"
+	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/rest-sh/restish/v2/internal/spec"
 )
 
@@ -95,5 +97,35 @@ func TestConfiguredCredentialsCountsAuthRef(t *testing.T) {
 	}
 	if got["Missing"] {
 		t.Fatalf("empty credential counted as configured: %#v", got)
+	}
+}
+
+func TestAuthHandlerForOAuthUsesThemeCallbackColors(t *testing.T) {
+	if err := output.SetTheme(output.ThemeEntries{
+		"status_2xx":   "bold #00ff00",
+		"status_error": "italic #ff0000",
+	}); err != nil {
+		t.Fatalf("SetTheme: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := output.SetTheme(nil); err != nil {
+			t.Fatalf("reset theme: %v", err)
+		}
+	})
+
+	c := New()
+	handler, err := c.authHandlerFor(&config.AuthConfig{Type: "oauth-authorization-code"}, authHandlerOptions{})
+	if err != nil {
+		t.Fatalf("authHandlerFor: %v", err)
+	}
+	oauthHandler, ok := handler.(*auth.AuthorizationCode)
+	if !ok {
+		t.Fatalf("handler = %T, want *auth.AuthorizationCode", handler)
+	}
+	if oauthHandler.CallbackSuccessColor != "#00ff00" {
+		t.Fatalf("success color = %q, want #00ff00", oauthHandler.CallbackSuccessColor)
+	}
+	if oauthHandler.CallbackFailureColor != "#ff0000" {
+		t.Fatalf("failure color = %q, want #ff0000", oauthHandler.CallbackFailureColor)
 	}
 }

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -222,6 +222,20 @@ func StyleText(tokenName, text string) string {
 	return out.String()
 }
 
+// ThemeTokenColor returns the active theme's foreground color for tokenName.
+// It returns an empty string when the token is unknown or has no color.
+func ThemeTokenColor(tokenName string) string {
+	token, err := themeTokenType(tokenName)
+	if err != nil {
+		return ""
+	}
+	entry := activeStyle().Get(token)
+	if !entry.Colour.IsSet() {
+		return ""
+	}
+	return entry.Colour.String()
+}
+
 func activeStyle() *chroma.Style {
 	themeStateMu.RLock()
 	style := restishStyle

--- a/internal/output/style_test.go
+++ b/internal/output/style_test.go
@@ -61,6 +61,27 @@ func TestBuildThemeTextToken(t *testing.T) {
 	}
 }
 
+func TestThemeTokenColorUsesActiveTheme(t *testing.T) {
+	if err := SetTheme(ThemeEntries{"status_2xx": "bold #00ff00", "status_error": "italic #ff0000"}); err != nil {
+		t.Fatalf("SetTheme: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := SetTheme(nil); err != nil {
+			t.Fatalf("reset theme: %v", err)
+		}
+	})
+
+	if got, want := ThemeTokenColor("status_2xx"), "#00ff00"; got != want {
+		t.Fatalf("status_2xx color = %q, want %q", got, want)
+	}
+	if got, want := ThemeTokenColor("status_error"), "#ff0000"; got != want {
+		t.Fatalf("status_error color = %q, want %q", got, want)
+	}
+	if got := ThemeTokenColor("not_a_token"); got != "" {
+		t.Fatalf("unknown token color = %q, want empty", got)
+	}
+}
+
 func TestBuildThemeDefaultHeaderKeyCanDifferFromKey(t *testing.T) {
 	style, err := BuildTheme(nil)
 	if err != nil {

--- a/site/content/en/docs/guides/oauth.md
+++ b/site/content/en/docs/guides/oauth.md
@@ -138,6 +138,27 @@ Some providers distinguish `localhost` from `127.0.0.1`. Restish sends
 `localhost` in the authorization request, so exact-match providers must allow
 the `localhost` URL.
 
+The browser callback page uses the active Restish theme. To brand that local
+page, set `callback_success_html` and/or `callback_error_html` on the
+authorization-code profile:
+
+```jsonc
+{
+  "type": "oauth-authorization-code",
+  "params": {
+    "authorize_url": "https://issuer.test/authorize",
+    "token_url": "https://issuer.test/oauth/token",
+    "client_id": "env:CLIENT_ID",
+    "callback_success_html": "<html><body><h1>Signed in</h1><p>You can return to the terminal.</p></body></html>",
+    "callback_error_html": "<html><body><h1>Sign-in failed: $ERROR</h1><p>$DETAILS</p></body></html>"
+  }
+}
+```
+
+Callback HTML supports `$TITLE` and `$DETAILS`; failure HTML also supports
+`$ERROR`. Restish escapes substituted values before inserting them, and does
+not forward callback HTML params to OAuth authorization or token endpoints.
+
 Use `--rsh-no-browser` when browser launch is not possible:
 
 ```bash

--- a/site/content/en/docs/reference/auth.md
+++ b/site/content/en/docs/reference/auth.md
@@ -17,7 +17,7 @@ need different security schemes or alternatives.
 | `http-basic` | `username` | `password` | Sets HTTP Basic auth. If `password` is omitted and prompting is available, Restish prompts. |
 | `api-key` | `in`, `name`, `value` | | Sends an API key in a `header`, `query`, or `cookie`. |
 | `oauth-client-credentials` | `client_id`, `client_secret`, plus `token_url` or `issuer_url` | `auth_method`, `scopes`, provider-specific token params such as `audience` | Fetches and caches a bearer token with the OAuth client credentials flow. |
-| `oauth-authorization-code` | `client_id`, plus `authorize_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, `redirect_port`, `redirect_path`, provider-specific token params | Runs an OAuth authorization-code flow with PKCE and caches the token. |
+| `oauth-authorization-code` | `client_id`, plus `authorize_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, `redirect_port`, `redirect_path`, `callback_success_html`, `callback_error_html`, provider-specific token params | Runs an OAuth authorization-code flow with PKCE and caches the token. |
 | `oauth-device-code` | `client_id`, plus `device_authorization_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, provider-specific token params | Runs the OAuth device-code flow and caches the token. |
 | `external-tool` | `commandline` | `omitbody`, `output` | Runs a local helper that can mutate request headers or URI. |
 
@@ -42,6 +42,14 @@ Some providers distinguish `localhost` from `127.0.0.1` or require loopback IP
 redirects. Restish currently sends `localhost` in the authorization request, so
 providers that perform exact redirect URI matching must allow the `localhost`
 callback URL.
+
+The browser callback page uses the active Restish theme by default.
+`callback_success_html` and `callback_error_html` replace the full success or
+failure page when an OAuth profile needs branded HTML. Callback HTML can
+include `$TITLE` and `$DETAILS`; failure HTML also supports `$ERROR`. Restish
+substitutes those placeholders with escaped callback values. These callback
+HTML params are local UI settings and are not forwarded to OAuth authorization
+or token endpoints.
 
 ## Profile Auth
 


### PR DESCRIPTION
## Summary

- Restore animated OAuth authorization-code callback success and failure pages from v1.
- Use the active Restish theme's `status_2xx` and `status_error` colors for the default callback backgrounds.
- Add optional `callback_success_html` and `callback_error_html` auth params for branded callback pages; error templates support `$ERROR`, `$TITLE`, and `$DETAILS` with escaped substitutions.
- Keep callback HTML params local to Restish so they are not forwarded to OAuth authorization, device authorization, or token endpoints.
- Document the themed defaults and custom HTML params in the OAuth guide/reference.

Credit: adapts the custom callback HTML idea from #330 by @davidlwg for the v2 OAuth implementation.

## Tests

- `env GOCACHE=/tmp/restish-gocache go test ./internal/auth -count=1`
- `env GOCACHE=/tmp/restish-gocache go test ./...`