### PR TITLE
fix(openapi): honor base_url for document servers

### DIFF
--- a/docs/design/034-openapi-implementation-contract.md
+++ b/docs/design/034-openapi-implementation-contract.md
@@ -307,6 +307,11 @@ Server resolution honors OpenAPI server precedence:
 3. document-level `servers`
 4. configured API `base_url`
 
+Document-level servers contribute the generated operation path shape, while the
+configured API/profile `base_url` supplies the default request origin. Path- and
+operation-level servers are treated as explicit routing for that part of the
+API.
+
 `operation_base` overrides OpenAPI servers for generated operation paths. In v2
 it is an absolute path prefix, not a full URL.
 
@@ -319,17 +324,18 @@ applicable OpenAPI server remain errors when the document declares server
 variables, because they cannot affect URL expansion and are usually typos.
 Restish does not expand variables into a Cartesian product of commands or URLs.
 
-Relative server URLs resolve against the configured API `base_url`. Absolute
-server URLs are used directly when they match the configured origin. A
-cross-origin path- or operation-level server is represented in operation
-metadata but may only be used when the API config explicitly allows its origin
-with `allowed_operation_origins`; otherwise the generated command fails with a
-configuration hint instead of falling back to `base_url`. If a matching absolute
-or relative server resolves outside the configured base path while staying on
-the same origin, Restish represents the generated operation path as a relative
-escape so short-name expansion reaches the intended path while keeping the
-selected API profile. If no OpenAPI server matches the configured origin and no
-cross-origin server is present, Restish falls back to `base_url`.
+Relative document server URLs resolve against the configured API `base_url`.
+Absolute document server URLs on another origin keep their path prefix but use
+the configured `base_url` origin. Absolute path- or operation-level server URLs
+are used directly when they match the configured origin. A cross-origin path- or
+operation-level server is represented in operation metadata but may only be used
+when the API config explicitly allows its origin with
+`allowed_operation_origins`, or when a configured `url_overrides` entry rewrites
+the resolved URL before execution; otherwise the generated command fails with a
+configuration hint. If a matching absolute or relative server resolves outside
+the configured base path while staying on the same origin, Restish represents
+the generated operation path as a relative escape so short-name expansion
+reaches the intended path while keeping the selected API profile.
 
 An untrusted spec must not be able to redirect authenticated generated commands
 to another origin by declaring a different server URL. Once an operator has

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -222,11 +222,11 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 	}
 	discCfg := spec.DiscoverConfig{
 		APIName:          apiName,
-		BaseURL:          apiCfg.BaseURL,
+		BaseURL:          effectiveProfileBaseURL(apiCfg, profileName),
 		SpecURL:          apiCfg.SpecURL,
 		SpecFiles:        apiCfg.SpecFiles,
 		CacheDir:         c.specCacheDir(),
-		OperationBase:    apiCfg.OperationBase,
+		OperationBase:    effectiveOperationBase(apiCfg, profileName),
 		ServerVariables:  effectiveServerVariables(apiCfg, profileName),
 		Version:          Version,
 		Transport:        transport,
@@ -247,7 +247,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 		if syncedCfg.SpecURL == "" && len(syncedCfg.SpecFiles) == 0 && apiSpec.SourceURL != "" {
 			syncedCfg.SpecURL = apiSpec.SourceURL
 		}
-		if err := c.configureAllowedOperationOrigins(cmd, apiName, syncedCfg, apiSpec, yes); err != nil {
+		if err := c.configureAllowedOperationOrigins(cmd, apiName, syncedCfg, apiSpec, profileName, yes); err != nil {
 			return err
 		}
 		if !reflect.DeepEqual(apiCfg, syncedCfg) {
@@ -259,8 +259,8 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 		}
 		c.emitGeneratedCommandWarnings(apiName, apiCfg, apiSpec, profileName)
 		opOpts := spec.OperationOptions{
-			BaseURL:         apiCfg.BaseURL,
-			OperationBase:   apiCfg.OperationBase,
+			BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
+			OperationBase:   effectiveOperationBase(apiCfg, profileName),
 			ServerVariables: effectiveServerVariables(apiCfg, profileName),
 		}
 		if err := spec.StoreSpecInCache(c.specCacheDir(), apiName, Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
@@ -385,7 +385,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 		apiCfg.SpecURL = apiSpec.SourceURL
 	}
 	if apiSpec != nil {
-		if err := c.configureAllowedOperationOrigins(cmd, apiName, apiCfg, apiSpec, yes); err != nil {
+		if err := c.configureAllowedOperationOrigins(cmd, apiName, apiCfg, apiSpec, "default", yes); err != nil {
 			return err
 		}
 	}
@@ -416,8 +416,8 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 	if apiSpec != nil {
 		c.emitGeneratedCommandWarnings(apiName, apiCfg, apiSpec, "default")
 		opOpts := spec.OperationOptions{
-			BaseURL:         apiCfg.BaseURL,
-			OperationBase:   apiCfg.OperationBase,
+			BaseURL:         effectiveProfileBaseURL(apiCfg, "default"),
+			OperationBase:   effectiveOperationBase(apiCfg, "default"),
 			ServerVariables: effectiveServerVariables(apiCfg, "default"),
 		}
 		if err := spec.StoreSpecInCache(c.specCacheDir(), apiName, Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
@@ -455,15 +455,18 @@ func connectedOperationCount(apiSpec *spec.APISpec, apiCfg *config.APIConfig) in
 	if apiSpec == nil {
 		return 0
 	}
-	ops, err := apiSpec.Operations(spec.OperationOptions{BaseURL: apiCfg.BaseURL, OperationBase: apiCfg.OperationBase})
+	ops, err := apiSpec.Operations(spec.OperationOptions{
+		BaseURL:       effectiveProfileBaseURL(apiCfg, "default"),
+		OperationBase: effectiveOperationBase(apiCfg, "default"),
+	})
 	if err != nil {
 		return 0
 	}
 	return len(ops)
 }
 
-func (c *CLI) configureAllowedOperationOrigins(cmd *cobra.Command, apiName string, apiCfg *config.APIConfig, apiSpec *spec.APISpec, yes bool) error {
-	origins := discoveredCrossOriginOperationServers(apiSpec, apiCfg)
+func (c *CLI) configureAllowedOperationOrigins(cmd *cobra.Command, apiName string, apiCfg *config.APIConfig, apiSpec *spec.APISpec, profileName string, yes bool) error {
+	origins := discoveredCrossOriginOperationServers(apiSpec, apiCfg, profileName)
 	if len(origins) == 0 {
 		return nil
 	}
@@ -490,14 +493,14 @@ func (c *CLI) configureAllowedOperationOrigins(cmd *cobra.Command, apiName strin
 	return nil
 }
 
-func discoveredCrossOriginOperationServers(apiSpec *spec.APISpec, apiCfg *config.APIConfig) []string {
+func discoveredCrossOriginOperationServers(apiSpec *spec.APISpec, apiCfg *config.APIConfig, profileName string) []string {
 	if apiSpec == nil || apiCfg == nil {
 		return nil
 	}
 	ops, err := apiSpec.Operations(spec.OperationOptions{
-		BaseURL:         apiCfg.BaseURL,
-		OperationBase:   apiCfg.OperationBase,
-		ServerVariables: effectiveServerVariables(apiCfg, "default"),
+		BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
+		OperationBase:   effectiveOperationBase(apiCfg, profileName),
+		ServerVariables: effectiveServerVariables(apiCfg, profileName),
 	})
 	if err != nil {
 		return nil
@@ -508,6 +511,9 @@ func discoveredCrossOriginOperationServers(apiSpec *spec.APISpec, apiCfg *config
 		if op.OperationServer == "" {
 			continue
 		}
+		if operationServerURLOverridden(op, apiCfg, profileName) {
+			continue
+		}
 		origin := operationServerOrigin(op.OperationServer)
 		if !seen[origin] {
 			seen[origin] = true
@@ -516,6 +522,12 @@ func discoveredCrossOriginOperationServers(apiSpec *spec.APISpec, apiCfg *config
 	}
 	sort.Strings(origins)
 	return origins
+}
+
+func operationServerURLOverridden(op spec.Operation, apiCfg *config.APIConfig, profileName string) bool {
+	rawURL := strings.TrimRight(op.OperationServer, "/") + op.Path
+	_, rewritten, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(apiCfg, profileName))
+	return err == nil && rewritten
 }
 
 func suggestedAllowedOperationOrigins(origins, existing []string) []string {

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -787,7 +787,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	var s *spec.APISpec
 	var err error
 	if forceRefresh {
-		s, err = c.discoverSpec(ctx, apiName)
+		s, err = c.discoverSpecForProfile(ctx, apiName, profileName, true, 0)
 	} else {
 		s, err = spec.LoadFromCache(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, c.loaders)
 	}
@@ -797,10 +797,10 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 		}
 		s, err = spec.Discover(ctx, spec.DiscoverConfig{
 			APIName:         apiName,
-			BaseURL:         apiCfg.BaseURL,
+			BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
 			SpecFiles:       apiCfg.SpecFiles,
 			CacheDir:        c.specCacheDir(),
-			OperationBase:   apiCfg.OperationBase,
+			OperationBase:   effectiveOperationBase(apiCfg, profileName),
 			ServerVariables: effectiveServerVariables(apiCfg, profileName),
 			Version:         Version,
 			ForceRefresh:    true,

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -780,6 +780,55 @@ func TestAPISyncUpdatesAllowedOperationOriginsAndPreservesProfiles(t *testing.T)
 	}
 }
 
+func TestAPISyncDoesNotPromptForOverriddenOperationServer(t *testing.T) {
+	cfgFile := writeAPIConfigObject(t, "files", &config.APIConfig{
+		BaseURL: "https://api.example.com",
+		SpecURL: "https://api.example.com/openapi.json",
+		URLOverrides: map[string]string{
+			"https://upload.example.com/v2": "http://localhost:8080/upload",
+		},
+	})
+	specBody := `{
+  "openapi": "3.1.0",
+  "info": {"title": "Files", "version": "1.0"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/files": {
+      "post": {
+        "operationId": "uploadFile",
+        "servers": [{"url": "https://upload.example.com/v2"}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() == "https://api.example.com/openapi.json" {
+			return textResponse(200, "application/json", specBody, r), nil
+		}
+		return textResponse(404, "text/plain", "not found", r), nil
+	})
+
+	if err := c.Run([]string{"restish", "api", "sync", "files"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+
+	written, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load written config: %v", err)
+	}
+	if got := written.APIs["files"].AllowedOperationOrigins; len(got) != 0 {
+		t.Fatalf("allowed_operation_origins = %#v, want none when url_overrides covers operation server", got)
+	}
+	if strings.Contains(out.String(), "cross-origin operation servers ignored") || strings.Contains(out.String(), "allowed_operation_origins") {
+		t.Fatalf("unexpected cross-origin warning with url_overrides:\n%s", out.String())
+	}
+}
+
 func TestAPISyncPersistsDiscoveredSpecURLAndPreservesProfiles(t *testing.T) {
 	cfgFile := writeAPIConfigObject(t, "myapi", &config.APIConfig{
 		BaseURL: "https://api.example.com",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -450,11 +450,11 @@ func (c *CLI) discoverSpecForProfile(ctx context.Context, apiName, profileName s
 	}
 	cfg := spec.DiscoverConfig{
 		APIName:          apiName,
-		BaseURL:          api.BaseURL,
+		BaseURL:          effectiveProfileBaseURL(api, profileName),
 		SpecURL:          api.SpecURL,
 		SpecFiles:        api.SpecFiles,
 		CacheDir:         c.specCacheDir(),
-		OperationBase:    api.OperationBase,
+		OperationBase:    effectiveOperationBase(api, profileName),
 		ServerVariables:  effectiveServerVariables(api, profileName),
 		Version:          Version,
 		Transport:        transport,
@@ -604,8 +604,8 @@ func (c *CLI) Run(args []string) error {
 	for _, apiName := range c.generatedAPINamesForScan(argScan, cfg) {
 		apiCfg := cfg.APIs[apiName]
 		opOpts := spec.OperationOptions{
-			BaseURL:         apiCfg.BaseURL,
-			OperationBase:   apiCfg.OperationBase,
+			BaseURL:         effectiveProfileBaseURL(apiCfg, startupProfile),
+			OperationBase:   effectiveOperationBase(apiCfg, startupProfile),
 			ServerVariables: effectiveServerVariables(apiCfg, startupProfile),
 		}
 		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opOpts, true); ok {
@@ -855,8 +855,8 @@ func (c *CLI) refreshStaleGeneratedMetadataForCommand(ctx context.Context, scan 
 		return
 	}
 	opts := spec.OperationOptions{
-		BaseURL:         apiCfg.BaseURL,
-		OperationBase:   apiCfg.OperationBase,
+		BaseURL:         effectiveProfileBaseURL(apiCfg, scan.ProfileName),
+		OperationBase:   effectiveOperationBase(apiCfg, scan.ProfileName),
 		ServerVariables: effectiveServerVariables(apiCfg, scan.ProfileName),
 	}
 	_, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), scan.FirstCommand, Version, apiCfg.SpecFiles, opts, true)
@@ -930,6 +930,31 @@ func effectiveServerVariables(apiCfg *config.APIConfig, profileName string) map[
 				out = map[string]string{}
 			}
 			out[key] = value
+		}
+	}
+	return out
+}
+
+func effectiveURLOverrides(apiCfg *config.APIConfig, profileName string) map[string]string {
+	if apiCfg == nil {
+		return nil
+	}
+	var out map[string]string
+	for source, destination := range apiCfg.URLOverrides {
+		if out == nil {
+			out = map[string]string{}
+		}
+		out[source] = destination
+	}
+	if profileName == "" {
+		profileName = "default"
+	}
+	if prof := apiCfg.Profiles[profileName]; prof != nil {
+		for source, destination := range prof.URLOverrides {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[source] = destination
 		}
 	}
 	return out

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -221,8 +221,8 @@ func (c *CLI) completeOperationURLs(cmd *cobra.Command, method string, _ []strin
 
 func (c *CLI) completionOperationSet(cmd *cobra.Command, apiName string, apiCfg *config.APIConfig, profileName string) (spec.OperationSet, bool) {
 	opOpts := spec.OperationOptions{
-		BaseURL:         apiCfg.BaseURL,
-		OperationBase:   apiCfg.OperationBase,
+		BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
+		OperationBase:   effectiveOperationBase(apiCfg, profileName),
 		ServerVariables: effectiveServerVariables(apiCfg, profileName),
 	}
 	if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opOpts, true); ok {

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -37,8 +37,8 @@ const (
 // Returns nil when the spec cannot be built into a v3 model.
 func (c *CLI) buildAPICommand(apiName string, apiCfg *config.APIConfig, s *spec.APISpec) *cobra.Command {
 	set, err := s.OperationSet(spec.OperationOptions{
-		BaseURL:         apiCfg.BaseURL,
-		OperationBase:   apiCfg.OperationBase,
+		BaseURL:         effectiveProfileBaseURL(apiCfg, "default"),
+		OperationBase:   effectiveOperationBase(apiCfg, "default"),
 		ServerVariables: effectiveServerVariables(apiCfg, "default"),
 	})
 	return c.buildAPICommandFromOperationResult(apiName, apiCfg, set, err)
@@ -1450,10 +1450,14 @@ func (c *CLI) runGeneratedOp(
 		if err != nil {
 			return err
 		}
-		if !config.OperationOriginAllowed(operationServer, apiCfg.AllowedOperationOrigins) {
+		rawURL = strings.TrimRight(operationServer, "/") + path
+		_, rewritten, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(apiCfg, c.profileFromCmd(cmd)))
+		if err != nil {
+			return fmt.Errorf("url_overrides: %w", err)
+		}
+		if !rewritten && !config.OperationOriginAllowed(operationServer, apiCfg.AllowedOperationOrigins) {
 			return fmt.Errorf("operation server %s is outside API base_url and is not allowed; add allowed_operation_origins[]: %s", operationServerOrigin(operationServer), suggestedOperationOrigin(operationServer))
 		}
-		rawURL = strings.TrimRight(operationServer, "/") + path
 	} else if operationBase != "" {
 		resolvedBase, err := config.ResolveOperationBaseURL(baseURL, operationBase)
 		if err != nil {

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -798,6 +798,44 @@ func TestGenericURLAppliesMatchedOperationAuth(t *testing.T) {
 	}
 }
 
+func TestGenericURLMatchesOperationAuthBeforeURLOverride(t *testing.T) {
+	var gotAuth, gotPath string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(target.Close)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Test API",
+			openAPISecuritySchemes(`"BasicAuth":{"type":"http","scheme":"basic"}`),
+			openAPIPaths(openAPIGet("/auth/basic", "getAuthBasic", `"security":[{"BasicAuth":[]}]`)))
+	})
+	baseURL := env.baseURL(t)
+	apiCfg := testAPIConfig(baseURL, profileCredentials(map[string]*config.CredentialConfig{
+		"BasicAuth": testCredential(basicAuth("alice", "secret")),
+	}))
+	apiCfg.URLOverrides = map[string]string{
+		baseURL + "/": target.URL + "/local/",
+	}
+	env.writeAPIConfig(t, apiCfg)
+
+	c := env.newCLI()
+	if err := c.Run([]string{"restish", "tapi/auth/basic"}); err != nil {
+		t.Fatalf("short URL request failed: %v", err)
+	}
+	if gotPath != "/local/auth/basic" {
+		t.Fatalf("request path = %q, want /local/auth/basic", gotPath)
+	}
+	if !strings.HasPrefix(gotAuth, "Basic ") {
+		t.Fatalf("Authorization = %q, want Basic auth", gotAuth)
+	}
+}
+
 func TestGenericURLMatchedSecurityEmptySuppressesProfileAuth(t *testing.T) {
 	var gotAuth string
 	mux := http.NewServeMux()
@@ -4341,6 +4379,71 @@ func TestGeneratedCommandsResolveRootRelativeServerURLEscapingAPIBase(t *testing
 	}
 }
 
+func TestGeneratedCommandsUseBaseOriginForDocumentServerPath(t *testing.T) {
+	var lastHost, lastPath string
+	mux := http.NewServeMux()
+	specBody := `{
+  "openapi": "3.1.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "servers": [{"url": "https://prod.example.com/v1"}],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, specBody)
+	})
+	mux.HandleFunc("/v1/items", func(w http.ResponseWriter, r *http.Request) {
+		lastHost = r.Host
+		lastPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfgData, _ := json.Marshal(&config.Config{
+		APIs: map[string]*config.APIConfig{
+			"tapi": {BaseURL: srv.URL, SpecURL: srv.URL + "/openapi.json"},
+		},
+	})
+	cfgFile := filepath.Join(t.TempDir(), "restish.json")
+	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cacheDir := t.TempDir()
+
+	c := cli.New()
+	c.Stdin = strings.NewReader("")
+	c.Stdout = io.Discard
+	c.Stderr = io.Discard
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	if err := c.Run([]string{"restish", "api", "sync", "tapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+
+	c = cli.New()
+	c.Stdin = strings.NewReader("")
+	c.Stdout = io.Discard
+	c.Stderr = io.Discard
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	if err := c.Run([]string{"restish", "tapi", "list-items"}); err != nil {
+		t.Fatalf("list-items failed: %v", err)
+	}
+	if wantHost := strings.TrimPrefix(srv.URL, "http://"); lastHost != wantHost || lastPath != "/v1/items" {
+		t.Fatalf("request = %s %s, want %s /v1/items", lastHost, lastPath, wantHost)
+	}
+}
+
 func TestGeneratedCommandsResolveOperationBasePathAgainstBaseURL(t *testing.T) {
 	var lastPath string
 	mux := http.NewServeMux()
@@ -4798,6 +4901,71 @@ func TestGeneratedCommandCrossOriginOperationServerRequiresAllow(t *testing.T) {
 	}
 	if gotInferencePath != "/v1/models" {
 		t.Fatalf("inference path = %q, want /v1/models", gotInferencePath)
+	}
+}
+
+func TestGeneratedCommandCrossOriginOperationServerCanUseURLOverride(t *testing.T) {
+	var gotUploadPath string
+	upload := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUploadPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(upload.Close)
+
+	controlMux := http.NewServeMux()
+	control := httptest.NewServer(controlMux)
+	t.Cleanup(control.Close)
+	specBody := fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Control API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/files": {
+      "post": {
+        "operationId": "uploadFile",
+        "servers": [{"url": "https://upload.example.com/v2"}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, control.URL)
+	controlMux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, specBody)
+	})
+	controlMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	cfgData, _ := json.Marshal(&config.Config{APIs: map[string]*config.APIConfig{
+		"tapi": {
+			BaseURL: control.URL,
+			URLOverrides: map[string]string{
+				"https://upload.example.com/v2": upload.URL + "/local",
+			},
+		},
+	}})
+	cfgFile := filepath.Join(t.TempDir(), "restish.json")
+	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cacheDir := t.TempDir()
+	newCLI := func() *cli.CLI {
+		c := cli.New()
+		c.Stdin = strings.NewReader("")
+		c.Stdout = io.Discard
+		c.Stderr = io.Discard
+		c.Hooks().ConfigPath = cfgFile
+		c.Hooks().SpecCachePath = cacheDir
+		return c
+	}
+	if err := newCLI().Run([]string{"restish", "api", "sync", "tapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if err := newCLI().Run([]string{"restish", "tapi", "upload-file"}); err != nil {
+		t.Fatalf("upload-file with url override: %v", err)
+	}
+	if gotUploadPath != "/local/files" {
+		t.Fatalf("upload path = %q, want /local/files", gotUploadPath)
 	}
 }
 

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rest-sh/restish/v2/internal/config"
 	"github.com/rest-sh/restish/v2/internal/hypermedia"
 	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/rest-sh/restish/v2/internal/request"
@@ -92,6 +93,13 @@ func (c *CLI) prepareRequest(
 			opts.OnRequest = callbacks.OnRequest
 			opts.OnUnauthorized = callbacks.OnUnauthorized
 		}
+	}
+	if apiName != "" {
+		rewritten, _, err := config.ApplyURLOverrides(rawURL, effectiveURLOverrides(c.cfg.APIs[apiName], profileName))
+		if err != nil {
+			return nil, fmt.Errorf("url_overrides: %w", err)
+		}
+		rawURL = rewritten
 	}
 	opts, err = c.resolveTLSSigner(opts)
 	if err != nil {

--- a/internal/cli/request_exec_test.go
+++ b/internal/cli/request_exec_test.go
@@ -111,6 +111,51 @@ func TestPrepareRequestBuildsSharedRequestState(t *testing.T) {
 	}
 }
 
+func TestPrepareRequestAppliesURLOverridesAfterAPIExpansion(t *testing.T) {
+	c := New()
+	c.cfg = &config.Config{
+		APIs: map[string]*config.APIConfig{
+			"svc": {
+				BaseURL: "https://api.example.com",
+				URLOverrides: map[string]string{
+					"https://api.example.com/": "http://localhost:8080/root/",
+				},
+				Profiles: map[string]*config.ProfileConfig{
+					"local": {
+						URLOverrides: map[string]string{
+							"https://api.example.com/": "http://localhost:9090/profile/",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prepared, err := c.prepareRequest(
+		context.Background(),
+		"GET",
+		"svc/items",
+		"local",
+		request.Options{},
+		nil,
+		nil,
+		false,
+		authHandlerOptions{},
+		nil,
+		false,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("prepareRequest() error = %v", err)
+	}
+	if got, want := prepared.rawURL, "http://localhost:9090/profile/items"; got != want {
+		t.Fatalf("rawURL = %q, want %q", got, want)
+	}
+	if got, want := prepared.apiName, "svc"; got != want {
+		t.Fatalf("apiName = %q, want %q", got, want)
+	}
+}
+
 func TestPrepareRequestBypassesCacheBeforeTransportForUnnamespacedAuth(t *testing.T) {
 	c := New()
 	prepared, err := c.prepareRequest(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -83,6 +84,10 @@ type APIConfig struct {
 	// Values are used for generated operation path resolution; enum values from
 	// remote specs are never expanded eagerly.
 	ServerVariables map[string]string `json:"server_variables,omitempty"`
+	// URLOverrides rewrites resolved request URL prefixes before execution.
+	// It is useful when an OpenAPI document names canonical servers but this
+	// profile should route requests to staging, local, or test endpoints.
+	URLOverrides map[string]string `json:"url_overrides,omitempty"`
 	// AllowedOperationOrigins permits generated commands to use operation- or
 	// path-level OpenAPI servers on origins outside base_url.
 	AllowedOperationOrigins []string `json:"allowed_operation_origins,omitempty"`
@@ -129,6 +134,9 @@ type ProfileConfig struct {
 	// ServerVariables overrides API-level OpenAPI server URL variables for this
 	// profile when generating operation paths.
 	ServerVariables map[string]string `json:"server_variables,omitempty"`
+	// URLOverrides overrides or extends API-level URL prefix rewrites for this
+	// profile.
+	URLOverrides map[string]string `json:"url_overrides,omitempty"`
 	// Auth holds authentication configuration for this profile.
 	Auth *AuthConfig `json:"auth,omitempty"`
 	// AuthRef names a top-level auth_profiles entry to use for this profile.
@@ -364,6 +372,9 @@ func Validate(cfg *Config) error {
 		if err := ValidateRetryMaxWait(api.RetryMaxWait); err != nil {
 			return fmt.Errorf("apis.%s.retry_max_wait: %w", name, err)
 		}
+		if err := ValidateURLOverrides(api.URLOverrides); err != nil {
+			return fmt.Errorf("apis.%s.url_overrides: %w", name, err)
+		}
 		for i, origin := range api.AllowedOperationOrigins {
 			if err := ValidateOperationOriginPattern(origin); err != nil {
 				return fmt.Errorf("apis.%s.allowed_operation_origins[%d]: %w", name, i, err)
@@ -389,6 +400,9 @@ func Validate(cfg *Config) error {
 				if err := ValidateBaseURLForOperationBase(baseURL); err != nil {
 					return fmt.Errorf("apis.%s.profiles.%s.base_url: %w", name, profileName, err)
 				}
+			}
+			if err := ValidateURLOverrides(prof.URLOverrides); err != nil {
+				return fmt.Errorf("apis.%s.profiles.%s.url_overrides: %w", name, profileName, err)
 			}
 			if prof.Auth != nil && prof.AuthRef != "" {
 				return fmt.Errorf("apis.%s.profiles.%s: auth and auth_ref are mutually exclusive", name, profileName)
@@ -475,6 +489,147 @@ func ValidateRetryMaxWait(raw string) error {
 	if d <= 0 {
 		return fmt.Errorf("must be greater than 0")
 	}
+	return nil
+}
+
+// ValidateURLOverrides enforces the URL prefix rewrite contract.
+func ValidateURLOverrides(overrides map[string]string) error {
+	for source, destination := range overrides {
+		if err := validateURLOverrideEndpoint(source); err != nil {
+			return fmt.Errorf("%q: %w", source, err)
+		}
+		if err := validateURLOverrideEndpoint(destination); err != nil {
+			return fmt.Errorf("%q destination: %w", source, err)
+		}
+	}
+	return nil
+}
+
+func validateURLOverrideEndpoint(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return fmt.Errorf("must be an absolute http/https URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("must not include userinfo, query, or fragment")
+	}
+	return nil
+}
+
+// ApplyURLOverrides rewrites rawURL when it matches a configured URL prefix.
+// The longest matching source prefix wins. Query strings and fragments from the
+// request URL are preserved.
+func ApplyURLOverrides(rawURL string, overrides map[string]string) (string, bool, error) {
+	if len(overrides) == 0 {
+		return rawURL, false, nil
+	}
+	target, err := url.Parse(rawURL)
+	if err != nil || !target.IsAbs() || target.Host == "" {
+		return rawURL, false, nil
+	}
+	if err := ValidateURLOverrides(overrides); err != nil {
+		return rawURL, false, err
+	}
+	sources := make([]string, 0, len(overrides))
+	for source := range overrides {
+		sources = append(sources, source)
+	}
+	sort.Slice(sources, func(i, j int) bool {
+		left := normalizedOverrideSource(sources[i])
+		right := normalizedOverrideSource(sources[j])
+		if len(left) != len(right) {
+			return len(left) > len(right)
+		}
+		return left < right
+	})
+	for _, source := range sources {
+		src, _ := url.Parse(source)
+		if !urlOverrideMatches(target, src) {
+			continue
+		}
+		dst, _ := url.Parse(overrides[source])
+		rewritten := *dst
+		rewritten.RawQuery = target.RawQuery
+		rewritten.Fragment = target.Fragment
+		if err := setURLOverridePath(&rewritten, joinURLOverridePath(dst.EscapedPath(), overrideSuffixPath(target.EscapedPath(), src.EscapedPath()))); err != nil {
+			return rawURL, false, err
+		}
+		return rewritten.String(), true, nil
+	}
+	return rawURL, false, nil
+}
+
+func normalizedOverrideSource(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	p := u.EscapedPath()
+	if p == "" {
+		return "/"
+	}
+	return strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host) + strings.TrimRight(p, "/")
+}
+
+func urlOverrideMatches(target, source *url.URL) bool {
+	if !strings.EqualFold(target.Scheme, source.Scheme) || !strings.EqualFold(target.Host, source.Host) {
+		return false
+	}
+	sourcePath := source.EscapedPath()
+	if sourcePath == "" {
+		sourcePath = "/"
+	}
+	targetPath := target.EscapedPath()
+	if targetPath == "" {
+		targetPath = "/"
+	}
+	sourcePath = strings.TrimRight(sourcePath, "/")
+	if sourcePath == "" {
+		return true
+	}
+	return targetPath == sourcePath || strings.HasPrefix(targetPath, sourcePath+"/")
+}
+
+func overrideSuffixPath(targetPath, sourcePath string) string {
+	if targetPath == "" {
+		targetPath = "/"
+	}
+	if sourcePath == "" {
+		sourcePath = "/"
+	}
+	sourcePath = strings.TrimRight(sourcePath, "/")
+	if sourcePath == "" {
+		if targetPath == "/" {
+			return ""
+		}
+		return targetPath
+	}
+	return strings.TrimPrefix(targetPath, sourcePath)
+}
+
+func joinURLOverridePath(basePath, suffix string) string {
+	if suffix == "" {
+		if basePath == "" {
+			return ""
+		}
+		return basePath
+	}
+	if basePath == "" || basePath == "/" {
+		return suffix
+	}
+	return strings.TrimRight(basePath, "/") + suffix
+}
+
+func setURLOverridePath(u *url.URL, escapedPath string) error {
+	path, err := url.PathUnescape(escapedPath)
+	if err != nil {
+		return err
+	}
+	u.Path = path
+	u.RawPath = escapedPath
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -910,6 +910,79 @@ func TestAllowedOperationOriginsValidationAndMatching(t *testing.T) {
 	}
 }
 
+func TestURLOverridesValidationAndRewrite(t *testing.T) {
+	path := writeConfig(t, `{
+  "apis": {
+    "example": {
+      "base_url": "https://api.example.com",
+      "url_overrides": {
+        "https://api.example.com/v1": "http://localhost:8080/root",
+        "https://api.example.com/": "https://fallback.example.com/"
+      },
+      "profiles": {
+        "local": {
+          "url_overrides": {
+            "https://upload.example.com/": "http://localhost:9090/"
+          }
+        }
+      }
+    }
+  }
+}`)
+	if _, err := config.Load(path); err != nil {
+		t.Fatalf("expected url_overrides to load: %v", err)
+	}
+
+	overrides := map[string]string{
+		"https://api.example.com/v1": "http://localhost:8080/root",
+		"https://api.example.com/":   "https://fallback.example.com/",
+	}
+	got, matched, err := config.ApplyURLOverrides("https://api.example.com/v1/items?limit=1", overrides)
+	if err != nil {
+		t.Fatalf("ApplyURLOverrides: %v", err)
+	}
+	if !matched || got != "http://localhost:8080/root/items?limit=1" {
+		t.Fatalf("rewrite = %q, %v; want localhost v1 rewrite", got, matched)
+	}
+	got, matched, err = config.ApplyURLOverrides("https://api.example.com/v10/items", overrides)
+	if err != nil {
+		t.Fatalf("ApplyURLOverrides v10: %v", err)
+	}
+	if !matched || got != "https://fallback.example.com/v10/items" {
+		t.Fatalf("rewrite = %q, %v; want fallback root rewrite", got, matched)
+	}
+	got, matched, err = config.ApplyURLOverrides("https://api.example.com/v1/items/a%2Fb?ref=x%2Fy", overrides)
+	if err != nil {
+		t.Fatalf("ApplyURLOverrides escaped path: %v", err)
+	}
+	if !matched || got != "http://localhost:8080/root/items/a%2Fb?ref=x%2Fy" {
+		t.Fatalf("rewrite = %q, %v; want escaped path preserved", got, matched)
+	}
+	got, matched, err = config.ApplyURLOverrides("https://api.example.com/v1/a%2Fb", map[string]string{
+		"https://api.example.com/v1": "http://localhost:8080/root%2Fprefix",
+	})
+	if err != nil {
+		t.Fatalf("ApplyURLOverrides escaped destination: %v", err)
+	}
+	if !matched || got != "http://localhost:8080/root%2Fprefix/a%2Fb" {
+		t.Fatalf("rewrite = %q, %v; want escaped destination path preserved", got, matched)
+	}
+
+	for _, raw := range []string{`"api.example.com/"`, `"ftp://api.example.com/"`, `"https://api.example.com/?x=1"`} {
+		path := writeConfig(t, fmt.Sprintf(`{
+  "apis": {
+    "example": {
+      "base_url": "https://api.example.com",
+      "url_overrides": {%s: "https://override.example.com/"}
+    }
+  }
+}`, raw))
+		if _, err := config.Load(path); err == nil {
+			t.Fatalf("expected invalid url_overrides entry %s", raw)
+		}
+	}
+}
+
 func TestLoadValidatesCommandLayout(t *testing.T) {
 	for _, layout := range []string{"", "flat", "tags"} {
 		t.Run("valid_"+layout, func(t *testing.T) {

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -250,13 +250,16 @@ func (s *APISpec) buildOperations(opts OperationOptions) ([]Operation, []string,
 				continue
 			}
 			servers := model.Model.Servers
+			scope := serverScopeDocument
 			if len(pathItem.Servers) > 0 {
 				servers = pathItem.Servers
+				scope = serverScopePath
 			}
 			if len(mo.Op.Servers) > 0 {
 				servers = mo.Op.Servers
+				scope = serverScopeOperation
 			}
-			basePath, operationServer, serverWarnings, err := deriveBasePath(opts.BaseURL, opts.OperationBase, servers, opts.ServerVariables)
+			basePath, operationServer, serverWarnings, err := deriveBasePath(opts.BaseURL, opts.OperationBase, servers, opts.ServerVariables, scope)
 			if err != nil {
 				return nil, nil, fmt.Errorf("derive base path for %s %s: %w", mo.Method, rawPath, err)
 			}
@@ -500,11 +503,19 @@ func isIgnoredOpenAPIHeaderParameter(p *v3.Parameter) bool {
 		strings.EqualFold(p.Name, "Authorization")
 }
 
-// deriveBasePath computes the path prefix to prepend to all operation paths.
-// When operationBase is set, no prefix is needed (the URL prefix is resolved
-// from baseURL+operationBase at call time). Otherwise, the spec's servers[] list is
-// inspected for a URL that resolves to the same scheme+host as baseURL.
-func deriveBasePath(baseURL, operationBase string, servers []*v3.Server, serverVariables map[string]string) (string, string, []string, error) {
+type serverScope int
+
+const (
+	serverScopeDocument serverScope = iota
+	serverScopePath
+	serverScopeOperation
+)
+
+// deriveBasePath computes the path prefix to prepend to an operation path.
+// When operationBase is set, no prefix is needed because baseURL+operationBase
+// is resolved at call time. Document-level servers only contribute a path
+// prefix; path- and operation-level servers may also select a different origin.
+func deriveBasePath(baseURL, operationBase string, servers []*v3.Server, serverVariables map[string]string, scope serverScope) (string, string, []string, error) {
 	if operationBase != "" || len(servers) == 0 {
 		return "", "", nil, nil
 	}
@@ -519,6 +530,11 @@ func deriveBasePath(baseURL, operationBase string, servers []*v3.Server, serverV
 	}
 	resolutionBase := serverResolutionBase(location)
 	var firstCrossOrigin string
+
+	if scope == serverScopeDocument {
+		basePath := deriveDocumentServerBasePath(location, resolutionBase, servers, serverVariables)
+		return basePath, "", warnings, nil
+	}
 
 	for _, server := range servers {
 		if server == nil {
@@ -549,6 +565,32 @@ func deriveBasePath(baseURL, operationBase string, servers []*v3.Server, serverV
 
 	// No matching server found — fall back to the configured API base URL.
 	return "", "", warnings, nil
+}
+
+func deriveDocumentServerBasePath(location, resolutionBase *url.URL, servers []*v3.Server, serverVariables map[string]string) string {
+	var firstResolved *url.URL
+	for _, server := range servers {
+		if server == nil {
+			continue
+		}
+		endpoint := resolveServerURLVariables(server, serverVariables)
+		parsed, err := url.Parse(endpoint)
+		if err != nil {
+			continue
+		}
+		resolved := resolutionBase.ResolveReference(parsed)
+		if firstResolved == nil {
+			copy := *resolved
+			firstResolved = &copy
+		}
+		if resolved.Scheme == location.Scheme && resolved.Host == location.Host {
+			return strings.TrimSuffix(relativeServerBasePath(location.Path, resolved.Path), "/")
+		}
+	}
+	if firstResolved == nil {
+		return ""
+	}
+	return strings.TrimSuffix(relativeServerBasePath(location.Path, firstResolved.Path), "/")
 }
 
 func serverResolutionBase(location *url.URL) *url.URL {

--- a/internal/spec/operation_test.go
+++ b/internal/spec/operation_test.go
@@ -778,7 +778,7 @@ func requireCredential(t *testing.T, op Operation, want [][]CredentialRequiremen
 	}
 }
 
-func TestOperationsAbsoluteNonMatchingServerRecordsOperationServer(t *testing.T) {
+func TestOperationsDocumentServerUsesBaseOriginAndServerPath(t *testing.T) {
 	raw := `openapi: "3.1.0"
 info:
   title: Test
@@ -789,6 +789,42 @@ paths:
   /items:
     get:
       operationId: listItems
+      responses:
+        "200":
+          description: OK`
+	loaded, err := load("application/yaml", []byte(raw), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ops, err := loaded.Operations(OperationOptions{BaseURL: "https://api.example.com/root"})
+	if err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("len(ops) = %d, want 1", len(ops))
+	}
+	if got := ops[0].Path; got != "/../v2/items" {
+		t.Fatalf("operation path = %q, want /../v2/items", got)
+	}
+	if got := ops[0].OperationServer; got != "" {
+		t.Fatalf("operation server = %q, want none for document-level server", got)
+	}
+}
+
+func TestOperationsOperationLevelAbsoluteNonMatchingServerRecordsOperationServer(t *testing.T) {
+	raw := `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: listItems
+      servers:
+        - url: https://other.example.com/v2
       responses:
         "200":
           description: OK`

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -86,6 +86,9 @@ restish config show -o json
       "operation_base": "/",
       "command_layout": "flat",
       "server_variables": {},
+      "url_overrides": {
+        "https://api.vendor.test/": "https://staging.vendor.test/"
+      },
       "allowed_operation_origins": [],
       "retry_max_wait": "30s",
       "pagination": {
@@ -138,6 +141,7 @@ APIConfig holds per-API configuration.
 | `operation_base` | `OperationBase` | `string` | no | OperationBase, when set, is an absolute path resolved against base_url for paths generated from OpenAPI operations. Useful when operation paths should escape or replace a sub-path in base_url. |
 | `command_layout` | `CommandLayout` | `string` | no | CommandLayout controls how generated operations are arranged under the API command. Empty or "flat" keeps one flat command namespace; "tags" groups operations under first-tag subcommands. |
 | `server_variables` | `ServerVariables` | `map[string]string` | no | ServerVariables supplies explicit values for OpenAPI server URL variables. Values are used for generated operation path resolution; enum values from remote specs are never expanded eagerly. |
+| `url_overrides` | `URLOverrides` | `map[string]string` | no | URLOverrides rewrites resolved request URL prefixes before execution. It is useful when an OpenAPI document names canonical servers but this profile should route requests to staging, local, or test endpoints. |
 | `allowed_operation_origins` | `AllowedOperationOrigins` | `[]string` | no | AllowedOperationOrigins permits generated commands to use operation- or path-level OpenAPI servers on origins outside base_url. |
 | `profiles` | `Profiles` | `map[string]*ProfileConfig` | no | Profiles is a map of profile name to profile configuration. |
 | `pagination` | `Pagination` | `*PaginationConfig` | no | Pagination holds optional per-API pagination configuration. |

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -243,9 +243,11 @@ document.
 ## Server URLs
 
 Restish honors OpenAPI `servers` at document, path, and operation level.
-Operation-level servers win over path-level servers, which win over
-document-level servers. Server variables use local `server_variables` config
-values when provided, then OpenAPI defaults:
+Document-level servers define the generated operation path shape, while the
+configured `base_url` provides the request origin. Operation-level servers win
+over path-level servers, and both are treated as explicit operation routing.
+Server variables use local `server_variables` config values when provided, then
+OpenAPI defaults:
 
 ```jsonc
 {
@@ -264,18 +266,23 @@ Relative server URLs resolve against `base_url`. A server such as `v2` with the
 base URL above sends generated operation requests under
 `https://api.vendor.test/root/v2`.
 
+If a document-level server is absolute and points at another origin, Restish
+keeps its path prefix but uses the configured `base_url` origin. For example,
+`base_url: https://staging.vendor.test` with a document server
+`https://api.vendor.test/v1` sends generated requests under
+`https://staging.vendor.test/v1`.
+
 If a configured server variable value is outside the OpenAPI `enum`, Restish
 warns and uses the configured value. Local config represents operator intent,
 and specs are sometimes stale. If a configured variable is not declared by any
 applicable OpenAPI server and the spec does declare server variables, Restish
 fails because the value cannot affect URL expansion.
 
-Absolute server URLs on another origin are blocked unless the API config lists
-the origin in `allowed_operation_origins`. `restish api connect --yes` and
-`restish api sync --yes` can add detected safe entries, and interactive connect
-or sync asks before saving them. Without that opt-in, generated commands fail
-with an `allowed_operation_origins` hint instead of silently routing the request
-to `base_url`.
+Path- or operation-level absolute server URLs on another origin are blocked
+unless the API config lists the origin in `allowed_operation_origins`, or a
+matching `url_overrides` entry rewrites that URL before the request is sent.
+Without that opt-in, generated commands fail with an `allowed_operation_origins`
+hint instead of silently sending profile credentials to another host.
 
 Same-origin absolute server URLs are used when scheme, hostname, and effective
 port all match.
@@ -283,6 +290,29 @@ If a same-origin server points outside the configured base path, Restish keeps
 the selected API profile and resolves the generated operation to that path. If
 no OpenAPI server matches the configured origin, Restish falls back to
 `base_url` instead of sending configured credentials to another host.
+
+Use `url_overrides` when a resolved URL should be rewritten for a profile, such
+as sending an upload operation to a local test service. Source and destination
+entries must be absolute `http` or `https` URL prefixes without userinfo, query,
+or fragment parts. The longest matching source prefix wins, and profile-level
+entries override or extend API-level entries:
+
+```jsonc
+{
+  "apis": {
+    "myapi": {
+      "base_url": "https://api.vendor.test",
+      "url_overrides": {
+        "https://upload.vendor.test/": "http://localhost:8080/"
+      }
+    }
+  }
+}
+```
+
+The rewrite runs after Restish has selected the generated operation URL, so it
+also covers path- or operation-level OpenAPI servers. It also runs for generic
+API-aware requests such as `restish myapi/items`.
 
 Use `operation_base` when the API registration needs an explicit request-path
 override independent of the OpenAPI document:

--- a/site/content/en/docs/reference/profiles.md
+++ b/site/content/en/docs/reference/profiles.md
@@ -69,6 +69,7 @@ ProfileConfig holds per-profile overrides for an API.
 | `tls_signer` | `TLSSigner` | `string` | no | TLSSigner selects a tls-signer plugin for mTLS client certificate signing. |
 | `tls_signer_params` | `TLSSignerParams` | `map[string]string` | no | TLSSignerParams passes plugin-specific configuration to the tls-signer. |
 | `server_variables` | `ServerVariables` | `map[string]string` | no | ServerVariables overrides API-level OpenAPI server URL variables for this profile when generating operation paths. |
+| `url_overrides` | `URLOverrides` | `map[string]string` | no | URLOverrides overrides or extends API-level URL prefix rewrites for this profile. |
 | `auth` | `Auth` | `*AuthConfig` | no | Auth holds authentication configuration for this profile. |
 | `auth_ref` | `AuthRef` | `string` | no | AuthRef names a top-level auth_profiles entry to use for this profile. |
 | `credentials` | `Credentials` | `map[string]*CredentialConfig` | no | Credentials maps operation credential requirement IDs to auth configurations that satisfy them. |


### PR DESCRIPTION
## Summary

- Restore v1-style document-level OpenAPI server handling so `base_url` supplies the request origin and document servers contribute path prefixes.
- Keep path- and operation-level servers as explicit routing, with `allowed_operation_origins` or `url_overrides` required for cross-origin requests.
- Add API/profile `url_overrides` support, docs, and regression coverage for generated commands, generic API-aware requests, and sync warnings.

## Validation

- `env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check`
- `hugo --source site --quiet`
- `env GOCACHE=/tmp/restish-gocache go test ./...`
- local smoke test with document-level non-matching servers plus operation-level upload server routing

Fixes #334
