### PR TITLE
fix: ignore encodings on bodyless responses

### DIFF
--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -3633,6 +3633,42 @@ func TestGeneratedCommandTraceOperation(t *testing.T) {
 	}
 }
 
+func TestGeneratedCommandNoContentWithEncodingHeader(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/items/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Delete API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/items/{id}": {
+      "delete": {
+        "operationId": "deleteItem",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {"204": {"description": "Deleted"}}
+      }
+    }
+  }
+}`, baseURL)
+	})
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "tapi", "delete-item", "123"}); err != nil {
+		t.Fatalf("delete-item failed: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("generated no-content output = %q, want empty", got)
+	}
+}
+
 func TestGeneratedCommandIgnoresReservedHeaderParameters(t *testing.T) {
 	var gotAuth string
 	mux := http.NewServeMux()

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -661,6 +661,9 @@ func (c *CLI) rawResponseBodyBytes(resp *http.Response, maxBytes int64) ([]byte,
 	if resp == nil || resp.Body == nil {
 		return nil, nil
 	}
+	if output.ResponseHasNoBody(resp) {
+		return nil, nil
+	}
 	if maxBytes <= 0 {
 		maxBytes = output.DefaultMaxBodyBytes
 	}
@@ -686,6 +689,12 @@ func (c *CLI) decompressedResponseBody(resp *http.Response) (io.ReadCloser, erro
 		return io.NopCloser(strings.NewReader("")), nil
 	}
 	original := resp.Body
+	if output.ResponseHasNoBody(resp) {
+		return &readCloser{
+			Reader: strings.NewReader(""),
+			Closer: original,
+		}, nil
+	}
 	reader, err := c.content.Decompress(resp.Header.Get("Content-Encoding"), original)
 	if err != nil {
 		return nil, err

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1004,6 +1004,86 @@ func TestExplicitPrintBodyNoContentNonTTYWritesNothing(t *testing.T) {
 	}
 }
 
+func TestExplicitPrintBodyBodylessEncodedResponsesWriteNothing(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		status   int
+		encoding string
+	}{
+		{
+			name:     "204 gzip",
+			args:     []string{"restish", "get", "--rsh-print", "b", "https://api.example.com/empty"},
+			status:   http.StatusNoContent,
+			encoding: "gzip",
+		},
+		{
+			name:     "205 br",
+			args:     []string{"restish", "get", "--rsh-print", "b", "https://api.example.com/reset"},
+			status:   http.StatusResetContent,
+			encoding: "br",
+		},
+		{
+			name:     "304 gzip",
+			args:     []string{"restish", "get", "--rsh-ignore-status-code", "--rsh-print", "b", "https://api.example.com/not-modified"},
+			status:   http.StatusNotModified,
+			encoding: "gzip",
+		},
+		{
+			name:     "HEAD gzip",
+			args:     []string{"restish", "head", "--rsh-print", "b", "https://api.example.com/head"},
+			status:   http.StatusOK,
+			encoding: "gzip",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, out, _ := newTestCLI(t)
+			c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.status,
+					Proto:      "HTTP/1.1",
+					Header: http.Header{
+						"Content-Type":     []string{"application/json"},
+						"Content-Encoding": []string{tt.encoding},
+					},
+					Body:    io.NopCloser(strings.NewReader("not a compressed body")),
+					Request: r,
+				}, nil
+			})
+			if err := c.Run(tt.args); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if got := out.String(); got != "" {
+				t.Fatalf("body output = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestExplicitPrintBodyEncodedEmptyOKStillFails(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Proto:      "HTTP/1.1",
+			Header: http.Header{
+				"Content-Type":     []string{"application/json"},
+				"Content-Encoding": []string{"gzip"},
+			},
+			Body:    http.NoBody,
+			Request: r,
+		}, nil
+	})
+	err := c.Run([]string{"restish", "get", "--rsh-print", "b", "https://api.example.com/empty"})
+	if err == nil {
+		t.Fatal("expected empty gzip body on 200 OK to fail")
+	}
+	if !strings.Contains(err.Error(), "decompressing response") {
+		t.Fatalf("error = %v, want decompression error", err)
+	}
+}
+
 func TestExplicitPrintBodyJSONNullNonTTYWritesNull(t *testing.T) {
 	c, out, _ := newTestCLI(t)
 	useJSONResponse(c, 200, "null")

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -74,6 +74,49 @@ func TestNormalize_EmptyBody(t *testing.T) {
 	}
 }
 
+func TestNormalize_BodylessResponsesSkipContentEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		method   string
+		encoding string
+	}{
+		{name: "informational gzip", status: 103, encoding: "gzip"},
+		{name: "no content gzip", status: http.StatusNoContent, encoding: "gzip"},
+		{name: "reset content br", status: http.StatusResetContent, encoding: "br"},
+		{name: "not modified gzip", status: http.StatusNotModified, encoding: "gzip"},
+		{name: "head success gzip", status: http.StatusOK, method: http.MethodHead, encoding: "gzip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := makeResp(tt.status, "application/json", "not a compressed body")
+			resp.Header.Set("Content-Encoding", tt.encoding)
+			if tt.method != "" {
+				resp.Request = &http.Request{Method: tt.method}
+			}
+			r, err := output.Normalize(resp, testRegistry, 0)
+			if err != nil {
+				t.Fatalf("Normalize: %v", err)
+			}
+			if r.Body != nil || len(r.Raw) != 0 {
+				t.Fatalf("body = %#v raw = %q, want no body", r.Body, r.Raw)
+			}
+		})
+	}
+}
+
+func TestNormalize_EncodedEmptyOKStillErrors(t *testing.T) {
+	resp := makeResp(http.StatusOK, "application/json", "")
+	resp.Header.Set("Content-Encoding", "gzip")
+	_, err := output.Normalize(resp, testRegistry, 0)
+	if err == nil {
+		t.Fatal("expected empty gzip body on 200 OK to fail")
+	}
+	if !strings.Contains(err.Error(), "decompressing response") {
+		t.Fatalf("error = %v, want decompression error", err)
+	}
+}
+
 func TestNormalize_Status(t *testing.T) {
 	resp := makeResp(404, "application/json", `{}`)
 	r, err := output.Normalize(resp, testRegistry, 0)

--- a/internal/output/response.go
+++ b/internal/output/response.go
@@ -75,10 +75,30 @@ func responseURL(resp *http.Response) string {
 	return resp.Request.URL.String()
 }
 
+// ResponseHasNoBody reports whether HTTP semantics forbid a response body.
+// Some servers still send Content-Encoding on these responses; callers should
+// ignore the body instead of attempting to decompress or decode it.
+func ResponseHasNoBody(resp *http.Response) bool {
+	if resp == nil {
+		return true
+	}
+	if resp.Request != nil && strings.EqualFold(resp.Request.Method, http.MethodHead) {
+		return true
+	}
+	status := resp.StatusCode
+	return (status >= 100 && status < 200) ||
+		status == http.StatusNoContent ||
+		status == http.StatusResetContent ||
+		status == http.StatusNotModified
+}
+
 // decodeBody reads the response body, decompresses Content-Encoding if needed,
 // then decodes it using the content registry. Returns the decoded body bytes so
 // callers can write them without formatter re-encoding if needed.
 func decodeBody(resp *http.Response, reg *content.Registry, maxBytes int64) (decoded any, raw []byte, err error) {
+	if ResponseHasNoBody(resp) {
+		return nil, nil, nil
+	}
 	encoding := resp.Header.Get("Content-Encoding")
 	reader, err := reg.Decompress(encoding, resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- skip Content-Encoding decompression and body decoding for responses that cannot legally have a body: 1xx, 204, 205, 304, and HEAD
- keep malformed encoded 200 OK responses failing as before
- add focused normalization, generic CLI, and generated-command regression coverage

Fixes #285.
Supersedes #288; thanks @terev for the original PR and repro direction.

## Tests
- env GOCACHE=/tmp/restish-gocache go test ./internal/output ./internal/cli -run 'TestNormalize_(BodylessResponsesSkipContentEncoding|EncodedEmptyOKStillErrors)|TestExplicitPrintBody(BodylessEncodedResponsesWriteNothing|EncodedEmptyOKStillFails)|TestGeneratedCommandNoContentWithEncodingHeader'\n- env GOCACHE=/tmp/restish-gocache go test ./internal/output ./internal/cli\n- env GOCACHE=/tmp/restish-gocache go test ./...\n- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...\n\n## Review\n- Sub-agent review found no issues.