### PR TITLE
security: update msgpack decoder to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pb33f/libopenapi v0.35.0
 	github.com/sandrolain/httpcache v1.4.0
-	github.com/shamaton/msgpack/v2 v2.4.0
+	github.com/shamaton/msgpack/v3 v3.1.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sandrolain/httpcache v1.4.0 h1:Jf4Vx62X2ybvNPSpPvI1kT3xvMdDG1AsApQjOQKO9E0=
 github.com/sandrolain/httpcache v1.4.0/go.mod h1:kHBuXveitSn39SNPBhdf/ybG272X706HJ2RJqOQ+Em0=
-github.com/shamaton/msgpack/v2 v2.4.0 h1:O5Z08MRmbo0lA9o2xnQ4TXx6teJbPqEurqcCOQ8Oi/4=
-github.com/shamaton/msgpack/v2 v2.4.0/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
+github.com/shamaton/msgpack/v3 v3.1.2 h1:d5gWAIyMU4M0WgDjz6IFSCuXJUA2dFwRHBpDclE8CLw=
+github.com/shamaton/msgpack/v3 v3.1.2/go.mod h1:DcQG8jrdrQCIxr3HlMYkiXdMhK+KfN2CitkyzsQV4uc=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1015,6 +1015,26 @@ func TestExplicitPrintBodyJSONNullNonTTYWritesNull(t *testing.T) {
 	}
 }
 
+func TestMsgpackMalformedResponseReturnsDecodeError(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/msgpack"}},
+			Body:       io.NopCloser(bytes.NewReader([]byte{0xd6, 0xff})),
+			Request:    r,
+		}, nil
+	})
+	err := c.Run([]string{"restish", "get", "-o", "json", "https://api.example.com/bad-msgpack"})
+	if err == nil {
+		t.Fatal("expected malformed msgpack response to fail")
+	}
+	if !strings.Contains(err.Error(), "decoding response body as application/msgpack") {
+		t.Fatalf("error = %v, want msgpack decode error", err)
+	}
+}
+
 func TestStructuredJSONResponseDefaultNonTTYPreservesOriginalBytes(t *testing.T) {
 	raw := "{\n  \"ok\": true\n}\n"
 	c, out, _ := newTestCLI(t)

--- a/internal/content/defaults.go
+++ b/internal/content/defaults.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/amazon-ion/ion-go/ion"
 	"github.com/fxamacker/cbor/v2"
-	"github.com/shamaton/msgpack/v2"
+	"github.com/shamaton/msgpack/v3"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/internal/content/registry_test.go
+++ b/internal/content/registry_test.go
@@ -708,3 +708,17 @@ func TestMsgpackRoundTripJSONNormalized(t *testing.T) {
 		t.Errorf("msgpack round-trip mismatch:\n got  %s\n want %s", got, want)
 	}
 }
+
+func TestMsgpackMalformedFixextReturnsError(t *testing.T) {
+	payloads := map[string][]byte{
+		"fixext4 missing bytes": {0xd6, 0xff},
+		"fixext8 missing bytes": {0xd7, 0xff},
+	}
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			if _, err := reg.Decode("application/msgpack", payload); err == nil {
+				t.Fatal("expected malformed msgpack to return an error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- replace `github.com/shamaton/msgpack/v2 v2.4.0` with `github.com/shamaton/msgpack/v3 v3.1.2`
- add regression coverage for malformed fixext payloads from GHSA-h9q6-hc68-35rp / CVE-2026-32284
- verify malformed MessagePack responses return decode errors through the CLI when decoding is requested

Addresses Dependabot alert #20.

## Tests
- env GOPATH=/tmp/restish-gopath GOCACHE=/tmp/restish-gocache go test ./internal/content ./internal/cli -run 'TestMsgpack(MalformedFixextReturnsError|RoundTripJSONNormalized)|TestMsgpackMalformedResponseReturnsDecodeError'\n- env GOPATH=/tmp/restish-gopath GOCACHE=/tmp/restish-gocache go test ./internal/content ./internal/cli\n- env GOPATH=/tmp/restish-gopath GOCACHE=/tmp/restish-gocache go test ./...\n- env GOPATH=/tmp/restish-gopath GOCACHE=/tmp/restish-gocache go test -tags=integration ./...\n\n## Review\n- Sub-agent review found no issues.