### PR TITLE
security: render playground errors without highlighting

### DIFF
--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -2209,6 +2209,7 @@
   }
 
   function setOutput(node, output, isError, highlight = true, language = "language-readable") {
+    highlight = highlight && !isError;
     node.replaceChildren();
     if (output && typeof output === "object" && output.kind === "image") {
       node.textContent = output.text || "";


### PR DESCRIPTION
## Summary
- disable Prism syntax highlighting for playground JavaScript exception output
- leave normal command output, including HTTP error responses, on the existing highlightable success path

Addresses CodeQL alert #23.

## Tests
- node --check site/static/js/restish-playground.js
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache

## Review
- Sub-agent review found no issues.