### PR TITLE
docs: define trusted project config discovery

### DIFF
--- a/docs/design/002-config-and-profiles.md
+++ b/docs/design/002-config-and-profiles.md
@@ -81,17 +81,54 @@ explicit config file is an error so operators do not accidentally run with the
 global default after mistyping a project path. The ordinary platform-default
 config path keeps the v1 migration and auto-create behavior described below.
 
-Restish v2 does not search the current working directory or parent directories
-for project config. Project-local configuration is selected explicitly with
-`--rsh-config` or `RSH_CONFIG`. That keeps repository checkout state from
-silently changing request behavior; an implicit project-discovery mode can be
-designed later if a real workflow needs it.
+When no explicit config file is selected, Restish may discover project config
+by walking from the current working directory toward the filesystem root and
+looking for `.restish.json`. Discovery alone does not grant trust. A discovered
+project config is used only when the user has trusted that exact canonical file
+path and content hash, either through the interactive first-use prompt or
+`restish config trust`. If the file content changes, the hash changes and the
+user must trust it again before Restish uses it.
+
+Interactive first-use prompts show the absolute project config path and a short
+summary of what would be applied. Non-interactive invocations do not prompt. If
+they discover an untrusted project config, they continue with the selected/global
+config and print a concise stderr warning that names the project config path and
+`restish config trust` recovery command. Users can avoid that warning by
+trusting the file ahead of time, explicitly selecting it with `--rsh-config` /
+`RSH_CONFIG`, or removing the project config.
+
+Trusted project config is a layered overlay, not a replacement for the global
+config. The first version honors only project `apis` and `theme`. Global APIs
+remain available, and project APIs shadow global APIs by API name for commands
+run under that working tree. Individual API definitions are not deep-merged:
+when a project API and global API share a name, the project API wins as a whole.
+Project `theme` overlays the global theme by token/style key so projects can
+provide a visible context signal such as a development or dangerous environment
+theme. Other top-level project keys, including `auth_profiles`, `plugins`,
+`cache`, and `theme_source`, are invalid in an auto-discovered project overlay.
+If a trusted project config contains those keys, Restish errors with a clear
+diagnostic instead of silently ignoring request-affecting or executable config.
+A later design may broaden the overlay shape with explicit merge and trust
+semantics.
+
+Auto-discovered project config is read-only for normal mutation commands.
+Commands such as `api connect`, `api set`, `config edit`, and `config set`
+continue to write the user's selected/global config unless the user explicitly
+selects the project file with `--rsh-config` or `RSH_CONFIG`. Explicit selection
+preserves the existing source-of-truth behavior: `restish --rsh-config
+.restish.json ...` reads and writes only that file and does not merge it with
+the platform default config.
 
 Sidecar state that belongs to the selected config trust root, such as OAuth
 token caches and external-tool approval records, lives next to the explicit
 config file. Response and spec caches remain under the cache root, but explicit
 configs get a cache namespace derived from the config path so two project
 configs do not reuse each other's cached HTTP responses or discovered specs.
+Auto-discovered project config keeps private machine state out of the repository:
+OAuth/token caches, response caches, and spec/generated-command caches live in
+the user's Restish state/cache roots under a namespace derived from the trusted
+project config's canonical path and content hash. That prevents a project API
+from sharing credentials or cached responses with a same-named global API.
 
 Cache directory selection mirrors config selection with `RSH_CACHE_DIR`,
 `XDG_CACHE_HOME/restish`, `~/.cache/restish` on Unix-like systems, and the

--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -119,19 +119,44 @@ validated. Examples:
 
 ### Explicit Config Roots
 
-Restish does not implicitly discover project config files from the current
-working directory in v2. Project config is selected with `--rsh-config` or
-`RSH_CONFIG`, and that selected file is the entire config source of truth rather
-than an overlay on top of the operator's global config.
+`--rsh-config` and `RSH_CONFIG` remain explicit config-root selectors. When
+either is present, the selected file is the entire config source of truth rather
+than an overlay on top of the operator's global config, and missing explicit
+files fail instead of falling back to the platform default.
 
-This avoids surprise trust transfer from a checked-out repository into normal
-requests. It also makes command review easier: the config trust root is visible
-in the command line or environment, and missing explicit files fail instead of
-falling back to the platform default.
+Project config discovery is a separate trust flow. When no explicit config file
+is selected, Restish may discover `.restish.json` in the current directory or an
+ancestor, but it must not use that file until the user trusts the canonical file
+path and current content hash. Trust records live in the user's Restish state
+outside the repository so a checked-out project cannot grant trust to itself.
+When the project config content changes, Restish asks for trust again before
+using the new content.
 
-This is a deliberate v2 boundary, not a claim that project config discovery is
-never useful. A future design may add an explicit opt-in mode for repository
-config, but v2 should not infer it from the local directory.
+Interactive prompts are allowed only for human TTY use and must show the
+absolute project config path plus a short summary. Non-interactive runs do not
+prompt; users must run `restish config trust`, pass `--rsh-config`, or set
+`RSH_CONFIG` before scripts can rely on project-local config. When a
+non-interactive run discovers an untrusted project config, it continues with the
+selected/global config but prints a concise stderr warning naming the untrusted
+file and the trust command, so the fallback is visible rather than silent.
+
+The auto-discovered project overlay is deliberately narrow. It can contribute
+API registrations and terminal theme entries, with project APIs shadowing global
+APIs by name and project theme entries overriding global theme entries by key.
+It must not execute project-specified plugins, load project top-level
+`auth_profiles`, apply project cache settings, or store sidecar state in the
+repository in the first version. Trusted project configs that include those
+unsupported top-level keys fail with a clear diagnostic instead of silently
+dropping them. OAuth tokens, response caches, and
+spec/generated-command caches for trusted project APIs stay in user-owned
+Restish state under a namespace derived from the project config path and hash.
+That keeps secrets and machine-local state out of source control and prevents a
+project API from sharing state with a same-named global API.
+
+Auto-discovered project config is read-only for ordinary config mutation
+commands. Users who want to edit a project config through Restish must select it
+explicitly with `--rsh-config` or `RSH_CONFIG`, making the write target visible
+in the command or environment.
 
 ### Least Necessary Exposure
 

--- a/docs/design/031-compatibility-and-migration.md
+++ b/docs/design/031-compatibility-and-migration.md
@@ -131,10 +131,13 @@ with a setup error instead of creating relative config state in the current
 working directory. Cache-only state can use a temporary fallback, but persistent
 configuration cannot.
 
-V2 also does not discover project config by walking the current directory or
-parent directories. Users who want project-local config should pass
-`--rsh-config ./restish.json` or set `RSH_CONFIG`; implicit repository config
-discovery can be considered after v2 if the workflow proves valuable.
+V1-to-v2 migration does not use project config discovery. Migration reads and
+writes only the selected/global user config root so a checked-out repository
+cannot affect one-time migration behavior. Normal v2 config loading may discover
+trusted `.restish.json` project overlays after migration, as described in the
+config and security design records. Users who want a project file to be the
+complete config source of truth can still pass `--rsh-config .restish.json` or
+set `RSH_CONFIG`.
 
 ### API Registrations
 

--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -60,8 +60,30 @@ and `%APPDATA%\restish\restish.json` on Windows.
 merge them with the default config. Token and external-tool approval sidecars
 live next to the selected explicit config. HTTP response and spec caches stay
 under the cache root, with a namespace derived from the explicit config path.
-Restish v2 does not search the current directory or ancestors for project
-config files; project-local config is explicit only.
+When no explicit config file is selected, Restish may discover `.restish.json`
+from the current directory or an ancestor. A discovered project config is used
+only after trust is recorded with `restish config trust` or an interactive TTY
+prompt. Trust is stored outside the repository in user Restish state and is
+keyed by canonical project config path plus content hash, so a changed project
+config must be trusted again.
+
+Trusted project config is layered over the selected/global config for reads. The
+first project layer honors only `apis` and `theme`: project APIs shadow global
+APIs by name without deep-merging individual API definitions, and project theme
+entries override global theme entries by key. Other top-level keys such as
+`auth_profiles`, `plugins`, `cache`, and `theme_source` are invalid in
+auto-discovered project config and produce a clear diagnostic when the project
+config is otherwise trusted. Non-interactive runs do not prompt for trust; when
+they discover an untrusted project config, they continue with the selected/global
+config and print a concise stderr warning naming the file and
+`restish config trust`. Auto-discovered project config is read-only for normal
+mutation commands; writes continue to target the selected/global config unless
+`--rsh-config` or `RSH_CONFIG` explicitly selects the project file.
+
+Project-local machine state is not written into the repository. OAuth/token
+caches, HTTP response caches, and spec/generated-command caches for trusted
+project APIs live in user Restish state/cache roots under a namespace derived
+from the trusted project config path and content hash.
 
 Windows ACL inspection is not implemented for the first v2 release. Existing
 config and token-cache files on Windows therefore report permission diagnostics


### PR DESCRIPTION
## Summary
- update config, security, migration, and implementation design docs for trusted `.restish.json` discovery
- document path+content-hash trust, `restish config trust`, noninteractive warning behavior, APIs/theme-only overlays, read-only auto-discovered config, and user-state cache/token namespaces
- clarify that migration does not use project discovery and explicit `--rsh-config` semantics remain unchanged

Related to #239, #263, and #303.

## Tests
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache
- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check

## Review
- Sub-agent review found and re-checked doc consistency issues; follow-up review found no issues.