### PR TITLE
feat: add page parameter pagination

### DIFF
--- a/docs/design/011-pagination-and-hypermedia.md
+++ b/docs/design/011-pagination-and-hypermedia.md
@@ -117,9 +117,15 @@ Per-API pagination config can refine how page data is interpreted:
 
 - `items_path` extracts the collection from a nested body field
 - `next_path` can extract a next-page URL from the body
+- `page_param` names a query parameter to increment when an API has no `next`
+  link or configured `next_path`
 
 This lets Restish handle both standard hypermedia and APIs whose collection
-wrappers need one extra hint.
+wrappers need one extra hint. `page_param` is explicit API config rather than
+autodetection. For generic requests, it applies only when the body, or the
+configured `items_path`, is an array. For generated operations, it applies only
+when the generated request URL already contains that query parameter, such as
+from a user-provided generated command flag.
 Configured pagination paths are treated as user-authored config, not as
 best-effort guesses. Invalid `items_path` or `next_path` expressions, missing
 configured fields, non-object bodies where an object is required, and
@@ -128,6 +134,9 @@ partial collection. A scalar `items_path` result is still rendered as a single
 item with a warning so users can correct the shape without losing the response.
 If a later page returns an HTTP error, Restish stops pagination and returns that
 status instead of discarding the error and formatting a partial collection.
+Synthesized `page_param` pagination is the exception: a later-page HTTP error
+stops successfully with a warning, because some APIs signal the end of an
+unsupported or out-of-range page sequence with an error status.
 
 Filters that select response metadata rather than body records normally disable
 automatic pagination. For example, `-f headers`, `-f headers.Date`, and
@@ -196,9 +205,13 @@ The conceptual paginator algorithm is:
 4. emit or collect items from the current page according to the output plan
 5. resolve the next target from:
    - normalized `next` relation, or
-   - configured `next_path`
+   - configured `next_path`, or
+   - configured `page_param` when no explicit next target exists and the
+     response shape is a collection
 6. stop when:
    - there is no next target
+   - a synthesized `page_param` request returns an empty collection
+   - a synthesized `page_param` request returns an HTTP error
    - a safety bound is reached
    - the context is canceled
    - the planner no longer permits more pages

--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -101,6 +101,7 @@ API fields:
 | `retry_max_wait` | string duration | API-local cap for `Retry-After`/`X-Retry-In` when no flag/env override is set. |
 | `pagination.items_path` | string | Item extraction path. |
 | `pagination.next_path` | string | Next URL extraction path. |
+| `pagination.page_param` | string | Query parameter to increment for APIs without next links. |
 | `profiles` | map | Profile configs keyed by name. |
 
 Profile fields are `base_url`, `headers`, `query`, `tls_signer`,

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -685,6 +685,45 @@ func TestGeneratedCommandPageParamPaginationRequiresPresentParam(t *testing.T) {
 	if got, want := strings.Join(pages, ","), "1,2,3"; got != want {
 		t.Fatalf("with --page saw page params %q, want %q", got, want)
 	}
+
+	pages = nil
+	c, out = env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "tapi", "list-items", "-q", "page=1", "-o", "json"}); err != nil {
+		t.Fatalf("list-items with -q page failed: %v", err)
+	}
+	allPages = nil
+	if err := json.Unmarshal([]byte(out.String()), &allPages); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", out.String(), err)
+	}
+	if len(allPages) != 2 || allPages[0]["id"] != 1 || allPages[1]["id"] != 2 {
+		t.Fatalf("with -q page output = %#v, want ids 1 and 2", allPages)
+	}
+	if got, want := strings.Join(pages, ","), "1,2,3"; got != want {
+		t.Fatalf("with -q page saw page params %q, want %q", got, want)
+	}
+
+	env.writeAPIConfig(t, &config.APIConfig{
+		BaseURL:    env.baseURL(t),
+		Pagination: &config.PaginationConfig{PageParam: "page"},
+		Profiles: map[string]*config.ProfileConfig{
+			"default": {Query: []string{"page=1"}},
+		},
+	})
+	pages = nil
+	c, out = env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "tapi", "list-items", "-o", "json"}); err != nil {
+		t.Fatalf("list-items with profile page query failed: %v", err)
+	}
+	allPages = nil
+	if err := json.Unmarshal([]byte(out.String()), &allPages); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", out.String(), err)
+	}
+	if len(allPages) != 2 || allPages[0]["id"] != 1 || allPages[1]["id"] != 2 {
+		t.Fatalf("with profile page query output = %#v, want ids 1 and 2", allPages)
+	}
+	if got, want := strings.Join(pages, ","), "1,2,3"; got != want {
+		t.Fatalf("with profile page query saw page params %q, want %q", got, want)
+	}
 }
 
 func TestGeneratedCommandSecurityEmptySuppressesAuth(t *testing.T) {

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -268,6 +268,7 @@ func (e *generatedEnv) newCLI() *cli.CLI {
 	c.Stderr = io.Discard
 	c.Hooks().ConfigPath = e.cfgFile
 	c.Hooks().SpecCachePath = e.cacheDir
+	c.Hooks().CachePath = filepath.Join(e.cacheDir, "http-cache")
 	c.Hooks().RetryBaseDelay = 0
 	return c
 }
@@ -605,6 +606,84 @@ func TestGeneratedCommandKebabCase(t *testing.T) {
 	c := env.newCLI()
 	if err := c.Run([]string{"restish", "tapi", "list-items"}); err != nil {
 		t.Fatalf("list-items failed: %v", err)
+	}
+}
+
+func TestGeneratedCommandPageParamPaginationRequiresPresentParam(t *testing.T) {
+	var pages []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/items", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		pages = append(pages, page)
+		w.Header().Set("Content-Type", "application/json")
+		body := `[{"id":1}]`
+		switch page {
+		case "2":
+			body = `[{"id":2}]`
+		case "3":
+			body = `[]`
+		}
+		fmt.Fprint(w, body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {"type": "integer"}
+          }
+        ],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, baseURL)
+	})
+	env.writeAPIConfig(t, &config.APIConfig{
+		BaseURL:    env.baseURL(t),
+		Pagination: &config.PaginationConfig{PageParam: "page"},
+	})
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "tapi", "list-items", "-o", "json"}); err != nil {
+		t.Fatalf("list-items without page failed: %v", err)
+	}
+	var firstOnly []map[string]int
+	if err := json.Unmarshal([]byte(out.String()), &firstOnly); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", out.String(), err)
+	}
+	if len(firstOnly) != 1 || firstOnly[0]["id"] != 1 {
+		t.Fatalf("without --page output = %#v, want first page only", firstOnly)
+	}
+	if got, want := strings.Join(pages, ","), ""; got != want {
+		t.Fatalf("without --page saw page params %q, want %q", got, want)
+	}
+
+	pages = nil
+	c, out = env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "tapi", "list-items", "--page", "1", "-o", "json"}); err != nil {
+		t.Fatalf("list-items with page failed: %v", err)
+	}
+	var allPages []map[string]int
+	if err := json.Unmarshal([]byte(out.String()), &allPages); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", out.String(), err)
+	}
+	if len(allPages) != 2 || allPages[0]["id"] != 1 || allPages[1]["id"] != 2 {
+		t.Fatalf("with --page output = %#v, want ids 1 and 2", allPages)
+	}
+	if got, want := strings.Join(pages, ","), "1,2,3"; got != want {
+		t.Fatalf("with --page saw page params %q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -406,7 +406,7 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 		if apiName != "" && c.cfg != nil && c.cfg.APIs[apiName] != nil {
 			pagCfg = c.cfg.APIs[apiName].Pagination
 		}
-		did, err := c.tryPaginate(cmd, resp, rawURL, opts, pagCfg, prepared)
+		did, err := c.tryPaginate(cmd, resp, rawURL, opts, pagCfg, prepared, bodyOpts.explicitAPIName != "")
 		if err != nil {
 			return err
 		}

--- a/internal/cli/paginate.go
+++ b/internal/cli/paginate.go
@@ -49,6 +49,10 @@ func (c *CLI) tryPaginate(
 		}
 		items, ok, err := pageParamPaginationItems(firstResp.Body, pagCfg)
 		if err != nil {
+			if !isFatalPaginationItemsPathError(err) {
+				c.warnf("pagination items_path: %v", err)
+				return false, nil
+			}
 			return false, err
 		}
 		if !ok || len(items) == 0 {
@@ -289,16 +293,11 @@ func effectiveFirstURL(prepared *preparedRequest, fallback string) string {
 
 func pageParamPaginationItems(body any, pagCfg *config.PaginationConfig) ([]any, bool, error) {
 	if pagCfg != nil && pagCfg.ItemsPath != "" {
-		m, ok := body.(map[string]any)
-		if !ok {
-			return nil, false, paginationItemsPathError{err: fmt.Errorf("pagination: items_path %q requires an object response body", pagCfg.ItemsPath), fatal: true}
-		}
-		result, err := filter.Apply(pagCfg.ItemsPath, m, filter.LangAuto)
+		items, err := pageItems(body, pagCfg)
 		if err != nil {
-			return nil, false, paginationItemsPathError{err: fmt.Errorf("pagination: items_path filter %q: %w", pagCfg.ItemsPath, err), fatal: true}
+			return items, false, err
 		}
-		items, ok := result.([]any)
-		return items, ok, nil
+		return items, true, nil
 	}
 	items, ok := body.([]any)
 	return items, ok, nil

--- a/internal/cli/paginate.go
+++ b/internal/cli/paginate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/rest-sh/restish/v2/internal/config"
@@ -26,6 +27,7 @@ func (c *CLI) tryPaginate(
 	opts request.Options,
 	pagCfg *config.PaginationConfig,
 	prepared *preparedRequest,
+	generated bool,
 ) (bool, error) {
 	noPaginate := globalFlagsFromContext(requestContext(cmd)).NoPaginate
 	if noPaginate {
@@ -37,8 +39,26 @@ func (c *CLI) tryPaginate(
 	if err != nil {
 		return false, err
 	}
+	mode := paginationNextLink
 	if nextURL == "" {
-		return false, nil
+		if pagCfg == nil || pagCfg.PageParam == "" {
+			return false, nil
+		}
+		if generated && !paginationURLHasParam(firstURL, pagCfg.PageParam) {
+			return false, nil
+		}
+		items, ok, err := pageParamPaginationItems(firstResp.Body, pagCfg)
+		if err != nil {
+			return false, err
+		}
+		if !ok || len(items) == 0 {
+			return false, nil
+		}
+		nextURL, err = nextPageParamURL(effectiveFirstURL(prepared, firstURL), pagCfg.PageParam)
+		if err != nil {
+			return false, err
+		}
+		mode = paginationNextPageParam
 	}
 
 	gfPag := globalFlagsFromContext(requestContext(cmd))
@@ -46,8 +66,15 @@ func (c *CLI) tryPaginate(
 	maxPages := gfPag.MaxPages
 	maxItems := gfPag.MaxItems
 
-	return true, c.runPagination(cmd, firstResp, firstURL, nextURL, opts, pagCfg, collect, maxPages, maxItems, prepared)
+	return true, c.runPagination(cmd, firstResp, firstURL, nextURL, opts, pagCfg, collect, maxPages, maxItems, prepared, mode)
 }
+
+type paginationNextMode int
+
+const (
+	paginationNextLink paginationNextMode = iota
+	paginationNextPageParam
+)
 
 // runPagination drives the pagination loop starting from firstResp.
 func (c *CLI) runPagination(
@@ -60,6 +87,7 @@ func (c *CLI) runPagination(
 	collect bool,
 	maxPages, maxItems int,
 	prepared *preparedRequest,
+	nextMode paginationNextMode,
 ) (retErr error) {
 	ctx := requestContext(cmd)
 	if err := c.paginationStatusError(cmd, 1, firstResp.Status); err != nil {
@@ -138,6 +166,7 @@ func (c *CLI) runPagination(
 	visited := map[string]int{firstURL: 1}
 
 	for !done && nextURL != "" {
+		currentNextMode := nextMode
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -163,6 +192,12 @@ func (c *CLI) runPagination(
 		if err != nil {
 			return fmt.Errorf("paginate page %d: %w", page, err)
 		}
+		if currentNextMode == paginationNextPageParam && output.StatusToExitCode(httpResp.StatusCode) != 0 {
+			status := httpResp.StatusCode
+			_ = httpResp.Body.Close()
+			c.warnf("pagination page %d returned HTTP %d; stopping", page, status)
+			break
+		}
 
 		resp, err := c.normalizeHTTPResponse(httpResp, maxBodyBytes(cmd))
 		if err != nil {
@@ -181,6 +216,17 @@ func (c *CLI) runPagination(
 				return filterErr
 			}
 			c.warnf("pagination items_path: %v", filterErr)
+		}
+		var explicitNextURL string
+		if currentNextMode == paginationNextPageParam {
+			c.ensureBodyLinks(resp)
+			explicitNextURL, err = resolveNextURL(resp, pagCfg, nextURL)
+			if err != nil {
+				return err
+			}
+		}
+		if currentNextMode == paginationNextPageParam && explicitNextURL == "" && len(items) == 0 {
+			break
 		}
 		existingCount := len(allItems)
 		if !collect && streamItems {
@@ -202,7 +248,16 @@ func (c *CLI) runPagination(
 			streamedCount += len(items)
 		}
 		c.ensureBodyLinks(resp)
-		nextURL, err = resolveNextURL(resp, pagCfg, nextURL)
+		if currentNextMode == paginationNextPageParam {
+			if explicitNextURL != "" {
+				nextURL = explicitNextURL
+				nextMode = paginationNextLink
+				continue
+			}
+			nextURL, err = nextPageParamURL(nextURL, pagCfg.PageParam)
+		} else {
+			nextURL, err = resolveNextURL(resp, pagCfg, nextURL)
+		}
 		if err != nil {
 			return err
 		}
@@ -223,6 +278,30 @@ func (c *CLI) runPagination(
 		return c.formatResponse(cmd, synthetic, prepared)
 	}
 	return nil
+}
+
+func effectiveFirstURL(prepared *preparedRequest, fallback string) string {
+	if prepared != nil && prepared.actualRequest != nil && prepared.actualRequest.URL != nil {
+		return prepared.actualRequest.URL.String()
+	}
+	return fallback
+}
+
+func pageParamPaginationItems(body any, pagCfg *config.PaginationConfig) ([]any, bool, error) {
+	if pagCfg != nil && pagCfg.ItemsPath != "" {
+		m, ok := body.(map[string]any)
+		if !ok {
+			return nil, false, paginationItemsPathError{err: fmt.Errorf("pagination: items_path %q requires an object response body", pagCfg.ItemsPath), fatal: true}
+		}
+		result, err := filter.Apply(pagCfg.ItemsPath, m, filter.LangAuto)
+		if err != nil {
+			return nil, false, paginationItemsPathError{err: fmt.Errorf("pagination: items_path filter %q: %w", pagCfg.ItemsPath, err), fatal: true}
+		}
+		items, ok := result.([]any)
+		return items, ok, nil
+	}
+	items, ok := body.([]any)
+	return items, ok, nil
 }
 
 func (c *CLI) filterPaginatedItems(cmd *cobra.Command, items []any) ([]any, error) {
@@ -663,6 +742,37 @@ func resolvePaginationURL(currentURL, next string) (string, error) {
 		return "", fmt.Errorf("pagination: next URL %q: %w", next, err)
 	}
 	return base.ResolveReference(ref).String(), nil
+}
+
+func paginationURLHasParam(rawURL, param string) bool {
+	if param == "" {
+		return false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	_, ok := u.Query()[param]
+	return ok
+}
+
+func nextPageParamURL(currentURL, param string) (string, error) {
+	u, err := url.Parse(currentURL)
+	if err != nil {
+		return "", fmt.Errorf("pagination: current URL %q: %w", currentURL, err)
+	}
+	q := u.Query()
+	page := 1
+	if raw := q.Get(param); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return "", fmt.Errorf("pagination: page_param %q value %q is not an integer", param, raw)
+		}
+		page = n
+	}
+	q.Set(param, strconv.Itoa(page+1))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }
 
 // applyItemLimits truncates items to stay within maxItems. Returns the

--- a/internal/cli/paginate.go
+++ b/internal/cli/paginate.go
@@ -44,7 +44,8 @@ func (c *CLI) tryPaginate(
 		if pagCfg == nil || pagCfg.PageParam == "" {
 			return false, nil
 		}
-		if generated && !paginationURLHasParam(firstURL, pagCfg.PageParam) {
+		pageParamBaseURL := effectiveFirstURL(prepared, firstURL)
+		if generated && !paginationURLHasParam(pageParamBaseURL, pagCfg.PageParam) {
 			return false, nil
 		}
 		items, ok, err := pageParamPaginationItems(firstResp.Body, pagCfg)
@@ -58,7 +59,7 @@ func (c *CLI) tryPaginate(
 		if !ok || len(items) == 0 {
 			return false, nil
 		}
-		nextURL, err = nextPageParamURL(effectiveFirstURL(prepared, firstURL), pagCfg.PageParam)
+		nextURL, err = nextPageParamURL(pageParamBaseURL, pagCfg.PageParam)
 		if err != nil {
 			return false, err
 		}

--- a/internal/cli/paginate_internal_test.go
+++ b/internal/cli/paginate_internal_test.go
@@ -267,7 +267,7 @@ func TestRunPaginationHonorsContextCancellation(t *testing.T) {
 
 	err = c.runPagination(cmd, firstResp, firstReq.URL.String(), "https://api.example.com/items?page=2", request.Options{
 		Transport: request.BuildTransport(request.Options{Transport: c.baseHTTPTransport()}),
-	}, nil, false, 25, 0, nil)
+	}, nil, false, 25, 0, nil, paginationNextLink)
 	if err == nil {
 		t.Fatal("expected pagination to stop on context cancellation")
 	}

--- a/internal/cli/paginate_test.go
+++ b/internal/cli/paginate_test.go
@@ -797,6 +797,291 @@ func TestPaginationItemsPath(t *testing.T) {
 	}
 }
 
+func TestPaginationPageParamGenericRequestStopsOnEmptyPage(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url": "https://api.example.com",
+				"pagination": map[string]any{
+					"page_param": "page",
+				},
+			},
+		},
+	})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	var pages []string
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		page := r.URL.Query().Get("page")
+		pages = append(pages, page)
+		body := `[{"id":1}]`
+		switch page {
+		case "2":
+			body = `[{"id":2}]`
+		case "3":
+			body = `[]`
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	var values []map[string]int
+	if err := json.Unmarshal(out.Bytes(), &values); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", out.String(), err)
+	}
+	if len(values) != 2 || values[0]["id"] != 1 || values[1]["id"] != 2 {
+		t.Fatalf("values = %#v, want ids 1 and 2", values)
+	}
+	if got, want := strings.Join(pages, ","), ",2,3"; got != want {
+		t.Fatalf("page params = %q, want %q", got, want)
+	}
+}
+
+func TestPaginationPageParamPreservesFlagQuery(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url":   "https://api.example.com",
+				"pagination": map[string]any{"page_param": "page"},
+				"profiles": map[string]any{
+					"default": map[string]any{
+						"query": []string{"profile=prod"},
+					},
+				},
+			},
+		},
+	})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	var queries []string
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		queries = append(queries, r.URL.RawQuery)
+		page := r.URL.Query().Get("page")
+		body := `[{"id":3}]`
+		switch page {
+		case "4":
+			body = `[{"id":4}]`
+		case "5":
+			body = `[]`
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("limit query = %q, want 2", got)
+		}
+		if got := r.URL.Query().Get("profile"); got != "prod" {
+			t.Fatalf("profile query = %q, want prod", got)
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-q", "page=3", "-q", "limit=2", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	var values []map[string]int
+	if err := json.Unmarshal(out.Bytes(), &values); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", out.String(), err)
+	}
+	if len(values) != 2 || values[0]["id"] != 3 || values[1]["id"] != 4 {
+		t.Fatalf("values = %#v, want ids 3 and 4", values)
+	}
+	for _, want := range []string{"page=3", "page=4", "page=5"} {
+		if !strings.Contains(strings.Join(queries, "\n"), want) {
+			t.Fatalf("queries %#v missing %q", queries, want)
+		}
+	}
+}
+
+func TestPaginationPageParamUsesExplicitNextFromLaterPage(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url":   "https://api.example.com",
+				"pagination": map[string]any{"page_param": "page"},
+			},
+		},
+	})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	var queries []string
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		queries = append(queries, r.URL.RawQuery)
+		headers := http.Header{"Content-Type": []string{"application/json"}}
+		body := `[{"id":1}]`
+		switch {
+		case r.URL.Query().Get("page") == "2":
+			body = `[]`
+			headers.Set("Link", `<https://api.example.com/items?cursor=abc>; rel="next"`)
+		case r.URL.Query().Get("cursor") == "abc":
+			body = `[{"id":3}]`
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     headers,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	var values []map[string]int
+	if err := json.Unmarshal(out.Bytes(), &values); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", out.String(), err)
+	}
+	if len(values) != 2 || values[0]["id"] != 1 || values[1]["id"] != 3 {
+		t.Fatalf("values = %#v, want ids 1 and 3", values)
+	}
+	if got, want := strings.Join(queries, ","), ",page=2,cursor=abc"; got != want {
+		t.Fatalf("queries = %q, want %q", got, want)
+	}
+}
+
+func TestPaginationPageParamItemsPathPreservesWrapper(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url": "https://api.example.com",
+				"pagination": map[string]any{
+					"items_path": "data",
+					"page_param": "page",
+				},
+			},
+		},
+	})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		body := `{"data":[{"id":1}],"meta":{"page":1}}`
+		switch r.URL.Query().Get("page") {
+		case "2":
+			body = `{"data":[{"id":2}],"meta":{"page":2}}`
+		case "3":
+			body = `{"data":[],"meta":{"page":3}}`
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	var doc struct {
+		Data []map[string]int `json:"data"`
+		Meta map[string]int   `json:"meta"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("expected wrapped JSON output, got %q: %v", out.String(), err)
+	}
+	if len(doc.Data) != 2 || doc.Data[0]["id"] != 1 || doc.Data[1]["id"] != 2 {
+		t.Fatalf("data = %#v, want ids 1 and 2", doc.Data)
+	}
+	if doc.Meta["page"] != 1 {
+		t.Fatalf("meta = %#v, want first page wrapper metadata", doc.Meta)
+	}
+}
+
+func TestPaginationPageParamLaterHTTPErrorStopsSuccessfully(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url":   "https://api.example.com",
+				"pagination": map[string]any{"page_param": "page"},
+			},
+		},
+	})
+
+	c, out, errOut := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Query().Get("page") == "2" {
+			return &http.Response{
+				StatusCode: 404,
+				Proto:      "HTTP/1.1",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":"not found"}`)),
+				Request:    r,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1}]`)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var values []map[string]int
+	if err := json.Unmarshal(out.Bytes(), &values); err != nil {
+		t.Fatalf("expected valid JSON output, got %q: %v", out.String(), err)
+	}
+	if len(values) != 1 || values[0]["id"] != 1 {
+		t.Fatalf("values = %#v, want only first page", values)
+	}
+	if !strings.Contains(errOut.String(), "pagination page 2 returned HTTP 404; stopping") {
+		t.Fatalf("expected stopping warning, got %q", errOut.String())
+	}
+}
+
+func TestPaginationPageParamFirstHTTPErrorStillFails(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url":   "https://api.example.com",
+				"pagination": map[string]any{"page_param": "page"},
+			},
+		},
+	})
+
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 500,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1}]`)),
+			Request:    r,
+		}, nil
+	})
+
+	err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"})
+	if exitCode(err) != 5 {
+		t.Fatalf("exit code = %d, want 5 (err=%v)", exitCode(err), err)
+	}
+}
+
 // TestPaginationProgressOnStderr verifies that progress output goes to stderr
 // not stdout when paginating.
 func TestPaginationProgressOnStderr(t *testing.T) {

--- a/internal/cli/paginate_test.go
+++ b/internal/cli/paginate_test.go
@@ -1008,6 +1008,84 @@ func TestPaginationPageParamItemsPathPreservesWrapper(t *testing.T) {
 	}
 }
 
+func TestPaginationPageParamItemsPathMissingFails(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url": "https://api.example.com",
+				"pagination": map[string]any{
+					"items_path": "data",
+					"page_param": "page",
+				},
+			},
+		},
+	})
+
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"meta":{"page":1}}`)),
+			Request:    r,
+		}, nil
+	})
+
+	err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"})
+	if err == nil || !strings.Contains(err.Error(), "items_path") {
+		t.Fatalf("expected items_path error, got %v", err)
+	}
+}
+
+func TestPaginationPageParamItemsPathScalarWarnsAndSkipsPagination(t *testing.T) {
+	cfgData, _ := json.Marshal(map[string]any{
+		"apis": map[string]any{
+			"myapi": map[string]any{
+				"base_url": "https://api.example.com",
+				"pagination": map[string]any{
+					"items_path": "data",
+					"page_param": "page",
+				},
+			},
+		},
+	})
+
+	c, out, errOut := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, string(cfgData))
+	var pages []string
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"id":1},"meta":{"page":1}}`)),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items", "-o", "json"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var doc struct {
+		Data map[string]int `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("expected first page JSON, got %q: %v", out.String(), err)
+	}
+	if doc.Data["id"] != 1 {
+		t.Fatalf("data = %#v, want id 1", doc.Data)
+	}
+	if got := strings.Join(pages, ","); got != "" {
+		t.Fatalf("pages = %q, want only first request", got)
+	}
+	if !strings.Contains(errOut.String(), "items_path") {
+		t.Fatalf("expected items_path warning, got %q", errOut.String())
+	}
+}
+
 func TestPaginationPageParamLaterHTTPErrorStopsSuccessfully(t *testing.T) {
 	cfgData, _ := json.Marshal(map[string]any{
 		"apis": map[string]any{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,9 @@ type PaginationConfig struct {
 	// NextPath is a filter expression that extracts the next-page URL from the
 	// response body (alternative to Link header rel="next").
 	NextPath string `json:"next_path,omitempty"`
+	// PageParam is the URL query parameter that increments between pages when
+	// an API has no next links or next_path metadata.
+	PageParam string `json:"page_param,omitempty"`
 }
 
 // ProfileConfig holds per-profile overrides for an API.

--- a/site/content/en/docs/guides/pagination.md
+++ b/site/content/en/docs/guides/pagination.md
@@ -56,6 +56,31 @@ Configured `pagination.items_path` and `pagination.next_path` are strict: a
 typo, missing configured field, wrong body type, or non-string `next_path`
 result returns an error instead of silently truncating the collection.
 
+## APIs Without Next Links
+
+Some APIs paginate with a numeric query parameter but do not return a `next`
+link. Configure the API with `pagination.page_param` to let Restish increment
+that parameter when the first response is a collection:
+
+```json
+{
+  "apis": {
+    "example": {
+      "base_url": "https://api.example.com",
+      "pagination": { "page_param": "page" }
+    }
+  }
+}
+```
+
+Generic requests start at the URL you pass and request the next page by
+incrementing the configured parameter. Generated operations use this mode only
+when the operation request already includes that parameter, for example
+`restish example list-items --page 1`.
+Pagination stops when a synthesized page returns an empty collection. If a
+later synthesized page returns an HTTP error, Restish treats that as the end of
+the sequence and prints a warning, while first-page HTTP errors still fail.
+
 ## Collect Before Filtering
 
 Without `--rsh-collect`, filters run once for each paginated item. Each item is

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -93,7 +93,8 @@ restish config show -o json
       "retry_max_wait": "30s",
       "pagination": {
         "items_path": "data",
-        "next_path": "links.next"
+        "next_path": "links.next",
+        "page_param": "page"
       },
       "profiles": {
         "default": {},
@@ -155,6 +156,7 @@ PaginationConfig holds per-API pagination settings.
 | --- | --- | --- | --- | --- |
 | `items_path` | `ItemsPath` | `string` | no | ItemsPath is a filter expression that extracts the items array from the response body (e.g. "data" for JSON:API, "results" for some REST APIs). When empty, the body itself is used (if it is an array). |
 | `next_path` | `NextPath` | `string` | no | NextPath is a filter expression that extracts the next-page URL from the response body (alternative to Link header rel="next"). |
+| `page_param` | `PageParam` | `string` | no | PageParam is the URL query parameter that increments between pages when an API has no next links or next_path metadata. |
 
 ### `CacheConfig`
 


### PR DESCRIPTION
Fixes #267.

## Summary
- adds API-level `pagination.page_param` for APIs that paginate by incrementing a numeric query parameter without next links
- keeps explicit `Link` / `next_path` pagination precedence, including when later synthesized pages provide next metadata
- stops synthesized page-param pagination on empty collections or later-page HTTP errors, while first-page HTTP errors still fail
- documents the config and behavior in design and site docs

## Tests
- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestPaginationPageParam|TestGeneratedCommandPageParamPaginationRequiresPresentParam|TestRunPaginationHonorsContextCancellation'`\n- `env GOCACHE=/tmp/restish-gocache go test ./internal/config ./internal/cli`\n- `env GOCACHE=/tmp/restish-gocache go test ./...`\n- `env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...`\n- `hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache`\n- `env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check`\n\n## Review\n- Sub-agent review found two pagination edge cases; both were fixed and covered by tests.\n- Follow-up sub-agent review found no concrete issues.