### PR TITLE
fix: preserve configured header casing

### DIFF
--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -99,6 +99,7 @@ API fields:
 | `command_layout` | string | `flat` or `tags`; empty means `flat`. |
 | `server_variables` | map | Explicit OpenAPI server URL variable values used for generated operation paths. |
 | `retry_max_wait` | string duration | API-local cap for `Retry-After`/`X-Retry-In` when no flag/env override is set. |
+| `preserve_header_case` | bool | Opt-in HTTP/1.x compatibility mode for broken servers that treat request header names as case-sensitive. |
 | `pagination.items_path` | string | Item extraction path. |
 | `pagination.next_path` | string | Next URL extraction path. |
 | `profiles` | map | Profile configs keyed by name. |

--- a/internal/auth/api_key.go
+++ b/internal/auth/api_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // APIKey implements OpenAPI-style API key authentication in a header, query
@@ -34,7 +35,7 @@ func (h *APIKey) Authenticate(_ context.Context, req *http.Request, ac AuthConte
 
 	switch location {
 	case "header":
-		if req.Header.Get(name) == "" {
+		if getHeaderCaseInsensitive(req.Header, name) == "" {
 			req.Header.Set(name, value)
 		}
 	case "query":
@@ -51,4 +52,16 @@ func (h *APIKey) Authenticate(_ context.Context, req *http.Request, ac AuthConte
 		return fmt.Errorf("api-key: unsupported in %q (supported: header, query, cookie)", location)
 	}
 	return nil
+}
+
+func getHeaderCaseInsensitive(header http.Header, name string) string {
+	if value := header.Get(name); value != "" {
+		return value
+	}
+	for existing, values := range header {
+		if strings.EqualFold(existing, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
 }

--- a/internal/auth/api_key_test.go
+++ b/internal/auth/api_key_test.go
@@ -97,6 +97,19 @@ func TestAPIKeyAuthenticateDoesNotOverwriteExistingValues(t *testing.T) {
 			},
 		},
 		{
+			name:     "preserved-case header",
+			location: "header",
+			setup:    func(req *http.Request) { req.Header["X-SourceSystem"] = []string{"manual"} },
+			want: func(t *testing.T, req *http.Request) {
+				if got := req.Header["X-SourceSystem"]; len(got) != 1 || got[0] != "manual" {
+					t.Fatalf("X-SourceSystem = %#v, want manual", got)
+				}
+				if got := req.Header["X-Sourcesystem"]; len(got) != 0 {
+					t.Fatalf("canonicalized header was added: %#v", req.Header)
+				}
+			},
+		},
+		{
 			name:     "query",
 			location: "query",
 			setup: func(req *http.Request) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -63,7 +63,7 @@ type ForceCapable interface {
 }
 
 func bearerAuth(req *http.Request, token string) {
-	if req.Header.Get("Authorization") != "" {
+	if getHeaderCaseInsensitive(req.Header, "Authorization") != "" {
 		return
 	}
 	req.Header.Set("Authorization", "Bearer "+token)

--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -37,7 +37,7 @@ func (h *HTTPBasic) OnRequest(req *http.Request, params map[string]string) error
 			return fmt.Errorf("http-basic: prompting for password: %w", err)
 		}
 	}
-	if req.Header.Get("Authorization") == "" {
+	if getHeaderCaseInsensitive(req.Header, "Authorization") == "" {
 		req.SetBasicAuth(user, pass)
 	}
 	return nil

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -143,8 +143,12 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 			if err := c.ensureOAuthAuthorizationCodeReady(resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName); err != nil {
 				return err
 			}
+			preserveInsertedHeader := c.apiPreservesHeaderCase(apiName) && !authHeaderPresent(req.Header, resolvedAuth.Config.Type, params)
 			if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, false)); err != nil {
 				return err
+			}
+			if preserveInsertedHeader {
+				preserveAuthHeaderCase(req, resolvedAuth.Config.Type, params)
 			}
 			markAuthCredentialTargets(req, resolvedAuth.Config.Type, params)
 			return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
@@ -166,8 +170,12 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 				if err := c.ensureOAuthAuthorizationCodeReady(resolvedAuth.Config.Type, resolvedAuth.CacheKey, apiName, profileName); err != nil {
 					return err
 				}
+				preserveInsertedHeader := c.apiPreservesHeaderCase(apiName) && !authHeaderPresent(req.Header, resolvedAuth.Config.Type, params)
 				if err := handler.Authenticate(req.Context(), req, c.authContext(req.Context(), apiName, profileName, params, resolvedAuth.CacheKey, true)); err != nil {
 					return err
+				}
+				if preserveInsertedHeader {
+					preserveAuthHeaderCase(req, resolvedAuth.Config.Type, params)
 				}
 				markAuthCredentialTargets(req, resolvedAuth.Config.Type, params)
 				return c.runAuthHookPlugins(apiName, profileName, rawParams, secretKeys, req)
@@ -188,6 +196,49 @@ func (c *CLI) authOnRequest(apiName, profileName string, prof *config.ProfileCon
 		return c.runAuthHookPlugins(apiName, profileName, nil, nil, req)
 	}
 	return callbacks
+}
+
+func (c *CLI) apiPreservesHeaderCase(apiName string) bool {
+	return c != nil && c.cfg != nil && c.cfg.APIs != nil && c.cfg.APIs[apiName] != nil && c.cfg.APIs[apiName].PreserveHeaderCase
+}
+
+func preserveAuthHeaderCase(req *http.Request, authType string, params map[string]string) {
+	if req == nil || authType != "api-key" || strings.ToLower(strings.TrimSpace(params["in"])) != "header" {
+		return
+	}
+	name := strings.TrimSpace(params["name"])
+	if name == "" {
+		return
+	}
+	var values []string
+	for existing, existingValues := range req.Header {
+		if strings.EqualFold(existing, name) {
+			values = append(values, existingValues...)
+			delete(req.Header, existing)
+		}
+	}
+	if len(values) > 0 {
+		req.Header[name] = values
+	}
+}
+
+func authHeaderPresent(header http.Header, authType string, params map[string]string) bool {
+	if authType != "api-key" || strings.ToLower(strings.TrimSpace(params["in"])) != "header" {
+		return false
+	}
+	return preservedHeaderValue(header, strings.TrimSpace(params["name"])) != ""
+}
+
+func preservedHeaderValue(header http.Header, name string) string {
+	if value := header.Get(name); value != "" {
+		return value
+	}
+	for existing, values := range header {
+		if strings.EqualFold(existing, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
 }
 
 func markAuthCredentialTargets(req *http.Request, authType string, params map[string]string) {
@@ -214,7 +265,7 @@ func (c *CLI) applyCachedOAuthClientCredentials(req *http.Request, authType stri
 	if token == "" {
 		return false
 	}
-	if req.Header.Get("Authorization") == "" {
+	if preservedHeaderValue(req.Header, "Authorization") == "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	return true

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -686,6 +686,44 @@ func TestGeneratedCommandVerboseRedactsUncommonAPIKeyHeader(t *testing.T) {
 	}
 }
 
+func TestGeneratedCommandPreservesOperationAPIKeyHeaderCase(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupGeneratedEnvForSpec(t, mux, func(baseURL string) string {
+		return openAPIGetSpec(baseURL, "Auth API", "/protected", "getProtected",
+			openAPISecurity(`{"SourceSystem":[]}`),
+			openAPISecuritySchemes(`"SourceSystem":{"type":"apiKey","in":"header","name":"X-SourceSystem"}`))
+	})
+	env.writeAPIConfig(t, &config.APIConfig{
+		BaseURL:            env.baseURL(t),
+		PreserveHeaderCase: true,
+		Profiles: map[string]*config.ProfileConfig{
+			"default": {
+				Credentials: map[string]*config.CredentialConfig{
+					"SourceSystem": testCredential(apiKeyAuth("header", "X-SourceSystem", "secret")),
+				},
+			},
+		},
+	})
+
+	c := env.newCLI()
+	var gotHeader http.Header
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		gotHeader = r.Header.Clone()
+		return jsonResponse(200, `{}`), nil
+	})
+	if err := c.Run([]string{"restish", "tapi", "get-protected"}); err != nil {
+		t.Fatalf("get-protected failed: %v", err)
+	}
+	if got := gotHeader["X-SourceSystem"]; len(got) != 1 || got[0] != "secret" {
+		t.Fatalf("X-SourceSystem = %#v, want preserved generated API-key header", got)
+	}
+	if got := gotHeader["X-Sourcesystem"]; len(got) != 0 {
+		t.Fatalf("canonicalized generated API-key header was left behind: %#v", gotHeader)
+	}
+}
+
 func TestGeneratedCommandVerboseRedactsUncommonAPIKeyQuery(t *testing.T) {
 	var gotQuery url.Values
 	mux := http.NewServeMux()
@@ -4901,6 +4939,81 @@ func TestGeneratedCommandCrossOriginOperationServerRequiresAllow(t *testing.T) {
 	}
 	if gotInferencePath != "/v1/models" {
 		t.Fatalf("inference path = %q, want /v1/models", gotInferencePath)
+	}
+}
+
+func TestGeneratedCommandCrossOriginOperationServerPreservesHeaderCase(t *testing.T) {
+	operationServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	t.Cleanup(operationServer.Close)
+
+	controlMux := http.NewServeMux()
+	control := httptest.NewServer(controlMux)
+	t.Cleanup(control.Close)
+	specBody := fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Control API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/v1/models": {
+      "get": {
+        "operationId": "listModels",
+        "servers": [{"url": %q}],
+        "parameters": [
+          {"name": "X-SourceSystem", "in": "header", "schema": {"type": "string"}}
+        ],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, control.URL, operationServer.URL)
+	controlMux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, specBody)
+	})
+	controlMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	cfgFile := filepath.Join(t.TempDir(), "restish.json")
+	cacheDir := t.TempDir()
+	cfgData, _ := json.Marshal(&config.Config{APIs: map[string]*config.APIConfig{
+		"tapi": {
+			BaseURL:                 control.URL,
+			AllowedOperationOrigins: []string{operationServer.URL},
+			PreserveHeaderCase:      true,
+		},
+	}})
+	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	newCLI := func() *cli.CLI {
+		c := cli.New()
+		c.Stdin = strings.NewReader("")
+		c.Stdout = io.Discard
+		c.Stderr = io.Discard
+		c.Hooks().ConfigPath = cfgFile
+		c.Hooks().SpecCachePath = cacheDir
+		return c
+	}
+
+	if err := newCLI().Run([]string{"restish", "api", "sync", "tapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	var gotHeader http.Header
+	c := newCLI()
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		gotHeader = r.Header.Clone()
+		return jsonResponse(200, `{}`), nil
+	})
+	if err := c.Run([]string{"restish", "tapi", "list-models", "--x-source-system", "demo"}); err != nil {
+		t.Fatalf("list-models with allowed origin: %v", err)
+	}
+	if got := gotHeader["X-SourceSystem"]; len(got) != 1 || got[0] != "demo" {
+		t.Fatalf("X-SourceSystem = %#v, want preserved operation server header param; headers=%#v", got, gotHeader)
+	}
+	if got := gotHeader["X-Sourcesystem"]; len(got) != 0 {
+		t.Fatalf("operation server header param was canonicalized: %#v", gotHeader)
 	}
 }
 

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -186,6 +186,9 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 	if err != nil {
 		return err
 	}
+	if bodyOpts.explicitAPIName != "" && c.apiPreservesHeaderCase(bodyOpts.explicitAPIName) {
+		opts.PreserveHeaderCase = true
+	}
 	if opts.ContentType == "" && contentTypeOverride != "" {
 		opts.ContentType = contentTypeOverride
 	}
@@ -1813,6 +1816,9 @@ func (c *CLI) applyAPIProfile(rawURL, profileName string, opts request.Options, 
 			return rawURL, match.apiName, opts, fmt.Errorf("invalid retry_max_wait for API %q: %w", match.apiName, parseErr)
 		}
 		opts.RetryMaxWait = retryMaxWait
+	}
+	if match.api.PreserveHeaderCase {
+		opts.PreserveHeaderCase = true
 	}
 
 	if match.profile == nil {

--- a/internal/cli/http_test.go
+++ b/internal/cli/http_test.go
@@ -372,6 +372,131 @@ func TestHTTPHeader(t *testing.T) {
 	}
 }
 
+func TestHTTPPreserveHeaderCaseForProfileAndFlagHeaders(t *testing.T) {
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com",
+				"preserve_header_case": true,
+				"profiles": {
+					"default": {
+						"headers": ["X-SourceSystem: profile"]
+					}
+				}
+			}
+		}
+	}`
+	var rr requestRecorder
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		rr.capture(r)
+		return jsonResponse(200, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "-H", "X-RequestID: flag", "myapi/items"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	header := rr.Last().Header
+	if got := header["X-SourceSystem"]; len(got) != 1 || got[0] != "profile" {
+		t.Fatalf("X-SourceSystem = %#v, want preserved profile header", got)
+	}
+	if got := header["X-RequestID"]; len(got) != 1 || got[0] != "flag" {
+		t.Fatalf("X-RequestID = %#v, want preserved flag header", got)
+	}
+	if _, ok := header["X-Sourcesystem"]; ok {
+		t.Fatalf("profile header was canonicalized: %#v", header)
+	}
+	if _, ok := header["X-Requestid"]; ok {
+		t.Fatalf("flag header was canonicalized: %#v", header)
+	}
+}
+
+func TestHTTPPreserveHeaderCaseForAPIKeyAuth(t *testing.T) {
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com",
+				"preserve_header_case": true,
+				"profiles": {
+					"default": {
+						"auth": {
+							"type": "api-key",
+							"params": {
+								"in": "header",
+								"name": "X-SourceSystem",
+								"value": "secret"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	var rr requestRecorder
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		rr.capture(r)
+		return jsonResponse(200, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "myapi/items"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	header := rr.Last().Header
+	if got := header["X-SourceSystem"]; len(got) != 1 || got[0] != "secret" {
+		t.Fatalf("X-SourceSystem = %#v, want preserved api-key header", got)
+	}
+	if _, ok := header["X-Sourcesystem"]; ok {
+		t.Fatalf("api-key header was canonicalized: %#v", header)
+	}
+}
+
+func TestHTTPPreserveHeaderCaseDoesNotRewriteManualAPIKeyHeader(t *testing.T) {
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com",
+				"preserve_header_case": true,
+				"profiles": {
+					"default": {
+						"auth": {
+							"type": "api-key",
+							"params": {
+								"in": "header",
+								"name": "X-SourceSystem",
+								"value": "secret"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	var rr requestRecorder
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		rr.capture(r)
+		return jsonResponse(200, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "-H", "x-sourcesystem: manual", "myapi/items"}); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	header := rr.Last().Header
+	if got := header["x-sourcesystem"]; len(got) != 1 || got[0] != "manual" {
+		t.Fatalf("x-sourcesystem = %#v, want manual header with user casing", got)
+	}
+	if got := header["X-SourceSystem"]; len(got) != 0 {
+		t.Fatalf("manual API-key header was rewritten: %#v", header)
+	}
+	if got := header["X-Sourcesystem"]; len(got) != 0 {
+		t.Fatalf("auth added canonicalized duplicate: %#v", header)
+	}
+}
+
 func TestHTTPHostHeader(t *testing.T) {
 	var rr requestRecorder
 	c, _, _ := newTestCLI(t)

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -415,8 +415,12 @@ func (c *CLI) applyOperationAuthStep(req *http.Request, s operationAuthStep, for
 	if err := c.ensureOAuthAuthorizationCodeReady(s.authType, s.cacheKey, s.apiName, s.profileName); err != nil {
 		return err
 	}
+	preserveInsertedHeader := c.apiPreservesHeaderCase(s.apiName) && !authHeaderPresent(req.Header, s.authType, params)
 	if err := s.handler.Authenticate(req.Context(), req, c.authContext(req.Context(), s.apiName, s.profileName, params, s.cacheKey, force)); err != nil {
 		return err
+	}
+	if preserveInsertedHeader {
+		preserveAuthHeaderCase(req, s.authType, params)
 	}
 	markAuthCredentialTargets(req, s.authType, params)
 	return nil

--- a/internal/cli/operation_auth_test.go
+++ b/internal/cli/operation_auth_test.go
@@ -646,3 +646,61 @@ func TestOperationAuthCallbacksRunHookOnceForMultipleCredentials(t *testing.T) {
 		t.Fatalf("headers after operation auth = %#v", req.Header)
 	}
 }
+
+func TestOperationAuthPreservesAPIKeyHeaderCase(t *testing.T) {
+	c := &CLI{cfg: &config.Config{APIs: map[string]*config.APIConfig{
+		"svc": {PreserveHeaderCase: true},
+	}}}
+	selected := []selectedOperationAuth{{
+		requirement: spec.CredentialRequirement{ID: "SourceSystem"},
+		resolved: resolvedAuthConfig{
+			Config: &config.AuthConfig{Type: "api-key", Params: map[string]string{"in": "header", "name": "X-SourceSystem", "value": "secret"}},
+		},
+	}}
+
+	callbacks, err := c.operationAuthCallbacks("svc", "default", selected, authHandlerOptions{})
+	if err != nil {
+		t.Fatalf("operationAuthCallbacks: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com/items", nil)
+	if err := callbacks.OnRequest(req); err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if got := req.Header["X-SourceSystem"]; len(got) != 1 || got[0] != "secret" {
+		t.Fatalf("X-SourceSystem = %#v, want preserved operation auth header", got)
+	}
+	if got := req.Header["X-Sourcesystem"]; len(got) != 0 {
+		t.Fatalf("canonicalized operation auth header was left behind: %#v", req.Header)
+	}
+}
+
+func TestOperationAuthPreserveHeaderCaseDoesNotRewriteManualHeader(t *testing.T) {
+	c := &CLI{cfg: &config.Config{APIs: map[string]*config.APIConfig{
+		"svc": {PreserveHeaderCase: true},
+	}}}
+	selected := []selectedOperationAuth{{
+		requirement: spec.CredentialRequirement{ID: "SourceSystem"},
+		resolved: resolvedAuthConfig{
+			Config: &config.AuthConfig{Type: "api-key", Params: map[string]string{"in": "header", "name": "X-SourceSystem", "value": "secret"}},
+		},
+	}}
+
+	callbacks, err := c.operationAuthCallbacks("svc", "default", selected, authHandlerOptions{})
+	if err != nil {
+		t.Fatalf("operationAuthCallbacks: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com/items", nil)
+	req.Header["x-sourcesystem"] = []string{"manual"}
+	if err := callbacks.OnRequest(req); err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if got := req.Header["x-sourcesystem"]; len(got) != 1 || got[0] != "manual" {
+		t.Fatalf("x-sourcesystem = %#v, want manual header with user casing", got)
+	}
+	if got := req.Header["X-SourceSystem"]; len(got) != 0 {
+		t.Fatalf("manual operation auth header was rewritten: %#v", req.Header)
+	}
+	if got := req.Header["X-Sourcesystem"]; len(got) != 0 {
+		t.Fatalf("operation auth added canonicalized duplicate: %#v", req.Header)
+	}
+}

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -60,6 +60,9 @@ func (c *CLI) prepareRequest(
 			return nil, fmt.Errorf("API %q is not configured", explicitAPIName)
 		}
 		apiName = explicitAPIName
+		if c.cfg.APIs[explicitAPIName].PreserveHeaderCase {
+			opts.PreserveHeaderCase = true
+		}
 		if opts.CacheNamespace == "" {
 			opts.CacheNamespace = apiName + ":" + profileName
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,11 @@ type APIConfig struct {
 	// RetryMaxWait caps Retry-After/X-Retry-In delays for this API when no
 	// command-line or environment override is supplied.
 	RetryMaxWait string `json:"retry_max_wait,omitempty"`
+	// PreserveHeaderCase sends user/API-supplied header names with their
+	// configured casing for broken HTTP/1.x servers that treat names as
+	// case-sensitive. It cannot affect HTTP/2, where header names are lowercase
+	// by protocol.
+	PreserveHeaderCase bool `json:"preserve_header_case,omitempty"`
 }
 
 // PaginationConfig holds per-API pagination settings.

--- a/internal/request/do.go
+++ b/internal/request/do.go
@@ -141,6 +141,10 @@ type Options struct {
 	// If empty and a body is present, the caller is responsible for setting
 	// the header via Headers.
 	ContentType string
+	// PreserveHeaderCase keeps caller-supplied header names in Headers as-is
+	// instead of using net/http's canonical MIME casing. This is only useful
+	// for broken HTTP/1.x servers; HTTP/2 lowercases header names by protocol.
+	PreserveHeaderCase bool
 	// UserAgent, if non-empty, is sent when the caller has not supplied a
 	// User-Agent header.
 	UserAgent string
@@ -244,14 +248,14 @@ func Do(ctx context.Context, method, rawURL string, body io.Reader, opts Options
 			return nil, err
 		}
 		if strings.EqualFold(name, "Accept") || strings.EqualFold(name, "Accept-Encoding") {
-			req.Header.Set(name, value)
+			setRequestHeader(req.Header, name, value, opts.PreserveHeaderCase)
 			continue
 		}
 		if strings.EqualFold(name, "Host") {
 			req.Host = value
 			continue
 		}
-		req.Header.Add(name, value)
+		addRequestHeader(req.Header, name, value, opts.PreserveHeaderCase)
 	}
 
 	// Append extra query parameters.
@@ -271,7 +275,7 @@ func Do(ctx context.Context, method, rawURL string, body io.Reader, opts Options
 			return nil, fmt.Errorf("auth: %w", err)
 		}
 	}
-	if opts.UserAgent != "" && req.Header.Get("User-Agent") == "" {
+	if opts.UserAgent != "" && getRequestHeader(req.Header, "User-Agent") == "" {
 		req.Header.Set("User-Agent", opts.UserAgent)
 	}
 	if opts.OnBeforeRequest != nil {
@@ -355,6 +359,43 @@ func Do(ctx context.Context, method, rawURL string, body io.Reader, opts Options
 	return resp, nil
 }
 
+func setRequestHeader(header http.Header, name, value string, preserveCase bool) {
+	if !preserveCase {
+		header.Set(name, value)
+		return
+	}
+	deleteHeaderCaseInsensitive(header, name)
+	header[name] = []string{value}
+}
+
+func addRequestHeader(header http.Header, name, value string, preserveCase bool) {
+	if !preserveCase {
+		header.Add(name, value)
+		return
+	}
+	header[name] = append(header[name], value)
+}
+
+func deleteHeaderCaseInsensitive(header http.Header, name string) {
+	for existing := range header {
+		if strings.EqualFold(existing, name) {
+			delete(header, existing)
+		}
+	}
+}
+
+func getRequestHeader(header http.Header, name string) string {
+	if value := header.Get(name); value != "" {
+		return value
+	}
+	for existing, values := range header {
+		if strings.EqualFold(existing, name) && len(values) > 0 {
+			return values[0]
+		}
+	}
+	return ""
+}
+
 type doResult struct {
 	resp *http.Response
 	err  error
@@ -418,8 +459,8 @@ func credentialStrippingRedirectPolicy(req *http.Request, via []*http.Request) e
 		return nil
 	}
 	for name := range req.Header {
-		if IsCredentialHeader(name) {
-			req.Header.Del(name)
+		if IsCredentialHeader(name) || IsMarkedCredentialHeader(req, name) {
+			delete(req.Header, name)
 		}
 	}
 	return nil

--- a/internal/request/do_test.go
+++ b/internal/request/do_test.go
@@ -1,9 +1,11 @@
 package request_test
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -427,6 +429,96 @@ func TestDo_HostHeaderSetsRequestHost(t *testing.T) {
 	}
 }
 
+func TestDo_PreserveHeaderCaseWritesRawHTTP1Header(t *testing.T) {
+	raw := rawRequestForHeaders(t, request.Options{
+		Headers:            []string{"X-SourceSystem: demo"},
+		PreserveHeaderCase: true,
+	})
+	if !strings.Contains(raw, "\r\nX-SourceSystem: demo\r\n") {
+		t.Fatalf("raw request missing preserved header case:\n%s", raw)
+	}
+	if strings.Contains(raw, "\r\nX-Sourcesystem: demo\r\n") {
+		t.Fatalf("raw request used canonicalized header case:\n%s", raw)
+	}
+}
+
+func TestDo_DefaultCanonicalizesHeaderCase(t *testing.T) {
+	raw := rawRequestForHeaders(t, request.Options{
+		Headers: []string{"X-SourceSystem: demo"},
+	})
+	if !strings.Contains(raw, "\r\nX-Sourcesystem: demo\r\n") {
+		t.Fatalf("raw request missing canonicalized header case:\n%s", raw)
+	}
+}
+
+func TestDo_PreservedUserAgentSuppressesDefaultUserAgent(t *testing.T) {
+	raw := rawRequestForHeaders(t, request.Options{
+		Headers:            []string{"user-agent: custom-agent"},
+		PreserveHeaderCase: true,
+		UserAgent:          "restish-default",
+	})
+	if !strings.Contains(raw, "\r\nuser-agent: custom-agent\r\n") {
+		t.Fatalf("raw request missing preserved user-agent:\n%s", raw)
+	}
+	if strings.Contains(raw, "restish-default") {
+		t.Fatalf("default user-agent was added despite preserved user-agent:\n%s", raw)
+	}
+}
+
+func rawRequestForHeaders(t *testing.T, opts request.Options) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	rawCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		var raw strings.Builder
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				errCh <- err
+				return
+			}
+			raw.WriteString(line)
+			if line == "\r\n" {
+				break
+			}
+		}
+		if _, err := io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"); err != nil {
+			errCh <- err
+			return
+		}
+		rawCh <- raw.String()
+	}()
+
+	resp, err := request.Do(context.Background(), "GET", "http://"+ln.Addr().String()+"/items", nil, opts)
+	if err != nil {
+		t.Fatalf("Do() error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	select {
+	case raw := <-rawCh:
+		return raw
+	case err := <-errCh:
+		t.Fatalf("server error: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for raw request")
+	}
+	return ""
+}
+
 func TestDo_InvalidHeader(t *testing.T) {
 	_, err := request.Do(context.Background(), "GET", "https://api.example.com/items", nil, request.Options{
 		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
@@ -570,6 +662,62 @@ func TestDo_SeeOtherRedirectStripsBodyHeaders(t *testing.T) {
 	}
 	if gotContentType != "" || gotContentEncoding != "" {
 		t.Fatalf("body headers crossed 303 redirect: Content-Type=%q Content-Encoding=%q", gotContentType, gotContentEncoding)
+	}
+}
+
+func TestDo_CrossOriginRedirectStripsPreservedCaseCredentialHeader(t *testing.T) {
+	var gotAuth string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+	start := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer start.Close()
+
+	resp, err := request.Do(context.Background(), "GET", start.URL, nil, request.Options{
+		Headers:            []string{"authorization: Bearer secret"},
+		PreserveHeaderCase: true,
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotAuth != "" {
+		t.Fatalf("preserved-case Authorization crossed redirect: %q", gotAuth)
+	}
+}
+
+func TestDo_CrossOriginRedirectStripsMarkedPreservedCaseCredentialHeader(t *testing.T) {
+	var gotSourceSystem string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSourceSystem = r.Header.Get("X-SourceSystem")
+		w.WriteHeader(200)
+	}))
+	defer target.Close()
+	start := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer start.Close()
+
+	resp, err := request.Do(context.Background(), "GET", start.URL, nil, request.Options{
+		Headers:            []string{"X-SourceSystem: secret"},
+		PreserveHeaderCase: true,
+		OnRequest: func(req *http.Request) error {
+			request.MarkCredentialHeader(req, "X-SourceSystem")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if gotSourceSystem != "" {
+		t.Fatalf("marked preserved-case credential crossed redirect: %q", gotSourceSystem)
 	}
 }
 

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -91,6 +91,7 @@ restish config show -o json
       },
       "allowed_operation_origins": [],
       "retry_max_wait": "30s",
+      "preserve_header_case": false,
       "pagination": {
         "items_path": "data",
         "next_path": "links.next"
@@ -146,6 +147,7 @@ APIConfig holds per-API configuration.
 | `profiles` | `Profiles` | `map[string]*ProfileConfig` | no | Profiles is a map of profile name to profile configuration. |
 | `pagination` | `Pagination` | `*PaginationConfig` | no | Pagination holds optional per-API pagination configuration. |
 | `retry_max_wait` | `RetryMaxWait` | `string` | no | RetryMaxWait caps Retry-After/X-Retry-In delays for this API when no command-line or environment override is supplied. |
+| `preserve_header_case` | `PreserveHeaderCase` | `bool` | no | PreserveHeaderCase sends user/API-supplied header names with their configured casing for broken HTTP/1.x servers that treat names as case-sensitive. It cannot affect HTTP/2, where header names are lowercase by protocol. |
 
 ### `PaginationConfig`
 

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -91,7 +91,6 @@ restish config show -o json
       },
       "allowed_operation_origins": [],
       "retry_max_wait": "30s",
-      "preserve_header_case": false,
       "pagination": {
         "items_path": "data",
         "next_path": "links.next"


### PR DESCRIPTION
Fixes #230.

## Summary
- adds API-level `preserve_header_case` for broken HTTP/1.x APIs that treat request header names as case-sensitive
- preserves user/API-supplied casing for profile headers, `-H`, generated header params, API-key auth, and generated-operation auth
- keeps semantic header lookups case-insensitive so manual headers are not duplicated or rewritten
- preserves redirect safety by stripping static and auth-marked credential headers even with noncanonical casing
- documents the config and HTTP/2 limitation

## Tests
- `env GOCACHE=/tmp/restish-gocache go test ./internal/auth ./internal/request ./internal/cli -run 'TestAPIKeyAuthenticateDoesNotOverwriteExistingValues|TestDo_(PreservedUserAgentSuppressesDefaultUserAgent|CrossOriginRedirectStripsMarkedPreservedCaseCredentialHeader|CrossOriginRedirectStripsPreservedCaseCredentialHeader|PreserveHeaderCaseWritesRawHTTP1Header|DefaultCanonicalizesHeaderCase)|TestHTTPPreserveHeaderCase|TestOperationAuthPreserveHeaderCase|TestOperationAuthPreservesAPIKeyHeaderCase|TestGeneratedCommand(PreservesOperationAPIKeyHeaderCase|CrossOriginOperationServerPreservesHeaderCase)'`\n- `env GOCACHE=/tmp/restish-gocache go test ./internal/auth ./internal/config ./internal/request ./internal/cli`\n- `env GOCACHE=/tmp/restish-gocache go test ./...`\n- `env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...`\n- `env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check`\n- `hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache`\n\n## Review\n- Sub-agent reviews found redirect, generated auth, semantic lookup, manual override, and operation-server edge cases; all were fixed with targeted tests.\n- Final sub-agent review found no concrete issues.