### PR TITLE
feat: support HTTPS OAuth callbacks

### DIFF
--- a/docs/design/004-authentication.md
+++ b/docs/design/004-authentication.md
@@ -292,11 +292,11 @@ discovery advertises a device endpoint. Flow choice affects provider client
 registration, redirect URI policy, consent UX, token semantics, and debugging;
 the operator should choose it in config.
 
-Local HTTPS callbacks are a post-release extension, not a v2 release blocker.
-If added, the callback listener should be explicit and operator-controlled:
-configurable scheme/host/port/path plus either user-supplied certificate/key
-files or documented `mkcert` setup. Restish should not silently generate or
-trust local certificates on the user's behalf.
+Local HTTPS callbacks are supported for providers that reject HTTP redirect
+URIs. The callback listener stays on `localhost`; `redirect_scheme` selects
+`http` or `https`, and HTTPS requires operator-supplied `redirect_cert` and
+`redirect_key` files. Restish does not generate certificates, install trust
+roots, or broaden OAuth endpoint scheme validation on the user's behalf.
 
 ### Client Credentials Flow
 

--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -27,6 +27,7 @@ const defaultCallbackSuccessColor = "#5fafd7"
 const defaultCallbackFailureColor = "#E94F37"
 const callbackSuccessHTMLParam = "callback_success_html"
 const callbackErrorHTMLParam = "callback_error_html"
+const defaultRedirectScheme = "http"
 
 // AuthorizationCode implements the OAuth2 authorization code flow with PKCE
 // (RFC 7636). On first use it opens a browser and waits for the redirect
@@ -75,8 +76,11 @@ func (h *AuthorizationCode) Parameters() []Param {
 		{Name: "token_url", Description: "OAuth2 token endpoint URL", Required: false},
 		{Name: "issuer_url", Description: "OIDC issuer URL (used for discovery when authorize_url/token_url are absent)", Required: false},
 		{Name: "scopes", Description: "Space-separated OAuth2 scopes to request; some providers require offline_access for refresh tokens", Required: false},
+		{Name: "redirect_scheme", Description: "Local callback URL scheme: http (default) or https", Required: false},
 		{Name: "redirect_port", Description: fmt.Sprintf("Local port for the redirect callback (default %s)", defaultRedirectPort), Required: false},
 		{Name: "redirect_path", Description: "Local path for the redirect callback (default /)", Required: false},
+		{Name: "redirect_cert", Description: "Path to the PEM certificate for an HTTPS local callback", Required: false},
+		{Name: "redirect_key", Description: "Path to the PEM private key for an HTTPS local callback", Required: false, Secret: true},
 		{Name: callbackSuccessHTMLParam, Description: "Custom HTML for the successful browser callback page", Required: false},
 		{Name: callbackErrorHTMLParam, Description: "Custom HTML for the failed browser callback page; supports $ERROR, $TITLE, and $DETAILS placeholders", Required: false},
 	})
@@ -240,23 +244,20 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 	}
 	state := base64.RawURLEncoding.EncodeToString(stateBytes)
 
-	// Determine redirect port and URL.
-	port := params["redirect_port"]
-	if port == "" {
-		port = defaultRedirectPort
-	}
-	redirectPath, err := oauthRedirectPath(params["redirect_path"])
+	manualOnly := h.CanPrompt && h.NoBrowser && h.Prompt != nil
+
+	// Determine redirect URL.
+	redirect, err := oauthRedirectConfigFromParams(params, !manualOnly)
 	if err != nil {
 		return CachedToken{}, err
 	}
-	redirectURI := "http://localhost:" + port + redirectPath
 	callbackPages := h.oauthCallbackPages(params)
 
 	// Build authorization URL.
 	q := url.Values{
 		"response_type":         {"code"},
 		"client_id":             {params["client_id"]},
-		"redirect_uri":          {redirectURI},
+		"redirect_uri":          {redirect.uri},
 		"state":                 {state},
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
@@ -273,6 +274,9 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		callbackSuccessHTMLParam: true,
 		"redirect_path":          true,
 		"redirect_port":          true,
+		"redirect_scheme":        true,
+		"redirect_cert":          true,
+		"redirect_key":           true,
 		"token_url":              true,
 	}) {
 		if q.Get(key) == "" {
@@ -290,18 +294,17 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		doneCh chan error
 		srv    *http.Server
 	)
-	manualOnly := h.CanPrompt && h.NoBrowser && h.Prompt != nil
 	if !manualOnly {
 		codeCh = make(chan string, 1)
 		errCh = make(chan error, 1)
 		doneCh = make(chan error, 1)
 		var receivedCode atomic.Bool
-		ln, err := net.Listen("tcp", "localhost:"+port)
+		ln, err := net.Listen("tcp", "localhost:"+redirect.port)
 		if err != nil {
-			return CachedToken{}, fmt.Errorf("starting callback server on port %s: %w", port, err)
+			return CachedToken{}, fmt.Errorf("starting callback server on port %s: %w", redirect.port, err)
 		}
 		srv = &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != redirectPath {
+			if r.URL.Path != redirect.path {
 				http.NotFound(w, r)
 				return
 			}
@@ -352,7 +355,7 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 			}
 		})}
 		go func() {
-			if e := srv.Serve(ln); e != nil && e != http.ErrServerClosed {
+			if e := serveOAuthCallback(srv, ln, redirect); e != nil && e != http.ErrServerClosed {
 				trySendErr(errCh, e)
 			}
 		}()
@@ -412,7 +415,7 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 	form := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {code},
-		"redirect_uri":  {redirectURI},
+		"redirect_uri":  {redirect.uri},
 		"client_id":     {params["client_id"]},
 		"code_verifier": {verifier},
 	}
@@ -424,6 +427,53 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 		return CachedToken{}, err
 	}
 	return ct, nil
+}
+
+type oauthRedirectConfig struct {
+	scheme string
+	port   string
+	path   string
+	uri    string
+	cert   string
+	key    string
+}
+
+func oauthRedirectConfigFromParams(params map[string]string, requireTLSFiles bool) (oauthRedirectConfig, error) {
+	scheme := strings.ToLower(strings.TrimSpace(params["redirect_scheme"]))
+	if scheme == "" {
+		scheme = defaultRedirectScheme
+	}
+	if scheme != "http" && scheme != "https" {
+		return oauthRedirectConfig{}, fmt.Errorf("oauth-authorization-code: redirect_scheme must be http or https")
+	}
+	cert := params["redirect_cert"]
+	key := params["redirect_key"]
+	if scheme == "https" && requireTLSFiles && (cert == "" || key == "") {
+		return oauthRedirectConfig{}, fmt.Errorf("oauth-authorization-code: redirect_cert and redirect_key are required when redirect_scheme is https")
+	}
+	port := params["redirect_port"]
+	if port == "" {
+		port = defaultRedirectPort
+	}
+	path, err := oauthRedirectPath(params["redirect_path"])
+	if err != nil {
+		return oauthRedirectConfig{}, err
+	}
+	return oauthRedirectConfig{
+		scheme: scheme,
+		port:   port,
+		path:   path,
+		uri:    scheme + "://localhost:" + port + path,
+		cert:   cert,
+		key:    key,
+	}, nil
+}
+
+func serveOAuthCallback(srv *http.Server, ln net.Listener, redirect oauthRedirectConfig) error {
+	if redirect.scheme == "https" {
+		return srv.ServeTLS(ln, redirect.cert, redirect.key)
+	}
+	return srv.Serve(ln)
 }
 
 func (h *AuthorizationCode) oauthCallbackSuccessPage(title, detail string) string {

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -3,12 +3,20 @@ package auth
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -640,6 +648,187 @@ func TestAuthCode_RedirectPath(t *testing.T) {
 	}
 }
 
+func TestAuthCode_HTTPSCallback(t *testing.T) {
+	certPath, keyPath := writeOAuthCallbackCert(t)
+	tlsClient := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	var authorizeURL string
+	var gotForm url.Values
+	h := &AuthorizationCode{
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			gotForm = r.Form
+			return testResponse(200, "application/json", `{"access_token":"https-token","token_type":"bearer","expires_in":3600}`), nil
+		}),
+		OpenBrowser: func(raw string) error {
+			authorizeURL = raw
+			go func() {
+				callbackURL, state := mustCallbackURL(t, raw)
+				if !strings.HasPrefix(callbackURL, "https://localhost:") {
+					t.Errorf("callback URL = %q, want https localhost", callbackURL)
+					return
+				}
+				resp, err := tlsClient.Get(fmt.Sprintf("%s?state=%s&code=secure-code", callbackURL, url.QueryEscape(state)))
+				if err != nil {
+					t.Errorf("https callback request failed: %v", err)
+					return
+				}
+				resp.Body.Close()
+			}()
+			return nil
+		},
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+	err := h.OnRequest(req, map[string]string{
+		"client_id":       "id1",
+		"authorize_url":   "https://auth.example.com/authorize",
+		"token_url":       "https://auth.example.com/token",
+		"redirect_scheme": "https",
+		"redirect_port":   availablePort(t),
+		"redirect_path":   "/callback",
+		"redirect_cert":   certPath,
+		"redirect_key":    keyPath,
+	})
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer https-token" {
+		t.Fatalf("Authorization = %q, want HTTPS callback token", got)
+	}
+	parsedAuthorize, err := url.Parse(authorizeURL)
+	if err != nil {
+		t.Fatalf("parse authorize URL: %v", err)
+	}
+	redirectURI := parsedAuthorize.Query().Get("redirect_uri")
+	if !strings.HasPrefix(redirectURI, "https://localhost:") || !strings.HasSuffix(redirectURI, "/callback") {
+		t.Fatalf("authorize redirect_uri = %q, want HTTPS callback URI", redirectURI)
+	}
+	if got := gotForm.Get("redirect_uri"); got != redirectURI {
+		t.Fatalf("token redirect_uri = %q, want %q", got, redirectURI)
+	}
+	for _, key := range []string{"redirect_scheme", "redirect_port", "redirect_path", "redirect_cert", "redirect_key"} {
+		if got := parsedAuthorize.Query().Get(key); got != "" {
+			t.Fatalf("%s forwarded to authorize endpoint: %q", key, got)
+		}
+		if got := gotForm.Get(key); got != "" {
+			t.Fatalf("%s forwarded to token endpoint: %q", key, got)
+		}
+	}
+}
+
+func TestOAuthRedirectConfig(t *testing.T) {
+	cases := []struct {
+		name            string
+		params          map[string]string
+		requireTLSFiles bool
+		wantURI         string
+		wantError       string
+	}{
+		{
+			name:    "default",
+			params:  map[string]string{},
+			wantURI: "http://localhost:8484/",
+		},
+		{
+			name: "https",
+			params: map[string]string{
+				"redirect_scheme": "https",
+				"redirect_port":   "9443",
+				"redirect_path":   "/callback",
+				"redirect_cert":   "cert.pem",
+				"redirect_key":    "key.pem",
+			},
+			wantURI: "https://localhost:9443/callback",
+		},
+		{
+			name:      "invalid scheme",
+			params:    map[string]string{"redirect_scheme": "ftp"},
+			wantError: "redirect_scheme must be http or https",
+		},
+		{
+			name:            "https requires cert and key for callback listener",
+			params:          map[string]string{"redirect_scheme": "https", "redirect_cert": "cert.pem"},
+			requireTLSFiles: true,
+			wantError:       "redirect_cert and redirect_key are required",
+		},
+		{
+			name: "https manual URL does not require cert and key",
+			params: map[string]string{
+				"redirect_scheme": "https",
+				"redirect_port":   "9443",
+			},
+			wantURI: "https://localhost:9443/",
+		},
+		{
+			name:      "invalid path",
+			params:    map[string]string{"redirect_path": "callback"},
+			wantError: "redirect_path",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := oauthRedirectConfigFromParams(tc.params, tc.requireTLSFiles)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.uri != tc.wantURI {
+				t.Fatalf("uri = %q, want %q", got.uri, tc.wantURI)
+			}
+		})
+	}
+}
+
+func TestAuthCode_NoBrowserHTTPSDoesNotRequireCallbackCert(t *testing.T) {
+	var authorizeURL string
+	var gotForm url.Values
+	h := &AuthorizationCode{
+		NoBrowser: true,
+		CanPrompt: true,
+		Prompt: func(prompt string) (string, error) {
+			return "manual-code", nil
+		},
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			gotForm = r.Form
+			return testResponse(200, "application/json", `{"access_token":"manual-https-token","token_type":"bearer","expires_in":3600}`), nil
+		}),
+		OpenBrowser: func(raw string) error {
+			authorizeURL = raw
+			t.Fatalf("OpenBrowser should not be called in no-browser mode")
+			return nil
+		},
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+	err := h.OnRequest(req, map[string]string{
+		"client_id":       "id1",
+		"authorize_url":   "https://auth.example.com/authorize",
+		"token_url":       "https://auth.example.com/token",
+		"redirect_scheme": "https",
+		"redirect_port":   availablePort(t),
+	})
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if authorizeURL != "" {
+		t.Fatalf("OpenBrowser captured URL %q", authorizeURL)
+	}
+	if got := gotForm.Get("redirect_uri"); !strings.HasPrefix(got, "https://localhost:") {
+		t.Fatalf("token redirect_uri = %q, want HTTPS localhost", got)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer manual-https-token" {
+		t.Fatalf("Authorization = %q, want manual HTTPS token", got)
+	}
+}
+
 func TestOAuthRedirectPathValidation(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -1026,4 +1215,40 @@ func availablePort(t *testing.T) string {
 	}
 	defer ln.Close()
 	return fmt.Sprintf("%d", ln.Addr().(*net.TCPAddr).Port)
+}
+
+func writeOAuthCallbackCert(t *testing.T) (string, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:   time.Now().Add(-time.Minute),
+		NotAfter:    time.Now().Add(time.Hour),
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "callback.pem")
+	keyPath := filepath.Join(dir, "callback.key")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(certPath, certPEM, 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath
 }

--- a/internal/auth/oauth_common.go
+++ b/internal/auth/oauth_common.go
@@ -460,7 +460,11 @@ func applyOAuthTokenExtraParams(form url.Values, params map[string]string) {
 		// TODO(openapi-3.2): use oauth2_metadata_url for RFC 8414 metadata
 		// discovery in place of, or alongside, issuer_url.
 		"oauth2_metadata_url": true,
+		"redirect_cert":       true,
+		"redirect_key":        true,
+		"redirect_path":       true,
 		"redirect_port":       true,
+		"redirect_scheme":     true,
 		"token_url":           true,
 	}) {
 		if form.Get(key) == "" {

--- a/internal/auth/oauth_device_code.go
+++ b/internal/auth/oauth_device_code.go
@@ -252,7 +252,11 @@ func (h *DeviceCode) requestDeviceAuthorization(ctx context.Context, params map[
 		callbackSuccessHTMLParam:   true,
 		"device_authorization_url": true,
 		"issuer_url":               true,
+		"redirect_cert":            true,
+		"redirect_key":             true,
+		"redirect_path":            true,
 		"redirect_port":            true,
+		"redirect_scheme":          true,
 		"token_url":                true,
 	}) {
 		if form.Get(key) == "" {

--- a/internal/auth/oauth_device_code_test.go
+++ b/internal/auth/oauth_device_code_test.go
@@ -41,6 +41,11 @@ func TestDeviceCode_PollsUntilAuthorized(t *testing.T) {
 				if got := r.FormValue("device_code"); got != "device-123" {
 					t.Fatalf("device_code = %q", got)
 				}
+				for _, key := range []string{"redirect_scheme", "redirect_port", "redirect_path", "redirect_cert", "redirect_key"} {
+					if got := r.Form.Get(key); got != "" {
+						t.Fatalf("%s leaked into device token request: %#v", key, r.Form)
+					}
+				}
 				return testResponse(200, "application/json", `{"access_token":"device-token","token_type":"bearer","expires_in":3600}`), nil
 			default:
 				t.Fatalf("unexpected URL %q", r.URL.String())
@@ -56,6 +61,11 @@ func TestDeviceCode_PollsUntilAuthorized(t *testing.T) {
 		"token_url":                "https://auth.example.com/token",
 		"audience":                 "https://api.example.com/",
 		"cache_key":                "local-cache-key",
+		"redirect_scheme":          "https",
+		"redirect_port":            "8484",
+		"redirect_path":            "/callback",
+		"redirect_cert":            "./localhost.pem",
+		"redirect_key":             "./localhost.key",
 	}
 	if err := h.OnRequest(req, params); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -68,6 +78,11 @@ func TestDeviceCode_PollsUntilAuthorized(t *testing.T) {
 	}
 	if gotStart.Get("cache_key") != "" {
 		t.Fatalf("cache_key leaked into device auth request: %#v", gotStart)
+	}
+	for _, key := range []string{"redirect_scheme", "redirect_port", "redirect_path", "redirect_cert", "redirect_key"} {
+		if got := gotStart.Get(key); got != "" {
+			t.Fatalf("%s leaked into device auth request: %#v", key, gotStart)
+		}
 	}
 }
 

--- a/site/content/en/docs/guides/oauth.md
+++ b/site/content/en/docs/guides/oauth.md
@@ -138,6 +138,29 @@ Some providers distinguish `localhost` from `127.0.0.1`. Restish sends
 `localhost` in the authorization request, so exact-match providers must allow
 the `localhost` URL.
 
+If your provider requires an HTTPS redirect URL, provide your own local
+callback certificate and key:
+
+```jsonc
+{
+  "type": "oauth-authorization-code",
+  "params": {
+    "authorize_url": "https://issuer.test/authorize",
+    "token_url": "https://issuer.test/oauth/token",
+    "client_id": "env:CLIENT_ID",
+    "redirect_scheme": "https",
+    "redirect_port": "8484",
+    "redirect_path": "/callback",
+    "redirect_cert": "./localhost.pem",
+    "redirect_key": "./localhost.key"
+  }
+}
+```
+
+Allow `https://localhost:8484/callback` in the OAuth app. Restish does not
+generate certificates or install local trust roots; use a certificate that your
+browser accepts for `localhost`.
+
 The browser callback page uses the active Restish theme. To brand that local
 page, set `callback_success_html` and/or `callback_error_html` on the
 authorization-code profile:

--- a/site/content/en/docs/reference/auth.md
+++ b/site/content/en/docs/reference/auth.md
@@ -17,7 +17,7 @@ need different security schemes or alternatives.
 | `http-basic` | `username` | `password` | Sets HTTP Basic auth. If `password` is omitted and prompting is available, Restish prompts. |
 | `api-key` | `in`, `name`, `value` | | Sends an API key in a `header`, `query`, or `cookie`. |
 | `oauth-client-credentials` | `client_id`, `client_secret`, plus `token_url` or `issuer_url` | `auth_method`, `scopes`, provider-specific token params such as `audience` | Fetches and caches a bearer token with the OAuth client credentials flow. |
-| `oauth-authorization-code` | `client_id`, plus `authorize_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, `redirect_port`, `redirect_path`, `callback_success_html`, `callback_error_html`, provider-specific token params | Runs an OAuth authorization-code flow with PKCE and caches the token. |
+| `oauth-authorization-code` | `client_id`, plus `authorize_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, `redirect_scheme`, `redirect_port`, `redirect_path`, `redirect_cert`, `redirect_key`, `callback_success_html`, `callback_error_html`, provider-specific token params | Runs an OAuth authorization-code flow with PKCE and caches the token. |
 | `oauth-device-code` | `client_id`, plus `device_authorization_url` and `token_url`, or `issuer_url` | `client_secret`, `auth_method`, `scopes`, provider-specific token params | Runs the OAuth device-code flow and caches the token. |
 | `external-tool` | `commandline` | `omitbody`, `output` | Runs a local helper that can mutate request headers or URI. |
 
@@ -42,6 +42,11 @@ Some providers distinguish `localhost` from `127.0.0.1` or require loopback IP
 redirects. Restish currently sends `localhost` in the authorization request, so
 providers that perform exact redirect URI matching must allow the `localhost`
 callback URL.
+
+Set `redirect_scheme` to `https` when the OAuth app requires an HTTPS localhost
+callback. HTTPS callbacks require `redirect_cert` and `redirect_key`, both PEM
+paths used by the local callback server. Restish does not generate certificates
+or install browser trust roots.
 
 The browser callback page uses the active Restish theme by default.
 `callback_success_html` and `callback_error_html` replace the full success or


### PR DESCRIPTION
## Summary
- add optional HTTPS support for oauth-authorization-code localhost callbacks via redirect_scheme, redirect_cert, and redirect_key
- keep redirect params local so they are not forwarded to OAuth provider endpoints
- document the config shape and update the auth design note

Fixes #31

## Validation
- env GOCACHE=/tmp/restish-gocache go test ./internal/auth -run 'TestAuthCode_HTTPSCallback|TestOAuthRedirectConfig|TestAuthCode_NoBrowserHTTPSDoesNotRequireCallbackCert|TestDeviceCode_PollsUntilAuthorized'
- env GOCACHE=/tmp/restish-gocache go test ./internal/auth ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./...
- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...
- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache

## Review
- Sub-agent review found two P2 edge cases; both were fixed and follow-up review found no issues.