### PR TITLE
fix: resolve relative OAuth endpoints

### DIFF
--- a/docs/design/004-authentication.md
+++ b/docs/design/004-authentication.md
@@ -255,6 +255,14 @@ development flows. Public `http://`, custom schemes, embedded credentials,
 fragments, and preexisting query strings are rejected before any token or
 authorization request is sent.
 
+Manually configured OAuth endpoints may be path-relative when the selected API
+has a `base_url`. `oauth2/token` resolves under the effective API/profile base
+path, while `/oauth2/token` resolves at the same host root. Scheme-relative
+values are rejected, and the resolved endpoint still goes through the same
+HTTPS/loopback, credential, query, and fragment validation as absolute
+endpoints. `issuer_url` remains absolute-only because it defines the OIDC
+issuer identity.
+
 Discovery and token requests inherit the CLI HTTP client's timeout and TLS
 configuration. This keeps `--rsh-timeout`, CA roots, TLS minimum version, and
 `--rsh-insecure` consistent across ordinary requests and auth setup. OAuth

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -38,6 +38,7 @@ type Logger interface {
 type AuthContext struct {
 	APIName     string
 	ProfileName string
+	BaseURL     string
 	CacheKey    string
 	Params      map[string]string // user-supplied only
 	TokenStore  TokenStore
@@ -80,6 +81,9 @@ func authParams(ac AuthContext) map[string]string {
 		params["_cache_key"] = ac.CacheKey
 	case ac.APIName != "" || ac.ProfileName != "":
 		params["_cache_key"] = ac.APIName + ":" + ac.ProfileName
+	}
+	if ac.BaseURL != "" {
+		params["_base_url"] = ac.BaseURL
 	}
 	return params
 }

--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -177,10 +177,11 @@ func (h *AuthorizationCode) SupportsForce() {}
 
 func (h *AuthorizationCode) resolveTokenURL(ctx context.Context, params map[string]string) (string, error) {
 	if u := params["token_url"]; u != "" {
-		if err := validateDirectOAuthEndpoint("token_url", u); err != nil {
+		resolved, err := resolveOAuthEndpoint("token_url", u, params["_base_url"])
+		if err != nil {
 			return "", err
 		}
-		return u, nil
+		return resolved, nil
 	}
 	_, tokenURL, err := h.resolveEndpoints(ctx, params)
 	return tokenURL, err
@@ -190,14 +191,18 @@ func (h *AuthorizationCode) resolveEndpoints(ctx context.Context, params map[str
 	authorizeURL = params["authorize_url"]
 	tokenURL = params["token_url"]
 	if authorizeURL != "" {
-		if err := validateDirectOAuthEndpoint("authorize_url", authorizeURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("authorize_url", authorizeURL, params["_base_url"])
+		if err != nil {
 			return "", "", err
 		}
+		authorizeURL = resolved
 	}
 	if tokenURL != "" {
-		if err := validateDirectOAuthEndpoint("token_url", tokenURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("token_url", tokenURL, params["_base_url"])
+		if err != nil {
 			return "", "", err
 		}
+		tokenURL = resolved
 	}
 	if authorizeURL == "" || tokenURL == "" {
 		issuer := params["issuer_url"]
@@ -266,6 +271,7 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 	}
 	for key, value := range extraOAuthParams(params, map[string]bool{
 		"_cache_key":             true,
+		"_base_url":              true,
 		"authorize_url":          true,
 		"cache_key":              true,
 		"issuer_url":             true,

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -286,6 +286,24 @@ func TestAuthCodeRejectsInvalidDirectEndpoints(t *testing.T) {
 	}
 }
 
+func TestAuthCodeResolvesRelativeEndpoints(t *testing.T) {
+	h := &AuthorizationCode{}
+	authorizeURL, tokenURL, err := h.resolveEndpoints(context.Background(), map[string]string{
+		"authorize_url": "oauth2/authorize",
+		"token_url":     "/oauth2/token",
+		"_base_url":     "https://api.example.com/v1",
+	})
+	if err != nil {
+		t.Fatalf("resolveEndpoints: %v", err)
+	}
+	if authorizeURL != "https://api.example.com/v1/oauth2/authorize" {
+		t.Fatalf("authorizeURL = %q", authorizeURL)
+	}
+	if tokenURL != "https://api.example.com/oauth2/token" {
+		t.Fatalf("tokenURL = %q", tokenURL)
+	}
+}
+
 func TestAuthCode_BrowserFlow_FaviconRequestDoesNotAbort(t *testing.T) {
 	var stderr bytes.Buffer
 	h := &AuthorizationCode{

--- a/internal/auth/oauth_client_creds.go
+++ b/internal/auth/oauth_client_creds.go
@@ -72,9 +72,11 @@ func (h *ClientCredentials) resolveToken(ctx context.Context, params map[string]
 	// Resolve token URL (possibly via OIDC discovery).
 	tokenURL := params["token_url"]
 	if tokenURL != "" {
-		if err := validateDirectOAuthEndpoint("token_url", tokenURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("token_url", tokenURL, params["_base_url"])
+		if err != nil {
 			return "", err
 		}
+		tokenURL = resolved
 	} else {
 		issuer := params["issuer_url"]
 		if issuer == "" {

--- a/internal/auth/oauth_client_creds_test.go
+++ b/internal/auth/oauth_client_creds_test.go
@@ -51,6 +51,32 @@ func TestClientCredentials_FetchesToken(t *testing.T) {
 	}
 }
 
+func TestClientCredentialsResolvesRelativeTokenURL(t *testing.T) {
+	var gotTokenURL string
+	h := &ClientCredentials{
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			gotTokenURL = r.URL.String()
+			return testResponse(200, "application/json", `{"access_token":"relative-token","token_type":"bearer","expires_in":3600}`), nil
+		}),
+	}
+	req, _ := http.NewRequest("GET", "https://api.example.com/items", nil)
+	err := h.OnRequest(req, map[string]string{
+		"client_id":     "id1",
+		"client_secret": "sec1",
+		"token_url":     "oauth2/token",
+		"_base_url":     "https://api.example.com/v1",
+	})
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if gotTokenURL != "https://api.example.com/v1/oauth2/token" {
+		t.Fatalf("token URL = %q", gotTokenURL)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer relative-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
 func TestClientCredentialsRejectsInvalidDirectTokenEndpoint(t *testing.T) {
 	h := &ClientCredentials{}
 	req, _ := http.NewRequest("GET", "https://api.example.com/items", nil)

--- a/internal/auth/oauth_common.go
+++ b/internal/auth/oauth_common.go
@@ -275,6 +275,37 @@ func validateDirectOAuthEndpoint(paramName, rawURL string) error {
 	}
 }
 
+func resolveOAuthEndpoint(paramName, rawURL, baseURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("%s: invalid OAuth endpoint URL %q: %w", paramName, rawURL, err)
+	}
+	if u.IsAbs() {
+		if err := validateDirectOAuthEndpoint(paramName, rawURL); err != nil {
+			return "", err
+		}
+		return rawURL, nil
+	}
+	if u.Host != "" {
+		return "", fmt.Errorf("%s: OAuth endpoint URL %q must not be scheme-relative", paramName, rawURL)
+	}
+	if baseURL == "" {
+		return "", fmt.Errorf("%s: relative OAuth endpoint URL %q requires API base_url", paramName, rawURL)
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil || !base.IsAbs() || base.Host == "" {
+		return "", fmt.Errorf("%s: relative OAuth endpoint URL %q cannot resolve against invalid API base_url %q", paramName, rawURL, baseURL)
+	}
+	if !strings.HasSuffix(base.Path, "/") {
+		base.Path += "/"
+	}
+	resolved := base.ResolveReference(u).String()
+	if err := validateDirectOAuthEndpoint(paramName, resolved); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
 func isLoopbackOAuthHost(host string) bool {
 	host = strings.TrimSuffix(host, ".")
 	if strings.EqualFold(host, "localhost") {
@@ -452,6 +483,7 @@ func applyTokenAuthHeader(req *http.Request, params map[string]string) {
 func applyOAuthTokenExtraParams(form url.Values, params map[string]string) {
 	for key, value := range extraOAuthParams(params, map[string]bool{
 		"_cache_key":             true,
+		"_base_url":              true,
 		"authorize_url":          true,
 		"cache_key":              true,
 		callbackErrorHTMLParam:   true,

--- a/internal/auth/oauth_common_test.go
+++ b/internal/auth/oauth_common_test.go
@@ -322,6 +322,75 @@ func TestValidateDirectOAuthEndpoint(t *testing.T) {
 	}
 }
 
+func TestResolveOAuthEndpoint(t *testing.T) {
+	cases := []struct {
+		name      string
+		rawURL    string
+		baseURL   string
+		want      string
+		wantError string
+	}{
+		{
+			name:    "absolute https",
+			rawURL:  "https://auth.example.com/token",
+			baseURL: "https://api.example.com/v1",
+			want:    "https://auth.example.com/token",
+		},
+		{
+			name:    "path relative resolves under base path",
+			rawURL:  "oauth2/token",
+			baseURL: "https://api.example.com/v1",
+			want:    "https://api.example.com/v1/oauth2/token",
+		},
+		{
+			name:    "root relative resolves at host root",
+			rawURL:  "/oauth2/token",
+			baseURL: "https://api.example.com/v1",
+			want:    "https://api.example.com/oauth2/token",
+		},
+		{
+			name:      "scheme relative rejected",
+			rawURL:    "//auth.example.com/token",
+			baseURL:   "https://api.example.com/v1",
+			wantError: "scheme-relative",
+		},
+		{
+			name:      "relative without base rejected",
+			rawURL:    "oauth2/token",
+			wantError: "requires API base_url",
+		},
+		{
+			name:      "relative query rejected after resolution",
+			rawURL:    "oauth2/token?audience=api",
+			baseURL:   "https://api.example.com/v1",
+			wantError: "query string",
+		},
+		{
+			name:      "relative public http still rejected",
+			rawURL:    "oauth2/token",
+			baseURL:   "http://api.example.com/v1",
+			wantError: "must use https",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveOAuthEndpoint("token_url", tc.rawURL, tc.baseURL)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolved = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestValidateOAuthIssuerURL(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/auth/oauth_device_code.go
+++ b/internal/auth/oauth_device_code.go
@@ -103,10 +103,11 @@ func (h *DeviceCode) doRefresh(ctx context.Context, params map[string]string, to
 
 func (h *DeviceCode) resolveTokenURL(ctx context.Context, params map[string]string) (string, error) {
 	if tokenURL := params["token_url"]; tokenURL != "" {
-		if err := validateDirectOAuthEndpoint("token_url", tokenURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("token_url", tokenURL, params["_base_url"])
+		if err != nil {
 			return "", err
 		}
-		return tokenURL, nil
+		return resolved, nil
 	}
 	issuer := params["issuer_url"]
 	if issuer == "" {
@@ -129,14 +130,18 @@ func (h *DeviceCode) resolveEndpoints(ctx context.Context, params map[string]str
 	deviceURL := params["device_authorization_url"]
 	tokenURL := params["token_url"]
 	if deviceURL != "" {
-		if err := validateDirectOAuthEndpoint("device_authorization_url", deviceURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("device_authorization_url", deviceURL, params["_base_url"])
+		if err != nil {
 			return "", "", err
 		}
+		deviceURL = resolved
 	}
 	if tokenURL != "" {
-		if err := validateDirectOAuthEndpoint("token_url", tokenURL); err != nil {
+		resolved, err := resolveOAuthEndpoint("token_url", tokenURL, params["_base_url"])
+		if err != nil {
 			return "", "", err
 		}
+		tokenURL = resolved
 	}
 	if deviceURL != "" && tokenURL != "" {
 		return deviceURL, tokenURL, nil
@@ -246,6 +251,7 @@ func (h *DeviceCode) requestDeviceAuthorization(ctx context.Context, params map[
 	}
 	for key, value := range extraOAuthParams(params, map[string]bool{
 		"_cache_key":               true,
+		"_base_url":                true,
 		"authorize_url":            true,
 		"cache_key":                true,
 		callbackErrorHTMLParam:     true,

--- a/internal/auth/oauth_device_code_test.go
+++ b/internal/auth/oauth_device_code_test.go
@@ -55,6 +55,7 @@ func TestDeviceCode_PollsUntilAuthorized(t *testing.T) {
 		"device_authorization_url": "https://auth.example.com/device",
 		"token_url":                "https://auth.example.com/token",
 		"audience":                 "https://api.example.com/",
+		"_base_url":                "https://api.example.com/v1",
 		"cache_key":                "local-cache-key",
 	}
 	if err := h.OnRequest(req, params); err != nil {
@@ -68,6 +69,9 @@ func TestDeviceCode_PollsUntilAuthorized(t *testing.T) {
 	}
 	if gotStart.Get("cache_key") != "" {
 		t.Fatalf("cache_key leaked into device auth request: %#v", gotStart)
+	}
+	if gotStart.Get("_base_url") != "" {
+		t.Fatalf("_base_url leaked into device auth request: %#v", gotStart)
 	}
 }
 
@@ -107,6 +111,24 @@ func TestDeviceCode_OIDCDiscovery(t *testing.T) {
 	}
 	if got := req.Header.Get("Authorization"); got != "Bearer device-token" {
 		t.Fatalf("Authorization = %q", got)
+	}
+}
+
+func TestDeviceCodeResolvesRelativeEndpoints(t *testing.T) {
+	h := &DeviceCode{}
+	deviceURL, tokenURL, err := h.resolveEndpoints(context.Background(), map[string]string{
+		"device_authorization_url": "oauth2/device",
+		"token_url":                "/oauth2/token",
+		"_base_url":                "https://api.example.com/v1",
+	})
+	if err != nil {
+		t.Fatalf("resolveEndpoints: %v", err)
+	}
+	if deviceURL != "https://api.example.com/v1/oauth2/device" {
+		t.Fatalf("deviceURL = %q", deviceURL)
+	}
+	if tokenURL != "https://api.example.com/oauth2/token" {
+		t.Fatalf("tokenURL = %q", tokenURL)
 	}
 }
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -286,7 +287,11 @@ func (c *CLI) resolveProfileAuth(apiName, profileName string, prof *config.Profi
 		return resolvedAuthConfig{}, fmt.Errorf("profile %q of API %q has both auth and auth_ref", profileName, apiName)
 	}
 	if prof.AuthRef == "" {
-		return resolvedAuthConfig{Config: prof.Auth}, nil
+		cacheKey := ""
+		if prof.Auth != nil {
+			cacheKey = inlineAuthCacheKey(apiName+":"+profileName, prof.Auth, c.authBaseURL(apiName, profileName))
+		}
+		return resolvedAuthConfig{Config: prof.Auth, CacheKey: cacheKey}, nil
 	}
 	if c.cfg == nil || c.cfg.AuthProfiles == nil || c.cfg.AuthProfiles[prof.AuthRef] == nil {
 		return resolvedAuthConfig{}, fmt.Errorf("profile %q of API %q references unknown auth profile %q", profileName, apiName, prof.AuthRef)
@@ -295,7 +300,7 @@ func (c *CLI) resolveProfileAuth(apiName, profileName string, prof *config.Profi
 	return resolvedAuthConfig{
 		Config:   ac,
 		Ref:      prof.AuthRef,
-		CacheKey: sharedAuthCacheKey(prof.AuthRef, ac),
+		CacheKey: sharedAuthCacheKey(prof.AuthRef, ac, c.authBaseURL(apiName, profileName)),
 	}, nil
 }
 
@@ -401,6 +406,7 @@ func (c *CLI) authContext(ctx context.Context, apiName, profileName string, para
 	return auth.AuthContext{
 		APIName:     apiName,
 		ProfileName: profileName,
+		BaseURL:     c.authBaseURL(apiName, profileName),
 		CacheKey:    cacheKey,
 		Params:      params,
 		TokenStore:  auth.NewTokenCache(c.tokenCachePath()),
@@ -412,7 +418,18 @@ func (c *CLI) authContext(ctx context.Context, apiName, profileName string, para
 	}
 }
 
-func sharedAuthCacheKey(ref string, ac *config.AuthConfig) string {
+func (c *CLI) authBaseURL(apiName, profileName string) string {
+	if c.cfg == nil || c.cfg.APIs == nil {
+		return ""
+	}
+	api := c.cfg.APIs[apiName]
+	if api == nil {
+		return ""
+	}
+	return effectiveProfileBaseURL(api, profileName)
+}
+
+func sharedAuthCacheKey(ref string, ac *config.AuthConfig, baseURL string) string {
 	if ac == nil {
 		return ""
 	}
@@ -424,6 +441,9 @@ func sharedAuthCacheKey(ref string, ac *config.AuthConfig) string {
 		if value := ac.Params[name]; value != "" {
 			relevant[name] = value
 		}
+	}
+	if baseURL != "" && authConfigUsesRelativeOAuthEndpoint(ac) {
+		relevant["base_url"] = baseURL
 	}
 	var keys []string
 	for key := range relevant {
@@ -439,6 +459,31 @@ func sharedAuthCacheKey(ref string, ac *config.AuthConfig) string {
 	}
 	sum := sha256.Sum256([]byte(b.String()))
 	return "auth_profile:" + ref + ":" + hex.EncodeToString(sum[:8])
+}
+
+func inlineAuthCacheKey(baseKey string, ac *config.AuthConfig, baseURL string) string {
+	if !authConfigUsesRelativeOAuthEndpoint(ac) || baseURL == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(baseURL))
+	return baseKey + ":base_url:" + hex.EncodeToString(sum[:8])
+}
+
+func authConfigUsesRelativeOAuthEndpoint(ac *config.AuthConfig) bool {
+	if ac == nil {
+		return false
+	}
+	for _, name := range []string{"authorize_url", "device_authorization_url", "token_url"} {
+		if value := ac.Params[name]; value != "" && isRelativeOAuthEndpointValue(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRelativeOAuthEndpointValue(value string) bool {
+	u, err := url.Parse(value)
+	return err == nil && !u.IsAbs() && u.Host == ""
 }
 
 type limitedWriter struct {

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -100,6 +100,65 @@ func TestConfiguredCredentialsCountsAuthRef(t *testing.T) {
 	}
 }
 
+func TestSharedAuthCacheKeyIncludesBaseURLForRelativeEndpoints(t *testing.T) {
+	ac := &config.AuthConfig{
+		Type: "oauth-client-credentials",
+		Params: map[string]string{
+			"client_id": "myid",
+			"token_url": "oauth2/token",
+		},
+	}
+	one := sharedAuthCacheKey("shared", ac, "https://one.example.com/api")
+	two := sharedAuthCacheKey("shared", ac, "https://two.example.com/api")
+	if one == two {
+		t.Fatalf("relative endpoint cache keys should differ by base URL: %q", one)
+	}
+}
+
+func TestSharedAuthCacheKeyIgnoresBaseURLForAbsoluteEndpoints(t *testing.T) {
+	ac := &config.AuthConfig{
+		Type: "oauth-client-credentials",
+		Params: map[string]string{
+			"client_id": "myid",
+			"token_url": "https://auth.example.com/oauth2/token",
+		},
+	}
+	one := sharedAuthCacheKey("shared", ac, "https://one.example.com/api")
+	two := sharedAuthCacheKey("shared", ac, "https://two.example.com/api")
+	if one != two {
+		t.Fatalf("absolute endpoint cache keys should ignore API base URL: %q != %q", one, two)
+	}
+}
+
+func TestInlineAuthCacheKeyIncludesBaseURLForRelativeEndpoints(t *testing.T) {
+	ac := &config.AuthConfig{
+		Type: "oauth-device-code",
+		Params: map[string]string{
+			"client_id":                "myid",
+			"device_authorization_url": "oauth2/device",
+			"token_url":                "oauth2/token",
+		},
+	}
+	one := inlineAuthCacheKey("api:default", ac, "https://one.example.com/api")
+	two := inlineAuthCacheKey("api:default", ac, "https://two.example.com/api")
+	if one == "" || two == "" || one == two {
+		t.Fatalf("inline relative endpoint cache keys = %q and %q, want non-empty and different", one, two)
+	}
+}
+
+func TestInlineAuthCacheKeyFallsBackForAbsoluteEndpoints(t *testing.T) {
+	ac := &config.AuthConfig{
+		Type: "oauth-client-credentials",
+		Params: map[string]string{
+			"client_id": "myid",
+			"token_url": "https://auth.example.com/oauth2/token",
+		},
+	}
+	if got := inlineAuthCacheKey("api:default", ac, "https://one.example.com/api"); got != "" {
+		t.Fatalf("inline absolute endpoint cache key = %q, want fallback", got)
+	}
+}
+
 func TestAuthHandlerForOAuthUsesThemeCallbackColors(t *testing.T) {
 	if err := output.SetTheme(output.ThemeEntries{
 		"status_2xx":   "bold #00ff00",

--- a/internal/cli/oauth_test.go
+++ b/internal/cli/oauth_test.go
@@ -80,6 +80,57 @@ func TestOAuthClientCredentials_BearerHeader(t *testing.T) {
 	}
 }
 
+func TestOAuthClientCredentials_RelativeTokenURLUsesProfileBase(t *testing.T) {
+	var rr requestRecorder
+	var tokenURL string
+	c, _, _ := newTestCLI(t)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch r.URL.String() {
+		case "https://staging.example.com/api/oauth2/token":
+			tokenURL = r.URL.String()
+			return oauthTokenResponse(r, "relative-token"), nil
+		case "https://staging.example.com/api/items":
+			rr.capture(r)
+			return jsonResponse(200, `{}`), nil
+		default:
+			return jsonResponse(404, `{"error":"not found"}`), nil
+		}
+	})
+
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com/v1",
+				"profiles": {
+					"default": {
+						"base_url": "https://staging.example.com/api",
+						"auth": {
+							"type": "oauth-client-credentials",
+							"params": {
+								"client_id": "myid",
+								"client_secret": "mysecret",
+								"token_url": "oauth2/token"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	c.Hooks().TokenCachePath = filepath.Join(t.TempDir(), "tokens.json")
+
+	if err := c.Run([]string{"restish", "get", "myapi/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tokenURL != "https://staging.example.com/api/oauth2/token" {
+		t.Fatalf("token URL = %q", tokenURL)
+	}
+	if got := rr.Last().Header.Get("Authorization"); got != "Bearer relative-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
 func TestOAuthClientCredentials_EnvSecretSource(t *testing.T) {
 	t.Setenv("RESTISH_TEST_CLIENT_SECRET", "resolved-secret")
 	var gotSecret string
@@ -593,6 +644,63 @@ func TestOAuthAuthorizationCode_NoBrowserManualCodeFallback(t *testing.T) {
 	}
 }
 
+func TestOAuthAuthorizationCode_RelativeEndpointsUseBaseURL(t *testing.T) {
+	var rr requestRecorder
+	var tokenRedirectURI string
+	c, _, errBuf := newTestCLI(t)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch r.URL.String() {
+		case "https://api.example.com/v1/oauth2/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			tokenRedirectURI = r.FormValue("redirect_uri")
+			return oauthTokenResponse(r, "relative-auth-code-token"), nil
+		case "https://api.example.com/v1/items":
+			rr.capture(r)
+			return jsonResponse(200, `{}`), nil
+		default:
+			return jsonResponse(404, `{"error":"not found"}`), nil
+		}
+	})
+
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com/v1",
+				"profiles": {
+					"default": {
+						"auth": {
+							"type": "oauth-authorization-code",
+							"params": {
+								"client_id": "myid",
+								"authorize_url": "oauth2/authorize",
+								"token_url": "oauth2/token"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	c.Hooks().TokenCachePath = filepath.Join(t.TempDir(), "tokens.json")
+	c.Hooks().PassReader = strings.NewReader("manual-code\n")
+
+	if err := c.Run([]string{"restish", "--rsh-no-browser", "get", "myapi/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "https://api.example.com/v1/oauth2/authorize?") {
+		t.Fatalf("expected resolved authorize URL, got %q", errBuf.String())
+	}
+	if tokenRedirectURI != "http://localhost:8484/" {
+		t.Fatalf("redirect_uri = %q", tokenRedirectURI)
+	}
+	if got := rr.Last().Header.Get("Authorization"); got != "Bearer relative-auth-code-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
 func TestOAuthDeviceCodeFlow(t *testing.T) {
 	var rr requestRecorder
 	c, _, errBuf := newTestCLI(t)
@@ -649,6 +757,78 @@ func TestOAuthDeviceCodeFlow(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := rr.Last().Header.Get("Authorization"); got != "Bearer device-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if !strings.Contains(errBuf.String(), "verify.example.com") {
+		t.Fatalf("expected verification instructions on stderr, got %q", errBuf.String())
+	}
+}
+
+func TestOAuthDeviceCode_RelativeEndpointsUseBaseURL(t *testing.T) {
+	var rr requestRecorder
+	var deviceURL string
+	var tokenURL string
+	c, _, errBuf := newTestCLI(t)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch r.URL.String() {
+		case "https://api.example.com/v1/oauth2/device":
+			deviceURL = r.URL.String()
+			return &http.Response{
+				StatusCode: 200,
+				Proto:      "HTTP/1.1",
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(`{
+					"device_code":"device-123",
+					"user_code":"ABCD-EFGH",
+					"verification_uri":"https://verify.example.com",
+					"interval":1,
+					"expires_in":60
+				}`)),
+				Request: r,
+			}, nil
+		case "https://api.example.com/v1/oauth2/token":
+			tokenURL = r.URL.String()
+			return oauthTokenResponse(r, "relative-device-token"), nil
+		case "https://api.example.com/v1/items":
+			rr.capture(r)
+			return jsonResponse(200, `{}`), nil
+		default:
+			return jsonResponse(404, `{"error":"not found"}`), nil
+		}
+	})
+
+	cfg := `{
+		"apis": {
+			"myapi": {
+				"base_url": "https://api.example.com/v1",
+				"profiles": {
+					"default": {
+						"auth": {
+							"type": "oauth-device-code",
+							"params": {
+								"client_id": "myid",
+								"device_authorization_url": "oauth2/device",
+								"token_url": "oauth2/token"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	c.Hooks().ConfigPath = writeAPIConfig(t, cfg)
+	c.Hooks().TokenCachePath = filepath.Join(t.TempDir(), "tokens.json")
+
+	if err := c.Run([]string{"restish", "get", "myapi/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deviceURL != "https://api.example.com/v1/oauth2/device" {
+		t.Fatalf("device URL = %q", deviceURL)
+	}
+	if tokenURL != "https://api.example.com/v1/oauth2/token" {
+		t.Fatalf("token URL = %q", tokenURL)
+	}
+	if got := rr.Last().Header.Get("Authorization"); got != "Bearer relative-device-token" {
 		t.Fatalf("Authorization = %q", got)
 	}
 	if !strings.Contains(errBuf.String(), "verify.example.com") {

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -295,9 +295,13 @@ func (c *CLI) resolveCredentialAuth(apiName, profileName, credentialID string, c
 		return resolvedAuthConfig{}, fmt.Errorf("credential %q in profile %q of API %q has both auth and auth_ref", credentialID, profileName, apiName)
 	}
 	if credential.AuthRef == "" {
+		cacheKey := apiName + ":" + profileName + ":credential:" + credentialID
+		if relativeKey := inlineAuthCacheKey(cacheKey, credential.Auth, c.authBaseURL(apiName, profileName)); relativeKey != "" {
+			cacheKey = relativeKey
+		}
 		return resolvedAuthConfig{
 			Config:   credential.Auth,
-			CacheKey: apiName + ":" + profileName + ":credential:" + credentialID,
+			CacheKey: cacheKey,
 		}, nil
 	}
 	if c.cfg == nil || c.cfg.AuthProfiles == nil || c.cfg.AuthProfiles[credential.AuthRef] == nil {
@@ -307,7 +311,7 @@ func (c *CLI) resolveCredentialAuth(apiName, profileName, credentialID string, c
 	return resolvedAuthConfig{
 		Config:   ac,
 		Ref:      credential.AuthRef,
-		CacheKey: sharedAuthCacheKey(credential.AuthRef, ac),
+		CacheKey: sharedAuthCacheKey(credential.AuthRef, ac, c.authBaseURL(apiName, profileName)),
 	}, nil
 }
 

--- a/site/content/en/docs/guides/oauth.md
+++ b/site/content/en/docs/guides/oauth.md
@@ -101,8 +101,14 @@ If your provider does not publish discovery, configure direct endpoint URLs:
 ```
 
 OAuth endpoints must use HTTPS except for localhost or loopback development
-URLs. Endpoint URLs must be absolute and must not include credentials,
-fragments, or query strings.
+URLs. Endpoint URLs must not include credentials, fragments, or query strings.
+
+When OAuth authorize, device authorization, or token endpoints live on the same
+host as the API, you may use relative paths in manual config. `oauth2/token`
+resolves under the active API/profile `base_url` path, while `/oauth2/token`
+resolves at that host root. For example, with
+`base_url: https://api.vendor.test/v1`, `oauth2/token` becomes
+`https://api.vendor.test/v1/oauth2/token`.
 
 ## Browser Sign-In
 

--- a/site/content/en/docs/reference/auth.md
+++ b/site/content/en/docs/reference/auth.md
@@ -28,6 +28,13 @@ endpoint URLs are absent. Unknown non-reserved OAuth params are forwarded to
 token requests, which is how provider-specific values such as `audience` are
 sent.
 
+Manual `authorize_url`, `token_url`, and `device_authorization_url` values may
+be absolute URLs or relative paths resolved against the active API/profile
+`base_url`. Path-relative values such as `oauth2/token` resolve under the
+`base_url` path; root-relative values such as `/oauth2/token` resolve at the
+same host root. Scheme-relative values such as `//auth.example.com/token` are
+rejected.
+
 OAuth flow selection is explicit. Restish does not automatically switch an
 `oauth-authorization-code` profile to `oauth-device-code` because issuer
 discovery advertises a device endpoint. Use `oauth-device-code` when the OAuth


### PR DESCRIPTION
## Summary
- resolve relative OAuth authorize, device authorization, and token endpoint params against the effective API/profile base_url
- keep scheme-relative values rejected and run resolved URLs through existing OAuth endpoint validation
- partition token cache keys by base_url when relative OAuth endpoints make the resolved provider endpoint API-dependent

Fixes #45

## Validation
- env GOCACHE=/tmp/restish-gocache go test ./internal/auth ./internal/cli -run 'TestResolveOAuthEndpoint|TestClientCredentialsResolvesRelativeTokenURL|TestAuthCodeResolvesRelativeEndpoints|TestDeviceCodeResolvesRelativeEndpoints|TestOAuthClientCredentials_RelativeTokenURLUsesProfileBase|TestOAuthAuthorizationCode_RelativeEndpointsUseBaseURL|TestOAuthDeviceCode_RelativeEndpointsUseBaseURL|TestSharedAuthCacheKey|TestInlineAuthCacheKey|TestDeviceCode_PollsUntilAuthorized'
- env GOCACHE=/tmp/restish-gocache go test ./internal/auth ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./...
- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...
- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache

## Review
- Sub-agent review found inline cache partitioning, device-code coverage, and docs wording gaps; all were fixed and follow-up review found no issues.