### PR TITLE
fix: ignore docs-only description refs

### DIFF
--- a/docs/design/034-openapi-implementation-contract.md
+++ b/docs/design/034-openapi-implementation-contract.md
@@ -73,6 +73,13 @@ External references are valid anywhere the parser accepts references that affect
 command generation, including Path Items, parameters, request schemas, response
 schemas, and shared component schemas.
 
+Some real-world specs place documentation-tool objects such as
+`description: {"$ref": "markdown/usecases.md"}` where OpenAPI requires a
+string. Restish treats those docs-only description refs as an empty description
+before reference resolution, and it does not fetch the referenced markdown. This
+compatibility cleanup must not rewrite schema properties or component entries
+that happen to be named `description`.
+
 Webhooks-only documents, documents with no paths, and empty Path Items generate
 no request commands and must not panic. Response links and callbacks are not
 generated as commands in v2.

--- a/internal/spec/discover_test.go
+++ b/internal/spec/discover_test.go
@@ -467,6 +467,52 @@ x-overlay: true`
 	}
 }
 
+func TestLoadSpecFilesMultiFileIgnoresDescriptionRefObjects(t *testing.T) {
+	dir := t.TempDir()
+
+	base := `openapi: "3.1.0"
+info:
+  title: Base
+  version: "1.0.0"
+tags:
+  - name: widgets
+    description:
+      $ref: missing.md
+paths: {}`
+	overlay := `openapi: "3.1.0"
+info:
+  title: Overlay
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK`
+
+	basePath := filepath.Join(dir, "base.yaml")
+	overlayPath := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(basePath, []byte(base), 0o644); err != nil {
+		t.Fatalf("write base: %v", err)
+	}
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	result, err := loadSpecFiles(context.Background(), DiscoverConfig{SpecFiles: []string{basePath, overlayPath}}, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("loadSpecFiles: %v", err)
+	}
+	ops, err := result.Operations(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("Operations: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "listItems" {
+		t.Fatalf("operations = %#v", ops)
+	}
+}
+
 func TestLoadSpecFiles_MissingFile(t *testing.T) {
 	cfg := DiscoverConfig{
 		SpecFiles: []string{"/nonexistent/spec.yaml"},

--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -74,6 +74,74 @@ func (OpenAPILoader) LoadWithOptions(body []byte, opts LoadOptions) (*APISpec, e
 	return &APISpec{Raw: body, Document: doc}, nil
 }
 
+func sanitizeOpenAPIDescriptionRefs(body []byte) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(body, &doc); err != nil {
+		return body, nil
+	}
+	changed := sanitizeDescriptionRefNode(&doc, nil)
+	if !changed {
+		return body, nil
+	}
+	return yaml.Marshal(&doc)
+}
+
+func sanitizeDescriptionRefNode(n *yaml.Node, path []string) bool {
+	if n == nil {
+		return false
+	}
+	changed := false
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, child := range n.Content {
+			changed = sanitizeDescriptionRefNode(child, path) || changed
+		}
+	case yaml.SequenceNode:
+		for _, child := range n.Content {
+			changed = sanitizeDescriptionRefNode(child, appendPathKey(path, "[]")) || changed
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i].Value
+			value := n.Content[i+1]
+			if shouldIgnoreDescriptionRefPath(appendPathKey(path, key)) && mappingRefValue(value) != "" {
+				n.Content[i+1] = &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ""}
+				changed = true
+				continue
+			}
+			changed = sanitizeDescriptionRefNode(value, appendPathKey(path, key)) || changed
+		}
+	}
+	return changed
+}
+
+func appendPathKey(path []string, key string) []string {
+	next := make([]string, len(path), len(path)+1)
+	copy(next, path)
+	return append(next, key)
+}
+
+func isArbitraryNamedOpenAPIMap(path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	switch path[len(path)-1] {
+	case "$defs", "callbacks", "dependentSchemas", "examples", "headers", "links",
+		"parameters", "pathItems", "paths", "patternProperties", "properties",
+		"requestBodies", "responses", "schemas", "securitySchemes", "webhooks":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldIgnoreDescriptionRefPath(path []string) bool {
+	if len(path) == 0 || path[len(path)-1] != "description" {
+		return false
+	}
+	return !isArbitraryNamedOpenAPIMap(path[:len(path)-1])
+}
+
 func isSwagger2Document(body []byte) bool {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(body, &doc); err != nil {
@@ -221,6 +289,10 @@ type openAPIRefResolver struct {
 const openAPIExternalRefConcurrency = 8
 
 func resolveOpenAPIExternalRefs(body []byte, opts LoadOptions) ([]byte, error) {
+	body, err := sanitizeOpenAPIDescriptionRefs(body)
+	if err != nil {
+		return nil, err
+	}
 	if opts.SourceURL == "" && opts.LocalPath == "" {
 		return body, nil
 	}
@@ -242,7 +314,7 @@ func resolveOpenAPIExternalRefs(body []byte, opts LoadOptions) ([]byte, error) {
 	if err := resolver.prefetchExternalDocs(root, source); err != nil {
 		return nil, err
 	}
-	changed, err := resolver.resolveNode(root, source)
+	changed, err := resolver.resolveNode(root, source, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -252,12 +324,16 @@ func resolveOpenAPIExternalRefs(body []byte, opts LoadOptions) ([]byte, error) {
 	return yaml.Marshal(&doc)
 }
 
-func (r *openAPIRefResolver) resolveNode(n *yaml.Node, source openAPIRefSource) (bool, error) {
+func (r *openAPIRefResolver) resolveNode(n *yaml.Node, source openAPIRefSource, path []string) (bool, error) {
 	if n == nil {
 		return false, nil
 	}
 	if r.depth > 100 {
 		return false, fmt.Errorf("OpenAPI external ref resolution exceeded maximum depth")
+	}
+	if shouldIgnoreDescriptionRefPath(path) && mappingRefValue(n) != "" {
+		*n = yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ""}
+		return true, nil
 	}
 	if ref := mappingRefValue(n); ref != "" {
 		if strings.HasPrefix(ref, "#") {
@@ -284,7 +360,7 @@ func (r *openAPIRefResolver) resolveNode(n *yaml.Node, source openAPIRefSource) 
 			defer delete(r.resolving, refKey)
 			r.depth++
 			defer func() { r.depth-- }()
-			if _, err := r.resolveNode(n, source); err != nil {
+			if _, err := r.resolveNode(n, source, path); err != nil {
 				return false, err
 			}
 			return true, nil
@@ -298,19 +374,38 @@ func (r *openAPIRefResolver) resolveNode(n *yaml.Node, source openAPIRefSource) 
 		mergeRefSiblings(n, originalSiblings)
 		r.depth++
 		defer func() { r.depth-- }()
-		if _, err := r.resolveNode(n, targetSource); err != nil {
+		if _, err := r.resolveNode(n, targetSource, path); err != nil {
 			return false, err
 		}
 		return true, nil
 	}
 
 	changed := false
-	for _, child := range n.Content {
-		childChanged, err := r.resolveNode(child, source)
-		if err != nil {
-			return false, err
+	switch n.Kind {
+	case yaml.SequenceNode:
+		for _, child := range n.Content {
+			childChanged, err := r.resolveNode(child, source, appendPathKey(path, "[]"))
+			if err != nil {
+				return false, err
+			}
+			changed = changed || childChanged
 		}
-		changed = changed || childChanged
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			childChanged, err := r.resolveNode(n.Content[i+1], source, appendPathKey(path, n.Content[i].Value))
+			if err != nil {
+				return false, err
+			}
+			changed = changed || childChanged
+		}
+	default:
+		for _, child := range n.Content {
+			childChanged, err := r.resolveNode(child, source, path)
+			if err != nil {
+				return false, err
+			}
+			changed = changed || childChanged
+		}
 	}
 	return changed, nil
 }
@@ -382,9 +477,12 @@ func (r *openAPIRefResolver) prefetchExternalDocs(root *yaml.Node, source openAP
 
 func (r *openAPIRefResolver) collectExternalDocRequests(n *yaml.Node, source openAPIRefSource, seen map[string]bool) ([]openAPIExternalDocRequest, error) {
 	var requests []openAPIExternalDocRequest
-	var walk func(*yaml.Node, openAPIRefSource) error
-	walk = func(n *yaml.Node, source openAPIRefSource) error {
+	var walk func(*yaml.Node, openAPIRefSource, []string) error
+	walk = func(n *yaml.Node, source openAPIRefSource, path []string) error {
 		if n == nil {
+			return nil
+		}
+		if shouldIgnoreDescriptionRefPath(path) {
 			return nil
 		}
 		if ref := mappingRefValue(n); ref != "" && !strings.HasPrefix(ref, "#") {
@@ -401,14 +499,29 @@ func (r *openAPIRefResolver) collectExternalDocRequests(n *yaml.Node, source ope
 				requests = append(requests, openAPIExternalDocRequest{key: key, source: targetSource})
 			}
 		}
-		for _, child := range n.Content {
-			if err := walk(child, source); err != nil {
-				return err
+		switch n.Kind {
+		case yaml.SequenceNode:
+			for _, child := range n.Content {
+				if err := walk(child, source, appendPathKey(path, "[]")); err != nil {
+					return err
+				}
+			}
+		case yaml.MappingNode:
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				if err := walk(n.Content[i+1], source, appendPathKey(path, n.Content[i].Value)); err != nil {
+					return err
+				}
+			}
+		default:
+			for _, child := range n.Content {
+				if err := walk(child, source, path); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
 	}
-	if err := walk(n, source); err != nil {
+	if err := walk(n, source, nil); err != nil {
 		return nil, err
 	}
 	return requests, nil

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -1,6 +1,9 @@
 package spec
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -213,6 +216,240 @@ func TestOpenAPILoader_Load_BadPathsShape(t *testing.T) {
 	body := []byte(`{"openapi":"3.1.0","info":{"title":"T","version":"1"},"paths":"not-an-object"}`)
 	// libopenapi may or may not error; the important thing is it doesn't panic.
 	_, _ = l.Load(body)
+}
+
+func TestOpenAPILoader_Load_IgnoresDescriptionRefObjects(t *testing.T) {
+	raw := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+  description:
+    $ref: markdown/info.md
+tags:
+  - name: widgets
+    description:
+      $ref: markdown/widgets.md
+paths:
+  /items:
+    get:
+      operationId: listItems
+      parameters:
+        - name: q
+          in: query
+          description:
+            $ref: markdown/query.md
+          schema:
+            type: string
+      responses:
+        "200":
+          description:
+            $ref: markdown/ok.md`)
+	l := OpenAPILoader{}
+	s, err := l.Load(raw)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	info, err := s.Info()
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if info.Description != "" {
+		t.Fatalf("description = %q, want ignored", info.Description)
+	}
+	ops, err := s.Operations(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("Operations: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "listItems" {
+		t.Fatalf("operations = %#v", ops)
+	}
+	if len(ops[0].Parameters) != 1 || ops[0].Parameters[0].Desc != "" {
+		t.Fatalf("parameter description = %#v, want ignored", ops[0].Parameters)
+	}
+}
+
+func TestOpenAPILoader_Load_DescriptionRefObjectDoesNotFetchExternalDoc(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "openapi.yaml")
+	raw := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+tags:
+  - name: widgets
+    description:
+      $ref: missing.md
+paths: {}`)
+	if err := os.WriteFile(specPath, raw, 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	l := OpenAPILoader{}
+	if _, err := l.LoadWithOptions(raw, LoadOptions{LocalPath: specPath}); err != nil {
+		t.Fatalf("load should not fetch description ref: %v", err)
+	}
+}
+
+func TestOpenAPILoader_Load_ExternalDocDescriptionRefObjectDoesNotFetchMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "openapi.yaml")
+	componentsPath := filepath.Join(dir, "components.yaml")
+	root := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: components.yaml#/components/schemas/Item`)
+	components := []byte(`components:
+  schemas:
+    Item:
+      type: object
+      description:
+        $ref: missing.md
+      properties:
+        id:
+          type: string`)
+	if err := os.WriteFile(rootPath, root, 0o600); err != nil {
+		t.Fatalf("write root: %v", err)
+	}
+	if err := os.WriteFile(componentsPath, components, 0o600); err != nil {
+		t.Fatalf("write components: %v", err)
+	}
+	l := OpenAPILoader{}
+	s, err := l.LoadWithOptions(root, LoadOptions{LocalPath: rootPath})
+	if err != nil {
+		t.Fatalf("load should not fetch external doc description ref: %v", err)
+	}
+	ops, err := s.Operations(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("Operations: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "listItems" {
+		t.Fatalf("operation response help = %#v", ops)
+	}
+}
+
+func TestOpenAPILoader_Load_ExternalDocRootDescriptionEntryPreservesRealRef(t *testing.T) {
+	dir := t.TempDir()
+	rootPath := filepath.Join(dir, "openapi.yaml")
+	schemasPath := filepath.Join(dir, "schemas.yaml")
+	commonPath := filepath.Join(dir, "common.yaml")
+	root := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: schemas.yaml#/description`)
+	schemas := []byte(`description:
+  $ref: common.yaml#/Description`)
+	common := []byte(`Description:
+  type: string`)
+	if err := os.WriteFile(rootPath, root, 0o600); err != nil {
+		t.Fatalf("write root: %v", err)
+	}
+	if err := os.WriteFile(schemasPath, schemas, 0o600); err != nil {
+		t.Fatalf("write schemas: %v", err)
+	}
+	if err := os.WriteFile(commonPath, common, 0o600); err != nil {
+		t.Fatalf("write common: %v", err)
+	}
+	resolved, err := resolveOpenAPIExternalRefs(root, LoadOptions{LocalPath: rootPath})
+	if err != nil {
+		t.Fatalf("resolve refs: %v", err)
+	}
+	if !strings.Contains(string(resolved), "type: string") {
+		t.Fatalf("external root entry named description was not resolved:\n%s", resolved)
+	}
+}
+
+func TestSanitizeOpenAPIDescriptionRefsPreservesSchemaProperties(t *testing.T) {
+	raw := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    StringValue:
+      type: string
+    Item:
+      type: object
+      properties:
+        description:
+          $ref: "#/components/schemas/StringValue"`)
+	sanitized, err := sanitizeOpenAPIDescriptionRefs(raw)
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	if string(sanitized) != string(raw) {
+		t.Fatalf("schema property named description should be preserved:\n%s", sanitized)
+	}
+}
+
+func TestSanitizeOpenAPIDescriptionRefsIgnoresRootSchemaDescriptionRef(t *testing.T) {
+	raw := []byte(`type: object
+description:
+  $ref: markdown/schema.md
+properties:
+  id:
+    type: string`)
+	sanitized, err := sanitizeOpenAPIDescriptionRefs(raw)
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	if strings.Contains(string(sanitized), "markdown/schema.md") {
+		t.Fatalf("root schema description ref should be ignored:\n%s", sanitized)
+	}
+}
+
+func TestSanitizeOpenAPIDescriptionRefsPreservesArbitraryNamedMaps(t *testing.T) {
+	raw := []byte(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+webhooks:
+  description:
+    $ref: "#/components/pathItems/Hook"
+components:
+  pathItems:
+    Hook:
+      post:
+        responses:
+          "200":
+            description: OK
+  schemas:
+    Item:
+      type: object
+      dependentSchemas:
+        description:
+          $ref: "#/components/schemas/StringValue"
+    StringValue:
+      type: string`)
+	sanitized, err := sanitizeOpenAPIDescriptionRefs(raw)
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	if string(sanitized) != string(raw) {
+		t.Fatalf("arbitrary named map entries should be preserved:\n%s", sanitized)
+	}
 }
 
 // ---- V3Model memoization ---------------------------------------------------


### PR DESCRIPTION
## Summary
- ignore non-string `description: {"": ...}` objects before OpenAPI parsing when they are docs-only fields
- avoid fetching markdown/documentation refs from root, external, and multi-file spec loading paths
- preserve real refs in schema/component maps whose entry name is `description`

Fixes #75

## Validation
- env GOCACHE=/tmp/restish-gocache go test ./internal/spec -run 'DescriptionRef|ExternalRef|LoadSpecFilesMultiFileIgnoresDescriptionRefObjects|SanitizeOpenAPIDescriptionRefs'
- env GOCACHE=/tmp/restish-gocache go test ./internal/spec ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./...
- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...
- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache

## Review
- Sub-agent review found external-doc, multi-file, and over-sanitization edge cases; all were fixed and final follow-up review found no issues.