### PR TITLE
feat: add optional generated body validation

### DIFF
--- a/cmd/restish-mcp/mcp_test.go
+++ b/cmd/restish-mcp/mcp_test.go
@@ -292,6 +292,47 @@ func TestToolsFromHostOperationsPreserveContentQueryParameters(t *testing.T) {
 	}
 }
 
+func TestToolsFromHostOperationsPreserveRequestBodySchema(t *testing.T) {
+	s := &APISpec{
+		Name: "demo",
+		Operations: []plugin.APIOperation{{
+			ID:                   "createItem",
+			Method:               "POST",
+			Path:                 "/items",
+			HasBody:              true,
+			BodyRequired:         true,
+			RequestMediaType:     "application/json",
+			RequestSchemaDialect: "https://json-schema.org/draft/2020-12/schema",
+			RequestSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		}},
+	}
+
+	tools, err := toolsFromSpec("demo", false, s, Options{AllowWriteTools: true})
+	if err != nil {
+		t.Fatalf("toolsFromSpec: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools = %#v, want one tool", tools)
+	}
+	props := tools[0].InputSchema["properties"].(map[string]any)
+	body := props["body"].(map[string]any)
+	if got := body["type"]; got != "object" {
+		t.Fatalf("body type = %#v, want object", got)
+	}
+	bodyProps, ok := body["properties"].(map[string]any)
+	if !ok || bodyProps["name"] == nil {
+		t.Fatalf("body properties = %#v, want name property", body["properties"])
+	}
+	if got, want := tools[0].BodySchemaDialect, "https://json-schema.org/draft/2020-12/schema"; got != want {
+		t.Fatalf("BodySchemaDialect = %q, want %q", got, want)
+	}
+}
+
 func TestToolsFromRawSpecPreserveContentQueryParameters(t *testing.T) {
 	s := loadTestSpec(t, "demo", `{
 	  "openapi": "3.1.0",

--- a/cmd/restish-mcp/tools.go
+++ b/cmd/restish-mcp/tools.go
@@ -25,15 +25,16 @@ type HTTPExecutor func(*HTTPRequest) (*HTTPResponse, error)
 type SpecFetcher func(name string) (*APISpec, error)
 
 type Tool struct {
-	APIName         string
-	Name            string
-	Description     string
-	Method          string
-	Path            string
-	InputSchema     map[string]any
-	Params          []Param
-	BodyContentType string
-	BodyRequired    bool
+	APIName           string
+	Name              string
+	Description       string
+	Method            string
+	Path              string
+	InputSchema       map[string]any
+	Params            []Param
+	BodyContentType   string
+	BodySchemaDialect string
+	BodyRequired      bool
 }
 
 type Param struct {
@@ -48,6 +49,7 @@ type Param struct {
 	AllowReserved    bool
 	ContentMediaType string
 	Schema           map[string]any
+	SchemaDialect    string
 }
 
 type Options struct {
@@ -208,6 +210,7 @@ func buildToolFromOperation(apiName string, multiAPI bool, op plugin.APIOperatio
 			AllowReserved:    p.AllowReserved,
 			ContentMediaType: p.ContentMediaType,
 			Schema:           paramSchema,
+			SchemaDialect:    p.SchemaDialect,
 		})
 		prop := schemaFromOperationParam(p)
 		properties[p.Name] = prop
@@ -217,7 +220,7 @@ func buildToolFromOperation(apiName string, multiAPI bool, op plugin.APIOperatio
 	}
 
 	if op.HasBody {
-		properties["body"] = map[string]any{"type": "object"}
+		properties["body"] = operationBodySchema(op.RequestSchema)
 		if op.BodyRequired {
 			required = append(required, "body")
 		}
@@ -231,16 +234,24 @@ func buildToolFromOperation(apiName string, multiAPI bool, op plugin.APIOperatio
 		inputSchema["required"] = required
 	}
 	return &Tool{
-		APIName:         apiName,
-		Name:            name,
-		Description:     description,
-		Method:          op.Method,
-		Path:            op.Path,
-		InputSchema:     inputSchema,
-		Params:          params,
-		BodyContentType: op.RequestMediaType,
-		BodyRequired:    op.BodyRequired,
+		APIName:           apiName,
+		Name:              name,
+		Description:       description,
+		Method:            op.Method,
+		Path:              op.Path,
+		InputSchema:       inputSchema,
+		Params:            params,
+		BodyContentType:   op.RequestMediaType,
+		BodySchemaDialect: op.RequestSchemaDialect,
+		BodyRequired:      op.BodyRequired,
 	}
+}
+
+func operationBodySchema(schema map[string]any) map[string]any {
+	if len(schema) == 0 {
+		return map[string]any{"type": "object"}
+	}
+	return schemaMap(schema)
 }
 
 func schemaFromOperationParam(p plugin.APIParam) map[string]any {

--- a/docs/design/007-api-command-generation.md
+++ b/docs/design/007-api-command-generation.md
@@ -251,12 +251,18 @@ generic HTTP command must interpret the same body shorthand the same way:
 `id: 123` is a number, while `id: "123"` is a string. OpenAPI schema metadata
 can describe the expected shape in help and examples, but it must not silently
 rewrite request-body values before they are sent. Unknown fields are still
-accepted unless a future explicit validation mode is enabled.
+accepted unless the user explicitly opts in to local validation.
 
 OpenAPI schema constructs such as `oneOf`, `anyOf`, `allOf`, nullable/type
 arrays, enum, const, defaults, examples, read-only/write-only, additional
 properties, and recursive references are used for help and bounded example
 generation. They are not full request validators by default.
+
+Generated operations may expose optional request-body validation through
+`--rsh-validate`. Validation runs after body assembly, applies only to JSON
+request bodies, reports field paths and schema expectations, and never coerces
+input. The server remains the source of truth, so validation is not enabled by
+default and generic HTTP commands remain schema-agnostic.
 
 Generated operation commands also expose `--rsh-generate-body` for request-body
 operations. The flag prints an example body derived from OpenAPI examples,

--- a/docs/design/034-openapi-implementation-contract.md
+++ b/docs/design/034-openapi-implementation-contract.md
@@ -271,6 +271,12 @@ reject unknown body fields by default, does not perform full validation before
 requests, and does not silently coerce generated-command request-body values
 based on schema metadata.
 
+`--rsh-validate` is the explicit generated-command escape hatch for local JSON
+request-body validation. It validates the assembled body against the selected
+operation request schema before execution, reports user-facing field paths, and
+does not rewrite input. Generic HTTP commands and default generated-command
+execution stay schema-agnostic because servers remain the source of truth.
+
 Schema support should cover OpenAPI 3.0 and 3.1 shapes including:
 
 - `type` as a string or an array;

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pb33f/libopenapi v0.35.0
 	github.com/sandrolain/httpcache v1.4.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/shamaton/msgpack/v2 v2.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sandrolain/httpcache v1.4.0 h1:Jf4Vx62X2ybvNPSpPvI1kT3xvMdDG1AsApQjOQKO9E0=
 github.com/sandrolain/httpcache v1.4.0/go.mod h1:kHBuXveitSn39SNPBhdf/ybG272X706HJ2RJqOQ+Em0=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shamaton/msgpack/v2 v2.4.0 h1:O5Z08MRmbo0lA9o2xnQ4TXx6teJbPqEurqcCOQ8Oi/4=
 github.com/shamaton/msgpack/v2 v2.4.0/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -373,24 +373,40 @@ func pluginOperationsFromSpec(ops []spec.Operation) []pluginwire.APIOperation {
 				AllowReserved:    p.AllowReserved,
 				ContentMediaType: p.ContentMediaType,
 				Schema:           cloneCommandPluginSchema(p.JSONSchema),
+				SchemaDialect:    p.JSONSchemaDialect,
 				Enum:             append([]string(nil), p.Enum...),
 			})
 		}
+		requestSchema, requestSchemaDialect := operationRequestSchema(op)
 		out = append(out, pluginwire.APIOperation{
-			ID:               operationCommandName(op),
-			Method:           op.Method,
-			Path:             op.Path,
-			Summary:          op.Summary,
-			Description:      op.Description,
-			Deprecated:       op.Deprecated,
-			Parameters:       params,
-			HasBody:          op.HasBody,
-			BodyRequired:     op.BodyRequired,
-			RequestMediaType: op.RequestMediaType,
-			MCPIgnore:        op.MCPIgnore,
+			ID:                   operationCommandName(op),
+			Method:               op.Method,
+			Path:                 op.Path,
+			Summary:              op.Summary,
+			Description:          op.Description,
+			Deprecated:           op.Deprecated,
+			Parameters:           params,
+			HasBody:              op.HasBody,
+			BodyRequired:         op.BodyRequired,
+			RequestMediaType:     op.RequestMediaType,
+			RequestSchema:        requestSchema,
+			RequestSchemaDialect: requestSchemaDialect,
+			MCPIgnore:            op.MCPIgnore,
 		})
 	}
 	return out
+}
+
+func operationRequestSchema(op spec.Operation) (map[string]any, string) {
+	if op.Help.Request != nil {
+		return cloneCommandPluginSchema(op.Help.Request.JSONSchema), op.Help.Request.JSONSchemaDialect
+	}
+	for _, request := range op.Help.Requests {
+		if mediaTypesMatch(request.MediaType, op.RequestMediaType) {
+			return cloneCommandPluginSchema(request.JSONSchema), request.JSONSchemaDialect
+		}
+	}
+	return nil, ""
 }
 
 func cloneCommandPluginSchema(in map[string]any) map[string]any {

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -417,10 +417,11 @@ func TestPluginOperationsFromSpecPreservesParameterContentSchema(t *testing.T) {
 		Method: "GET",
 		Path:   "/items",
 		Parameters: []spec.Param{{
-			Name:             "filter",
-			In:               "query",
-			Type:             "object",
-			ContentMediaType: "application/json",
+			Name:              "filter",
+			In:                "query",
+			Type:              "object",
+			ContentMediaType:  "application/json",
+			JSONSchemaDialect: "https://json-schema.org/draft/2020-12/schema",
 			JSONSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -445,6 +446,44 @@ func TestPluginOperationsFromSpecPreservesParameterContentSchema(t *testing.T) {
 	}
 	if _, ok := props["active"]; !ok {
 		t.Fatalf("Schema properties = %#v, want active", props)
+	}
+	if got, want := param.SchemaDialect, "https://json-schema.org/draft/2020-12/schema"; got != want {
+		t.Fatalf("SchemaDialect = %q, want %q", got, want)
+	}
+}
+
+func TestPluginOperationsFromSpecPreservesRequestBodySchema(t *testing.T) {
+	ops := pluginOperationsFromSpec([]spec.Operation{{
+		Method:           "POST",
+		Path:             "/items",
+		HasBody:          true,
+		BodyRequired:     true,
+		RequestMediaType: "application/json",
+		Help: spec.OperationHelp{
+			Request: &spec.OperationBodyHelp{
+				MediaType:         "application/json",
+				JSONSchemaDialect: "https://json-schema.org/draft/2020-12/schema",
+				JSONSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}})
+	if len(ops) != 1 {
+		t.Fatalf("len(ops) = %d, want 1", len(ops))
+	}
+	props, ok := ops[0].RequestSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("RequestSchema properties = %#v, want map", ops[0].RequestSchema["properties"])
+	}
+	if _, ok := props["name"]; !ok {
+		t.Fatalf("RequestSchema properties = %#v, want name", props)
+	}
+	if got, want := ops[0].RequestSchemaDialect, "https://json-schema.org/draft/2020-12/schema"; got != want {
+		t.Fatalf("RequestSchemaDialect = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -1477,6 +1477,7 @@ func (c *CLI) runGeneratedOp(
 	gf := globalFlagsFromContext(requestContext(cmd))
 	var validationSchema map[string]any
 	var validationMediaType string
+	var validationSchemaDialect string
 	validateBody, _ := cmd.Flags().GetBool("rsh-validate")
 	if validateBody {
 		validationRequest, err := c.generatedBodyExampleRequest(help, gf.ContentType)
@@ -1486,6 +1487,7 @@ func (c *CLI) runGeneratedOp(
 		if validationRequest != nil {
 			validationSchema = validationRequest.JSONSchema
 			validationMediaType = validationRequest.MediaType
+			validationSchemaDialect = validationRequest.JSONSchemaDialect
 		}
 	}
 	return c.runHTTPWithOptions(cmd, method, append([]string{rawURL}, bodyArgs...), false, extraHeaders, noAuth, "", requestMediaType, requestBodyOptions{
@@ -1493,6 +1495,7 @@ func (c *CLI) runGeneratedOp(
 		acceptOverride:            responseMediaType,
 		validationSchema:          validationSchema,
 		validationMediaType:       validationMediaType,
+		validationSchemaDialect:   validationSchemaDialect,
 		validationRequested:       validateBody,
 		bodyRequired:              bodyRequired,
 		rawBinaryBody:             rawBinaryBody,

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -488,7 +488,7 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 			}
 			acceptOverride := c.generatedOperationAcceptHeader(op.ResponseMediaTypes, op.ResponseMediaType)
 			rawBinaryBody := op.Help.Request != nil && op.Help.Request.RawBinary
-			return c.runGeneratedOp(cmd, apiName, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, required, optional, args)
+			return c.runGeneratedOp(cmd, apiName, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.Help, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, required, optional, args)
 		},
 	}
 	if candidates := authOverrideCandidates(op.OptionalAuth, op.CredentialAlternatives); len(candidates) > 0 {
@@ -514,6 +514,7 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 	} else {
 		cmd.Args = generatedOperationArgs(required, true)
 		cmd.Flags().Bool("rsh-generate-body", false, "Print an example request body and exit")
+		cmd.Flags().Bool("rsh-validate", false, "Validate the JSON request body against the OpenAPI schema before sending")
 	}
 
 	for _, p := range optional {
@@ -1368,6 +1369,7 @@ func (c *CLI) runGeneratedOp(
 	cmd *cobra.Command,
 	apiName, opPath, operationServer, method, requestMediaType, responseMediaType string,
 	requestMultipartContentTypes map[string]string,
+	help spec.OperationHelp,
 	bodyRequired bool,
 	rawBinaryBody bool,
 	noAuth bool,
@@ -1473,9 +1475,25 @@ func (c *CLI) runGeneratedOp(
 
 	bodyArgs := args[bodyArgStart:]
 	gf := globalFlagsFromContext(requestContext(cmd))
+	var validationSchema map[string]any
+	var validationMediaType string
+	validateBody, _ := cmd.Flags().GetBool("rsh-validate")
+	if validateBody {
+		validationRequest, err := c.generatedBodyExampleRequest(help, gf.ContentType)
+		if err != nil {
+			return err
+		}
+		if validationRequest != nil {
+			validationSchema = validationRequest.JSONSchema
+			validationMediaType = validationRequest.MediaType
+		}
+	}
 	return c.runHTTPWithOptions(cmd, method, append([]string{rawURL}, bodyArgs...), false, extraHeaders, noAuth, "", requestMediaType, requestBodyOptions{
 		multipartPartContentTypes: requestMultipartContentTypes,
 		acceptOverride:            responseMediaType,
+		validationSchema:          validationSchema,
+		validationMediaType:       validationMediaType,
+		validationRequested:       validateBody,
 		bodyRequired:              bodyRequired,
 		rawBinaryBody:             rawBinaryBody,
 		explicitAPIName:           apiName,

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -1961,6 +1961,151 @@ func TestGeneratedCommandGenerateBodyRejectsUndeclaredContentType(t *testing.T) 
 	}
 }
 
+func TestGeneratedCommandOptionalJSONSchemaValidation(t *testing.T) {
+	var hits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupGeneratedEnvForSpec(t, mux, func(baseURL string) string {
+		return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Validation API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/validate": {
+      "post": {
+        "operationId": "validateBody",
+        "requestBody": {
+          "required": true,
+          "content": {"application/json": {"schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "server_id"],
+            "properties": {
+              "server_id": {"type": "string", "readOnly": true},
+              "name": {"type": "string"},
+              "count": {"type": "integer"},
+              "note": {"type": "string", "nullable": true},
+              "details": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {"label": {"type": "string"}}
+                  }
+                ]
+              },
+              "meta": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {"code": {"type": "string"}}
+              },
+              "tags": {"type": "array", "items": {"type": "string"}}
+            }
+          }}}
+        },
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, baseURL)
+	})
+
+	c := env.newCLI()
+	c.Stdin = strings.NewReader(`{"name":"Ada","extra":true}`)
+	if err := c.Run([]string{"restish", "tapi", "validate-body"}); err != nil {
+		t.Fatalf("validation should be disabled by default: %v", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("request hits = %d, want 1", got)
+	}
+
+	c = env.newCLI()
+	c.Stdin = strings.NewReader(`{"name":"Ada","count":5,"note":null,"details":null,"meta":{"code":"ok"},"tags":["one"]}`)
+	if err := c.Run([]string{"restish", "tapi", "validate-body", "--rsh-content-type", "json", "--rsh-validate"}); err != nil {
+		t.Fatalf("valid body with content type alias: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("request hits = %d, want 2", got)
+	}
+
+	tests := []struct {
+		name     string
+		body     string
+		wantPath string
+		wantText string
+	}{
+		{
+			name:     "unknown field",
+			body:     `{"name":"Ada","extra":true}`,
+			wantPath: "$",
+			wantText: "additional properties",
+		},
+		{
+			name:     "wrong scalar type",
+			body:     `{"name":"Ada","count":"five"}`,
+			wantPath: "$.count",
+			wantText: "want integer",
+		},
+		{
+			name:     "nested object",
+			body:     `{"name":"Ada","meta":{"code":123}}`,
+			wantPath: "$.meta.code",
+			wantText: "want string",
+		},
+		{
+			name:     "array item",
+			body:     `{"name":"Ada","tags":["ok",123]}`,
+			wantPath: "$.tags[1]",
+			wantText: "want string",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := env.newCLI()
+			c.Stdin = strings.NewReader(tc.body)
+			err := c.Run([]string{"restish", "tapi", "validate-body", "--rsh-validate"})
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "request body failed OpenAPI schema validation") ||
+				!strings.Contains(msg, tc.wantPath) ||
+				!strings.Contains(msg, tc.wantText) {
+				t.Fatalf("unexpected validation error:\n%s", msg)
+			}
+			if got := hits.Load(); got != 2 {
+				t.Fatalf("validation error should not send request; hits = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestGeneratedCommandValidationRequiresJSONBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/multi-body", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("invalid validation mode should not send a request")
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupGeneratedEnvForSpec(t, mux, specWithMultiBodyOperation)
+	c := env.newCLI()
+	err := c.Run([]string{"restish", "tapi", "multi-body", "--rsh-content-type", "text/plain", "--rsh-validate", "hello"})
+	if err == nil {
+		t.Fatal("expected non-JSON validation error")
+	}
+	if !strings.Contains(err.Error(), "--rsh-validate only supports generated JSON request bodies") ||
+		!strings.Contains(err.Error(), "text/plain") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGeneratedCommandAcceptHeaderIncludesDeclaredSupportedResponseTypes(t *testing.T) {
 	var gotAccept string
 	mux := http.NewServeMux()

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -156,6 +156,7 @@ type requestBodyOptions struct {
 	explicitAPIName           string
 	validationSchema          map[string]any
 	validationMediaType       string
+	validationSchemaDialect   string
 	validationRequested       bool
 	bodyRequired              bool
 	rawBinaryBody             bool
@@ -226,7 +227,7 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 		bodyVal = content.MultipartBody{Value: bodyVal, ContentTypes: bodyOpts.multipartPartContentTypes}
 	}
 	if bodyOpts.validationRequested && bodyVal != nil {
-		if err := validateGeneratedJSONBody(bodyVal, opts.ContentType, bodyOpts.validationMediaType, bodyOpts.validationSchema); err != nil {
+		if err := validateGeneratedJSONBody(bodyVal, opts.ContentType, bodyOpts.validationMediaType, bodyOpts.validationSchema, bodyOpts.validationSchemaDialect); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -154,6 +154,9 @@ type requestBodyOptions struct {
 	acceptOverride            string
 	operationAuth             *operationAuthPolicy
 	explicitAPIName           string
+	validationSchema          map[string]any
+	validationMediaType       string
+	validationRequested       bool
 	bodyRequired              bool
 	rawBinaryBody             bool
 	bodyOverrideSet           bool
@@ -221,6 +224,11 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 	}
 	if len(bodyOpts.multipartPartContentTypes) > 0 && strings.HasPrefix(strings.ToLower(opts.ContentType), "multipart/form-data") {
 		bodyVal = content.MultipartBody{Value: bodyVal, ContentTypes: bodyOpts.multipartPartContentTypes}
+	}
+	if bodyOpts.validationRequested && bodyVal != nil {
+		if err := validateGeneratedJSONBody(bodyVal, opts.ContentType, bodyOpts.validationMediaType, bodyOpts.validationSchema); err != nil {
+			return err
+		}
 	}
 	inputSource := traceInputSource(bodyInfo, bodyVal != nil)
 	if bodyVal != nil {

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -230,7 +230,7 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 		bodyVal = content.MultipartBody{Value: bodyVal, ContentTypes: bodyOpts.multipartPartContentTypes}
 	}
 	if bodyOpts.validationRequested && bodyVal != nil {
-		if err := validateGeneratedJSONBody(bodyVal, opts.ContentType, bodyOpts.validationMediaType, bodyOpts.validationSchema, bodyOpts.validationSchemaDialect); err != nil {
+		if err := validateGeneratedJSONBody(bodyVal, opts.ContentType, bodyOpts.validationMediaType, bodyOpts.validationSchema, bodyOpts.validationSchemaDialect, output.ColorEnabled(c.Stderr)); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/validation.go
+++ b/internal/cli/validation.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const generatedRequestSchemaURL = "restish-request-body.schema.json"
+
+func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, schema map[string]any) error {
+	mediaType := strings.TrimSpace(contentType)
+	if mediaType != "" && !strings.Contains(mediaType, "/") && schemaMediaType != "" {
+		mediaType = schemaMediaType
+	}
+	if mediaType == "" {
+		mediaType = schemaMediaType
+	}
+	if mediaType == "" {
+		mediaType = "application/json"
+	}
+	if !isJSONMediaType(mediaType) {
+		return fmt.Errorf("--rsh-validate only supports generated JSON request bodies; selected request content type is %s", mediaType)
+	}
+	if len(schema) == 0 {
+		return fmt.Errorf("--rsh-validate requires a generated JSON request body schema for this operation")
+	}
+	normalizedSchema, err := normalizeJSONSchemaValue(schema)
+	if err != nil {
+		return fmt.Errorf("compile request body schema: %w", err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource(generatedRequestSchemaURL, normalizedSchema); err != nil {
+		return fmt.Errorf("compile request body schema: %w", err)
+	}
+	compiled, err := compiler.Compile(generatedRequestSchemaURL)
+	if err != nil {
+		return fmt.Errorf("compile request body schema: %w", err)
+	}
+	if err := compiled.Validate(body); err != nil {
+		return fmt.Errorf("request body failed OpenAPI schema validation: %s", formatJSONSchemaValidationError(err))
+	}
+	return nil
+}
+
+func normalizeJSONSchemaValue(schema map[string]any) (map[string]any, error) {
+	normalized, err := normalizeJSONCompatible(schema)
+	if err != nil {
+		return nil, err
+	}
+	out, ok := normalized.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema root is %T, want object", normalized)
+	}
+	normalizeOpenAPIJSONSchema(out)
+	return out, nil
+}
+
+func normalizeJSONCompatible(value any) (any, error) {
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			normalized, err := normalizeJSONCompatible(child)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = normalized
+		}
+		return out, nil
+	case map[interface{}]interface{}:
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			keyString, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("schema object key is %T, want string", key)
+			}
+			normalized, err := normalizeJSONCompatible(child)
+			if err != nil {
+				return nil, err
+			}
+			out[keyString] = normalized
+		}
+		return out, nil
+	case []any:
+		out := make([]any, len(v))
+		for i, child := range v {
+			normalized, err := normalizeJSONCompatible(child)
+			if err != nil {
+				return nil, err
+			}
+			out[i] = normalized
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+func normalizeOpenAPIJSONSchema(value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		normalizeOpenAPIReadOnlyRequired(v)
+		normalizeOpenAPIJSONSchemaMap(v)
+		normalizeOpenAPIExclusiveBound(v, "minimum", "exclusiveMinimum")
+		normalizeOpenAPIExclusiveBound(v, "maximum", "exclusiveMaximum")
+		for _, child := range v {
+			normalizeOpenAPIJSONSchema(child)
+		}
+	case []any:
+		for _, child := range v {
+			normalizeOpenAPIJSONSchema(child)
+		}
+	}
+}
+
+func normalizeOpenAPIJSONSchemaMap(schema map[string]any) {
+	nullable, ok := schema["nullable"].(bool)
+	if !ok || !nullable {
+		return
+	}
+	switch typ := schema["type"].(type) {
+	case string:
+		if typ != "null" {
+			schema["type"] = []any{typ, "null"}
+		}
+	case []any:
+		for _, item := range typ {
+			if item == "null" {
+				return
+			}
+		}
+		schema["type"] = append(typ, "null")
+	case nil:
+		withoutNullable := make(map[string]any, len(schema))
+		for key, value := range schema {
+			if key != "nullable" {
+				withoutNullable[key] = value
+			}
+		}
+		for key := range schema {
+			delete(schema, key)
+		}
+		schema["anyOf"] = []any{withoutNullable, map[string]any{"type": "null"}}
+	}
+}
+
+func normalizeOpenAPIReadOnlyRequired(schema map[string]any) {
+	required, ok := schema["required"].([]any)
+	if !ok || len(required) == 0 {
+		return
+	}
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok || len(properties) == 0 {
+		return
+	}
+	out := required[:0]
+	for _, item := range required {
+		name, ok := item.(string)
+		if !ok || !openAPIPropertyReadOnly(properties[name]) {
+			out = append(out, item)
+		}
+	}
+	if len(out) == 0 {
+		delete(schema, "required")
+		return
+	}
+	schema["required"] = out
+}
+
+func openAPIPropertyReadOnly(property any) bool {
+	prop, ok := property.(map[string]any)
+	if !ok {
+		return false
+	}
+	readOnly, _ := prop["readOnly"].(bool)
+	return readOnly
+}
+
+func normalizeOpenAPIExclusiveBound(schema map[string]any, limitKey, exclusiveKey string) {
+	exclusive, ok := schema[exclusiveKey].(bool)
+	if !ok {
+		return
+	}
+	if !exclusive {
+		delete(schema, exclusiveKey)
+		return
+	}
+	if limit, ok := schema[limitKey]; ok {
+		schema[exclusiveKey] = limit
+	}
+}
+
+func formatJSONSchemaValidationError(err error) string {
+	var validationErr *jsonschema.ValidationError
+	if !errors.As(err, &validationErr) {
+		return err.Error()
+	}
+	units := validationOutputLeaves(validationErr.BasicOutput())
+	if len(units) == 0 {
+		return validationErr.Error()
+	}
+	const maxErrors = 5
+	var parts []string
+	for i, unit := range units {
+		if i >= maxErrors {
+			parts = append(parts, fmt.Sprintf("and %d more", len(units)-maxErrors))
+			break
+		}
+		msg := validationOutputMessage(unit.Error)
+		if msg == "" {
+			continue
+		}
+		parts = append(parts, jsonPointerDisplayPath(unit.InstanceLocation)+": "+msg)
+	}
+	if len(parts) == 0 {
+		return validationErr.Error()
+	}
+	return strings.Join(parts, "; ")
+}
+
+func validationOutputLeaves(unit *jsonschema.OutputUnit) []jsonschema.OutputUnit {
+	if unit == nil {
+		return nil
+	}
+	if len(unit.Errors) == 0 {
+		return []jsonschema.OutputUnit{*unit}
+	}
+	var out []jsonschema.OutputUnit
+	for _, child := range unit.Errors {
+		out = append(out, validationOutputLeaves(&child)...)
+	}
+	return out
+}
+
+func validationOutputMessage(err *jsonschema.OutputError) string {
+	if err == nil {
+		return ""
+	}
+	data, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		return ""
+	}
+	var msg string
+	if unmarshalErr := json.Unmarshal(data, &msg); unmarshalErr != nil {
+		return strings.Trim(string(data), `"`)
+	}
+	return msg
+}
+
+func jsonPointerDisplayPath(ptr string) string {
+	if ptr == "" {
+		return "$"
+	}
+	parts := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
+	var b strings.Builder
+	b.WriteByte('$')
+	for _, part := range parts {
+		part = strings.ReplaceAll(strings.ReplaceAll(part, "~1", "/"), "~0", "~")
+		if part == "" {
+			b.WriteString(`[""]`)
+			continue
+		}
+		if _, err := strconv.Atoi(part); err == nil {
+			b.WriteByte('[')
+			b.WriteString(part)
+			b.WriteByte(']')
+			continue
+		}
+		if isIdentifierPathSegment(part) {
+			b.WriteByte('.')
+			b.WriteString(part)
+			continue
+		}
+		encoded, _ := json.Marshal(part)
+		b.WriteByte('[')
+		b.Write(encoded)
+		b.WriteByte(']')
+	}
+	return b.String()
+}
+
+func isIdentifierPathSegment(value string) bool {
+	for i, r := range value {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return value != ""
+}

--- a/internal/cli/validation.go
+++ b/internal/cli/validation.go
@@ -300,8 +300,8 @@ func validationOutputParts(units []jsonschema.OutputUnit, color bool) []string {
 		generic := msg == "validation failed"
 		path := jsonPointerDisplayPath(unit.InstanceLocation)
 		if color {
-			path = output.StyleText("key", path)
-			msg = output.StyleText("diagnostic_error", msg)
+			path = colorJSONPointerDisplayPath(unit.InstanceLocation)
+			msg = colorValidationMessage(msg)
 		}
 		parts = append(parts, validationOutputPart{
 			text:    path + ": " + msg,
@@ -355,6 +355,87 @@ func validationOutputMessage(err *jsonschema.OutputError) string {
 		return strings.Trim(string(data), `"`)
 	}
 	return msg
+}
+
+func colorValidationMessage(msg string) string {
+	var b strings.Builder
+	for i := 0; i < len(msg); {
+		if msg[i] == '\'' {
+			end := i + 1
+			for end < len(msg) {
+				if msg[end] == '\'' && msg[end-1] != '\\' {
+					end++
+					break
+				}
+				end++
+			}
+			b.WriteString(output.StyleText("string", msg[i:end]))
+			i = end
+			continue
+		}
+		if isASCIIWordByte(msg[i]) {
+			start := i
+			for i < len(msg) && isASCIIWordByte(msg[i]) {
+				i++
+			}
+			word := msg[start:i]
+			if isSchemaTypeWord(word) {
+				b.WriteString(output.StyleText("type", word))
+			} else {
+				b.WriteString(word)
+			}
+			continue
+		}
+		b.WriteByte(msg[i])
+		i++
+	}
+	return b.String()
+}
+
+func isASCIIWordByte(ch byte) bool {
+	return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+}
+
+func isSchemaTypeWord(word string) bool {
+	switch word {
+	case "array", "boolean", "integer", "null", "number", "object", "string":
+		return true
+	default:
+		return false
+	}
+}
+
+func colorJSONPointerDisplayPath(ptr string) string {
+	if ptr == "" {
+		return output.StyleText("key", "$")
+	}
+	parts := strings.Split(strings.TrimPrefix(ptr, "/"), "/")
+	var b strings.Builder
+	b.WriteString(output.StyleText("key", "$"))
+	for _, part := range parts {
+		part = strings.ReplaceAll(strings.ReplaceAll(part, "~1", "/"), "~0", "~")
+		if part == "" {
+			b.WriteString(output.StyleText("punctuation", "["))
+			b.WriteString(output.StyleText("string", `""`))
+			b.WriteString(output.StyleText("punctuation", "]"))
+			continue
+		}
+		if _, err := strconv.Atoi(part); err == nil {
+			b.WriteString(output.StyleText("punctuation", "["))
+			b.WriteString(output.StyleText("number", part))
+			b.WriteString(output.StyleText("punctuation", "]"))
+			continue
+		}
+		if isIdentifierPathSegment(part) {
+			b.WriteString(output.StyleText("key", "."+part))
+			continue
+		}
+		encoded, _ := json.Marshal(part)
+		b.WriteString(output.StyleText("punctuation", "["))
+		b.WriteString(output.StyleText("string", string(encoded)))
+		b.WriteString(output.StyleText("punctuation", "]"))
+	}
+	return b.String()
 }
 
 func jsonPointerDisplayPath(ptr string) string {

--- a/internal/cli/validation.go
+++ b/internal/cli/validation.go
@@ -13,7 +13,7 @@ import (
 
 const generatedRequestSchemaURL = "restish-request-body.schema.json"
 
-func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, schema map[string]any) error {
+func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, schema map[string]any, schemaDialect string) error {
 	mediaType := strings.TrimSpace(contentType)
 	if mediaType != "" && !strings.Contains(mediaType, "/") && schemaMediaType != "" {
 		mediaType = schemaMediaType
@@ -34,9 +34,23 @@ func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, sc
 	if err != nil {
 		return fmt.Errorf("compile request body schema: %w", err)
 	}
+	rootSchemaDialect, _ := normalizedSchema["$schema"].(string)
+	if shouldNormalizeOpenAPISchema(schemaDialect, rootSchemaDialect) {
+		normalizeOpenAPIJSONSchema(normalizedSchema)
+	}
+	if isOpenAPIJSONSchemaDialect(rootSchemaDialect) {
+		normalizedSchema["$schema"] = jsonschema.Draft2020.String()
+	}
+	defaultDraft, err := jsonSchemaDraftForDialect(schemaDialect)
+	if err != nil && strings.TrimSpace(rootSchemaDialect) == "" {
+		return fmt.Errorf("compile request body schema: %w", err)
+	}
+	if defaultDraft == nil {
+		defaultDraft = jsonschema.Draft2020
+	}
 
 	compiler := jsonschema.NewCompiler()
-	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.DefaultDraft(defaultDraft)
 	if err := compiler.AddResource(generatedRequestSchemaURL, normalizedSchema); err != nil {
 		return fmt.Errorf("compile request body schema: %w", err)
 	}
@@ -50,6 +64,53 @@ func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, sc
 	return nil
 }
 
+func shouldNormalizeOpenAPISchema(defaultDialect, rootDialect string) bool {
+	if isOpenAPIJSONSchemaDialect(defaultDialect) || isOpenAPIJSONSchemaDialect(rootDialect) {
+		return true
+	}
+	return strings.TrimSpace(defaultDialect) == "" && strings.TrimSpace(rootDialect) == ""
+}
+
+func jsonSchemaDraftForDialect(dialect string) (*jsonschema.Draft, error) {
+	switch normalizedJSONSchemaDialect(dialect) {
+	case "":
+		return jsonschema.Draft2020, nil
+	case "https://json-schema.org/draft/2020-12/schema", "http://json-schema.org/draft/2020-12/schema":
+		return jsonschema.Draft2020, nil
+	case "https://json-schema.org/draft/2019-09/schema", "http://json-schema.org/draft/2019-09/schema":
+		return jsonschema.Draft2019, nil
+	case "https://json-schema.org/draft-07/schema", "http://json-schema.org/draft-07/schema":
+		return jsonschema.Draft7, nil
+	case "https://json-schema.org/draft-06/schema", "http://json-schema.org/draft-06/schema":
+		return jsonschema.Draft6, nil
+	case "https://json-schema.org/draft-04/schema", "http://json-schema.org/draft-04/schema":
+		return jsonschema.Draft4, nil
+	case "https://spec.openapis.org/oas/3.1/dialect/base",
+		"https://spec.openapis.org/oas/3.2/dialect/2025-09-17":
+		return jsonschema.Draft2020, nil
+	default:
+		return nil, fmt.Errorf("unsupported JSON Schema dialect %q", dialect)
+	}
+}
+
+func normalizedJSONSchemaDialect(dialect string) string {
+	dialect = strings.TrimSpace(dialect)
+	if strings.HasSuffix(dialect, "#") {
+		dialect = strings.TrimSuffix(dialect, "#")
+	}
+	return dialect
+}
+
+func isOpenAPIJSONSchemaDialect(dialect string) bool {
+	switch normalizedJSONSchemaDialect(dialect) {
+	case "https://spec.openapis.org/oas/3.1/dialect/base",
+		"https://spec.openapis.org/oas/3.2/dialect/2025-09-17":
+		return true
+	default:
+		return false
+	}
+}
+
 func normalizeJSONSchemaValue(schema map[string]any) (map[string]any, error) {
 	normalized, err := normalizeJSONCompatible(schema)
 	if err != nil {
@@ -59,7 +120,6 @@ func normalizeJSONSchemaValue(schema map[string]any) (map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("schema root is %T, want object", normalized)
 	}
-	normalizeOpenAPIJSONSchema(out)
 	return out, nil
 }
 

--- a/internal/cli/validation.go
+++ b/internal/cli/validation.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 const generatedRequestSchemaURL = "restish-request-body.schema.json"
 
-func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, schema map[string]any, schemaDialect string) error {
+func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, schema map[string]any, schemaDialect string, color bool) error {
 	mediaType := strings.TrimSpace(contentType)
 	if mediaType != "" && !strings.Contains(mediaType, "/") && schemaMediaType != "" {
 		mediaType = schemaMediaType
@@ -59,7 +60,15 @@ func validateGeneratedJSONBody(body any, contentType, schemaMediaType string, sc
 		return fmt.Errorf("compile request body schema: %w", err)
 	}
 	if err := compiled.Validate(body); err != nil {
-		return fmt.Errorf("request body failed OpenAPI schema validation: %s", formatJSONSchemaValidationError(err))
+		prefix := "request body failed OpenAPI schema validation"
+		if color {
+			prefix = output.StyleText("diagnostic_error", prefix)
+		}
+		details := formatJSONSchemaValidationError(err, color)
+		if strings.Contains(details, "\n") {
+			return fmt.Errorf("%s:\n%s", prefix, details)
+		}
+		return fmt.Errorf("%s: %s", prefix, details)
 	}
 	return nil
 }
@@ -258,7 +267,7 @@ func normalizeOpenAPIExclusiveBound(schema map[string]any, limitKey, exclusiveKe
 	}
 }
 
-func formatJSONSchemaValidationError(err error) string {
+func formatJSONSchemaValidationError(err error, color bool) string {
 	var validationErr *jsonschema.ValidationError
 	if !errors.As(err, &validationErr) {
 		return err.Error()
@@ -267,23 +276,56 @@ func formatJSONSchemaValidationError(err error) string {
 	if len(units) == 0 {
 		return validationErr.Error()
 	}
-	const maxErrors = 5
-	var parts []string
-	for i, unit := range units {
-		if i >= maxErrors {
-			parts = append(parts, fmt.Sprintf("and %d more", len(units)-maxErrors))
-			break
-		}
+	parts := validationOutputParts(units, color)
+	if len(parts) == 0 {
+		return validationErr.Error()
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "  " + strings.Join(parts, "\n  ")
+}
+
+func validationOutputParts(units []jsonschema.OutputUnit, color bool) []string {
+	type validationOutputPart struct {
+		text    string
+		generic bool
+	}
+	var parts []validationOutputPart
+	for _, unit := range units {
 		msg := validationOutputMessage(unit.Error)
 		if msg == "" {
 			continue
 		}
-		parts = append(parts, jsonPointerDisplayPath(unit.InstanceLocation)+": "+msg)
+		generic := msg == "validation failed"
+		path := jsonPointerDisplayPath(unit.InstanceLocation)
+		if color {
+			path = output.StyleText("key", path)
+			msg = output.StyleText("diagnostic_error", msg)
+		}
+		parts = append(parts, validationOutputPart{
+			text:    path + ": " + msg,
+			generic: generic,
+		})
 	}
 	if len(parts) == 0 {
-		return validationErr.Error()
+		return nil
 	}
-	return strings.Join(parts, "; ")
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.generic {
+			continue
+		}
+		filtered = append(filtered, part.text)
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		out = append(out, part.text)
+	}
+	return out
 }
 
 func validationOutputLeaves(unit *jsonschema.OutputUnit) []jsonschema.OutputUnit {

--- a/internal/cli/validation_test.go
+++ b/internal/cli/validation_test.go
@@ -12,10 +12,10 @@ func TestValidateGeneratedJSONBodyUsesSchemaDialectDefault(t *testing.T) {
 		"exclusiveMinimum": true,
 	}
 
-	if err := validateGeneratedJSONBody(6.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#"); err != nil {
+	if err := validateGeneratedJSONBody(6.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#", false); err != nil {
 		t.Fatalf("draft-04 valid body: %v", err)
 	}
-	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#")
+	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#", false)
 	if err == nil {
 		t.Fatal("expected draft-04 exclusiveMinimum validation error")
 	}
@@ -32,7 +32,7 @@ func TestValidateGeneratedJSONBodySchemaKeywordOverridesDefaultDialect(t *testin
 		"exclusiveMinimum": true,
 	}
 
-	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "https://json-schema.org/draft/2020-12/schema")
+	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "https://json-schema.org/draft/2020-12/schema", false)
 	if err == nil {
 		t.Fatal("expected root $schema dialect to override default dialect")
 	}
@@ -43,11 +43,135 @@ func TestValidateGeneratedJSONBodySchemaKeywordOverridesDefaultDialect(t *testin
 
 func TestValidateGeneratedJSONBodyRejectsUnsupportedDefaultDialect(t *testing.T) {
 	schema := map[string]any{"type": "object"}
-	err := validateGeneratedJSONBody(map[string]any{}, "application/json", "application/json", schema, "https://schemas.example.com/future")
+	err := validateGeneratedJSONBody(map[string]any{}, "application/json", "application/json", schema, "https://schemas.example.com/future", false)
 	if err == nil {
 		t.Fatal("expected unsupported dialect error")
 	}
 	if !strings.Contains(err.Error(), `unsupported JSON Schema dialect "https://schemas.example.com/future"`) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGeneratedJSONBodyFormatsAllLeafErrors(t *testing.T) {
+	err := validateGeneratedJSONBody(map[string]any{
+		"name": 123,
+		"age":  "seventeen",
+		"profile": map[string]any{
+			"displayName": false,
+			"settings": map[string]any{
+				"newsletter": "yes",
+				"theme":      "blue",
+			},
+		},
+		"tags": []any{"ok", 42},
+		"addresses": []any{
+			map[string]any{"city": 99, "zip": "abc"},
+			map[string]any{"zip": 90210},
+		},
+	}, "application/json", "application/json", validationFormatterSchema(), "https://spec.openapis.org/oas/3.1/dialect/base", false)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "and ") {
+		t.Fatalf("validation output should not truncate errors:\n%s", msg)
+	}
+	if strings.Contains(msg, "validation failed") {
+		t.Fatalf("validation output should omit generic wrapper errors:\n%s", msg)
+	}
+	for _, want := range []string{
+		"request body failed OpenAPI schema validation:\n",
+		"\n  $.name: got number, want string",
+		"\n  $.age: got string, want integer",
+		"\n  $.profile.displayName: got boolean, want string",
+		"\n  $.profile.settings.newsletter: got string, want boolean",
+		"\n  $.profile.settings.theme: value must be one of 'light', 'dark'",
+		"\n  $.tags[1]: got number, want string",
+		"\n  $.addresses[0].city: got number, want string",
+		"\n  $.addresses[0].zip: 'abc' does not match pattern '^[0-9]{5}$'",
+		"\n  $.addresses[1]: missing property 'city'",
+		"\n  $.addresses[1].zip: got number, want string",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("validation output missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestValidateGeneratedJSONBodyColorizesValidationOutput(t *testing.T) {
+	err := validateGeneratedJSONBody(map[string]any{
+		"name": 123,
+	}, "application/json", "application/json", validationFormatterSchema(), "https://spec.openapis.org/oas/3.1/dialect/base", true)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "\x1b[") {
+		t.Fatalf("expected ANSI color in validation output:\n%q", msg)
+	}
+	if plain := stripValidationANSI(msg); !strings.Contains(plain, "$.name: got number, want string") {
+		t.Fatalf("colored validation output should preserve plain text after stripping ANSI:\n%s", plain)
+	}
+}
+
+func stripValidationANSI(s string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7E) {
+				i++
+			}
+			if i < len(s) {
+				i++
+			}
+			continue
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}
+
+func validationFormatterSchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"name", "age", "profile", "tags", "addresses"},
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+			"age":  map[string]any{"type": "integer"},
+			"profile": map[string]any{
+				"type":     "object",
+				"required": []any{"displayName", "settings"},
+				"properties": map[string]any{
+					"displayName": map[string]any{"type": "string"},
+					"settings": map[string]any{
+						"type":     "object",
+						"required": []any{"newsletter", "theme"},
+						"properties": map[string]any{
+							"newsletter": map[string]any{"type": "boolean"},
+							"theme":      map[string]any{"enum": []any{"light", "dark"}},
+						},
+					},
+				},
+			},
+			"tags": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+			"addresses": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type":     "object",
+					"required": []any{"city", "zip"},
+					"properties": map[string]any{
+						"city": map[string]any{"type": "string"},
+						"zip":  map[string]any{"type": "string", "pattern": "^[0-9]{5}$"},
+					},
+				},
+			},
+		},
 	}
 }

--- a/internal/cli/validation_test.go
+++ b/internal/cli/validation_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateGeneratedJSONBodyUsesSchemaDialectDefault(t *testing.T) {
+	schema := map[string]any{
+		"type":             "number",
+		"minimum":          5.0,
+		"exclusiveMinimum": true,
+	}
+
+	if err := validateGeneratedJSONBody(6.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#"); err != nil {
+		t.Fatalf("draft-04 valid body: %v", err)
+	}
+	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "http://json-schema.org/draft-04/schema#")
+	if err == nil {
+		t.Fatal("expected draft-04 exclusiveMinimum validation error")
+	}
+	if !strings.Contains(err.Error(), "request body failed OpenAPI schema validation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGeneratedJSONBodySchemaKeywordOverridesDefaultDialect(t *testing.T) {
+	schema := map[string]any{
+		"$schema":          "http://json-schema.org/draft-04/schema#",
+		"type":             "number",
+		"minimum":          5.0,
+		"exclusiveMinimum": true,
+	}
+
+	err := validateGeneratedJSONBody(5.0, "application/json", "application/json", schema, "https://json-schema.org/draft/2020-12/schema")
+	if err == nil {
+		t.Fatal("expected root $schema dialect to override default dialect")
+	}
+	if !strings.Contains(err.Error(), "request body failed OpenAPI schema validation") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGeneratedJSONBodyRejectsUnsupportedDefaultDialect(t *testing.T) {
+	schema := map[string]any{"type": "object"}
+	err := validateGeneratedJSONBody(map[string]any{}, "application/json", "application/json", schema, "https://schemas.example.com/future")
+	if err == nil {
+		t.Fatal("expected unsupported dialect error")
+	}
+	if !strings.Contains(err.Error(), `unsupported JSON Schema dialect "https://schemas.example.com/future"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/validation_test.go
+++ b/internal/cli/validation_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/rest-sh/restish/v2/internal/output"
 )
 
 func TestValidateGeneratedJSONBodyUsesSchemaDialectDefault(t *testing.T) {
@@ -101,6 +103,16 @@ func TestValidateGeneratedJSONBodyFormatsAllLeafErrors(t *testing.T) {
 func TestValidateGeneratedJSONBodyColorizesValidationOutput(t *testing.T) {
 	err := validateGeneratedJSONBody(map[string]any{
 		"name": 123,
+		"age":  "seventeen",
+		"profile": map[string]any{
+			"displayName": "Ada",
+			"settings": map[string]any{
+				"newsletter": "yes",
+				"theme":      "blue",
+			},
+		},
+		"tags":      []any{"ok", 42},
+		"addresses": []any{map[string]any{"city": "Portland", "zip": "abc"}},
 	}, "application/json", "application/json", validationFormatterSchema(), "https://spec.openapis.org/oas/3.1/dialect/base", true)
 	if err == nil {
 		t.Fatal("expected validation error")
@@ -111,6 +123,25 @@ func TestValidateGeneratedJSONBodyColorizesValidationOutput(t *testing.T) {
 	}
 	if plain := stripValidationANSI(msg); !strings.Contains(plain, "$.name: got number, want string") {
 		t.Fatalf("colored validation output should preserve plain text after stripping ANSI:\n%s", plain)
+	}
+	if !strings.Contains(msg, output.StyleText("diagnostic_error", "request body failed OpenAPI schema validation")) {
+		t.Fatalf("expected validation prefix to be red:\n%q", msg)
+	}
+	if strings.Contains(msg, output.StyleText("diagnostic_error", "got number, want string")) {
+		t.Fatalf("error messages should not be colored as diagnostic errors:\n%q", msg)
+	}
+	for _, want := range []string{
+		output.StyleText("key", ".tags"),
+		output.StyleText("number", "1"),
+		output.StyleText("type", "number"),
+		output.StyleText("type", "integer"),
+		output.StyleText("type", "boolean"),
+		output.StyleText("string", "'light'"),
+		output.StyleText("string", "'abc'"),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("colored validation output missing styled fragment %q:\n%q", want, msg)
+		}
 	}
 }
 

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -59,7 +59,7 @@ type opsBlob struct {
 }
 
 const currentCacheSchema = 2
-const currentOperationCacheSchema = 10
+const currentOperationCacheSchema = 11
 
 // OperationCacheStatus describes the freshness of cached operation metadata.
 type OperationCacheStatus struct {

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -59,7 +59,7 @@ type opsBlob struct {
 }
 
 const currentCacheSchema = 2
-const currentOperationCacheSchema = 11
+const currentOperationCacheSchema = 12
 
 // OperationCacheStatus describes the freshness of cached operation metadata.
 type OperationCacheStatus struct {

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -34,24 +34,25 @@ type ParamXCLI struct {
 
 // Param is a single request parameter (path, query, header, or cookie).
 type Param struct {
-	Name             string
-	In               string // "path", "query", "header", "cookie"
-	Desc             string
-	Schema           string
-	JSONSchema       map[string]any
-	Required         bool
-	Type             string
-	ItemType         string
-	Default          string
-	DefaultValues    []string
-	HasDefault       bool
-	Style            string
-	Explode          *bool
-	AllowReserved    bool
-	ContentMediaType string
-	Enum             []string
-	ObjectProperties []ParamObjectProperty
-	XCLI             ParamXCLI
+	Name              string
+	In                string // "path", "query", "header", "cookie"
+	Desc              string
+	Schema            string
+	JSONSchema        map[string]any
+	JSONSchemaDialect string
+	Required          bool
+	Type              string
+	ItemType          string
+	Default           string
+	DefaultValues     []string
+	HasDefault        bool
+	Style             string
+	Explode           *bool
+	AllowReserved     bool
+	ContentMediaType  string
+	Enum              []string
+	ObjectProperties  []ParamObjectProperty
+	XCLI              ParamXCLI
 }
 
 // ParamObjectProperty is a simple scalar property from an object-capable
@@ -66,11 +67,12 @@ type ParamObjectProperty struct {
 // OperationBodyHelp is a compact request/response body example extracted from
 // OpenAPI schemas for generated command help.
 type OperationBodyHelp struct {
-	MediaType  string
-	Schema     string
-	JSONSchema map[string]any
-	Example    string
-	RawBinary  bool
+	MediaType         string
+	Schema            string
+	JSONSchema        map[string]any
+	JSONSchemaDialect string
+	Example           string
+	RawBinary         bool
 }
 
 // OperationResponseHelp is a compact response shape for generated command help.
@@ -271,7 +273,7 @@ func (s *APISpec) buildOperations(opts OperationOptions) ([]Operation, []string,
 				}
 			}
 			fullPath := joinOperationPath(basePath, rawPath)
-			op := extractOperation(mo.Method, fullPath, pathParams, mo.Op, model.Model.Security, securitySchemes(model.Model.Components))
+			op := extractOperation(mo.Method, fullPath, pathParams, mo.Op, model.Model.Security, securitySchemes(model.Model.Components), openAPIJSONSchemaDialect(model.Model))
 			op.OperationServer = operationServer
 			if op.XCLI.Ignore {
 				continue
@@ -295,7 +297,7 @@ func emitOperationWarnings(warnf func(format string, args ...any), warnings []st
 }
 
 // extractOperation converts a single libopenapi operation to the neutral form.
-func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Operation, docSecurity []*base.SecurityRequirement, schemes map[string]*v3.SecurityScheme) Operation {
+func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Operation, docSecurity []*base.SecurityRequirement, schemes map[string]*v3.SecurityScheme, schemaDialect string) Operation {
 	effectiveSecurity := docSecurity
 	if op.Security != nil {
 		effectiveSecurity = op.Security
@@ -323,7 +325,7 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 			Aliases:     OpExtStrings(op, "x-cli-aliases"),
 		},
 	}
-	o.Help = buildOperationHelp(op, o.RequestMediaType)
+	o.Help = buildOperationHelp(op, o.RequestMediaType, schemaDialect)
 	o.RequestMultipartContentTypes = buildRequestMultipartContentTypes(op, o.RequestMediaType)
 	o.OptionalAuth, o.CredentialAlternatives = credentialAlternatives(effectiveSecurity, schemes)
 
@@ -338,33 +340,34 @@ func extractOperation(method, path string, pathParams []*v3.Parameter, op *v3.Op
 		var enum, defaultValues []string
 		var objectProperties []ParamObjectProperty
 		var jsonSchema map[string]any
-		var paramType, itemType, defaultValue, schemaHelp string
+		var paramType, itemType, defaultValue, schemaHelp, jsonSchemaDialect string
 		var hasDefault bool
 		if p.Schema != nil {
 			if schema := p.Schema.Schema(); schema != nil {
-				schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema = parameterSchemaDetails(schema)
+				schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema, jsonSchemaDialect = parameterSchemaDetails(schema, schemaDialect)
 			}
 		} else if schema := preferredParameterContentSchema(p); schema != nil {
-			schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema = parameterSchemaDetails(schema)
+			schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema, jsonSchemaDialect = parameterSchemaDetails(schema, schemaDialect)
 		}
 		o.Parameters = append(o.Parameters, Param{
-			Name:             p.Name,
-			In:               p.In,
-			Desc:             p.Description,
-			Schema:           schemaHelp,
-			JSONSchema:       jsonSchema,
-			Required:         p.Required != nil && *p.Required,
-			Type:             paramType,
-			ItemType:         itemType,
-			Default:          defaultValue,
-			DefaultValues:    defaultValues,
-			HasDefault:       hasDefault,
-			Style:            p.Style,
-			Explode:          p.Explode,
-			AllowReserved:    p.AllowReserved,
-			ContentMediaType: preferredParameterContentMediaType(p),
-			Enum:             enum,
-			ObjectProperties: objectProperties,
+			Name:              p.Name,
+			In:                p.In,
+			Desc:              p.Description,
+			Schema:            schemaHelp,
+			JSONSchema:        jsonSchema,
+			JSONSchemaDialect: jsonSchemaDialect,
+			Required:          p.Required != nil && *p.Required,
+			Type:              paramType,
+			ItemType:          itemType,
+			Default:           defaultValue,
+			DefaultValues:     defaultValues,
+			HasDefault:        hasDefault,
+			Style:             p.Style,
+			Explode:           p.Explode,
+			AllowReserved:     p.AllowReserved,
+			ContentMediaType:  preferredParameterContentMediaType(p),
+			Enum:              enum,
+			ObjectProperties:  objectProperties,
 			XCLI: ParamXCLI{
 				Ignore:      ParamExtBool(p, "x-cli-ignore"),
 				Hidden:      ParamExtBool(p, "x-cli-hidden"),
@@ -767,9 +770,9 @@ func schemaType(types []string) string {
 	return "string"
 }
 
-func parameterSchemaDetails(schema *base.Schema) (schemaHelp, paramType, itemType, defaultValue string, defaultValues []string, hasDefault bool, enum []string, objectProperties []ParamObjectProperty, jsonSchema map[string]any) {
+func parameterSchemaDetails(schema *base.Schema, defaultDialect string) (schemaHelp, paramType, itemType, defaultValue string, defaultValues []string, hasDefault bool, enum []string, objectProperties []ParamObjectProperty, jsonSchema map[string]any, jsonSchemaDialect string) {
 	if schema == nil {
-		return "", "", "", "", nil, false, nil, nil, nil
+		return "", "", "", "", nil, false, nil, nil, nil, ""
 	}
 	schemaHelp = buildParameterSchemaHelp(schema)
 	paramType = schemaType(schema.Type)
@@ -802,7 +805,8 @@ func parameterSchemaDetails(schema *base.Schema) (schemaHelp, paramType, itemTyp
 		schemaHelp = buildParameterSchemaHelpWithType(schema, paramType)
 	}
 	jsonSchema = schemaJSONMap(schema)
-	return schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema
+	jsonSchemaDialect = schemaJSONDialect(schema, defaultDialect)
+	return schemaHelp, paramType, itemType, defaultValue, defaultValues, hasDefault, enum, objectProperties, jsonSchema, jsonSchemaDialect
 }
 
 func buildParameterSchemaHelpWithType(schema *base.Schema, typ string) string {
@@ -827,6 +831,28 @@ func schemaJSONMap(schema *base.Schema) map[string]any {
 		return nil
 	}
 	return out
+}
+
+func schemaJSONDialect(schema *base.Schema, defaultDialect string) string {
+	if schema != nil && strings.TrimSpace(schema.SchemaTypeRef) != "" {
+		return strings.TrimSpace(schema.SchemaTypeRef)
+	}
+	return strings.TrimSpace(defaultDialect)
+}
+
+func openAPIJSONSchemaDialect(doc v3.Document) string {
+	if strings.TrimSpace(doc.JsonSchemaDialect) != "" {
+		return strings.TrimSpace(doc.JsonSchemaDialect)
+	}
+	version := strings.TrimSpace(doc.Version)
+	switch {
+	case strings.HasPrefix(version, "3.2."):
+		return "https://spec.openapis.org/oas/3.2/dialect/2025-09-17"
+	case strings.HasPrefix(version, "3.1."):
+		return "https://spec.openapis.org/oas/3.1/dialect/base"
+	default:
+		return ""
+	}
 }
 
 func scalarObjectProperties(schema *base.Schema) []ParamObjectProperty {

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -66,10 +66,11 @@ type ParamObjectProperty struct {
 // OperationBodyHelp is a compact request/response body example extracted from
 // OpenAPI schemas for generated command help.
 type OperationBodyHelp struct {
-	MediaType string
-	Schema    string
-	Example   string
-	RawBinary bool
+	MediaType  string
+	Schema     string
+	JSONSchema map[string]any
+	Example    string
+	RawBinary  bool
 }
 
 // OperationResponseHelp is a compact response shape for generated command help.

--- a/internal/spec/operation_test.go
+++ b/internal/spec/operation_test.go
@@ -83,6 +83,57 @@ paths:
 	}
 }
 
+func TestOperationsCarriesRequestJSONSchemaDialect(t *testing.T) {
+	raw := `openapi: "3.1.0"
+jsonSchemaDialect: "http://json-schema.org/draft-07/schema#"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+          application/merge-patch+json:
+            schema:
+              "$schema": "https://json-schema.org/draft/2019-09/schema"
+              type: object
+      responses:
+        "200":
+          description: OK`
+	loaded, err := load("application/yaml", []byte(raw), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	ops, err := loaded.Operations(OperationOptions{})
+	if err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("len(ops) = %d, want 1", len(ops))
+	}
+	if got, want := ops[0].Help.Request.JSONSchemaDialect, "http://json-schema.org/draft-07/schema#"; got != want {
+		t.Fatalf("preferred request dialect = %q, want %q", got, want)
+	}
+	var override OperationBodyHelp
+	for _, request := range ops[0].Help.Requests {
+		if request.MediaType == "application/merge-patch+json" {
+			override = request
+			break
+		}
+	}
+	if got, want := override.JSONSchemaDialect, "https://json-schema.org/draft/2019-09/schema"; got != want {
+		t.Fatalf("schema $schema dialect = %q, want %q", got, want)
+	}
+}
+
 func TestOperationsIncludesContentParameterSchemaHelp(t *testing.T) {
 	raw := `openapi: "3.1.0"
 info:

--- a/internal/spec/schema_help.go
+++ b/internal/spec/schema_help.go
@@ -36,14 +36,14 @@ type schemaHelpRenderer struct {
 	inheritedType string
 }
 
-func buildOperationHelp(op *v3.Operation, requestMediaType string) OperationHelp {
+func buildOperationHelp(op *v3.Operation, requestMediaType, schemaDialect string) OperationHelp {
 	if op == nil {
 		return OperationHelp{}
 	}
 
 	help := OperationHelp{
-		Request:  buildRequestHelp(op, requestMediaType),
-		Requests: buildRequestHelps(op),
+		Request:  buildRequestHelp(op, requestMediaType, schemaDialect),
+		Requests: buildRequestHelps(op, schemaDialect),
 		Examples: buildCommandExamples(op, requestMediaType),
 	}
 	help.Responses = buildResponseHelp(op)
@@ -57,7 +57,7 @@ func buildParameterSchemaHelp(schema *base.Schema) string {
 	return schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, "")
 }
 
-func buildRequestHelp(op *v3.Operation, requestMediaType string) *OperationBodyHelp {
+func buildRequestHelp(op *v3.Operation, requestMediaType, schemaDialect string) *OperationBodyHelp {
 	if op.RequestBody == nil || op.RequestBody.Content == nil || requestMediaType == "" {
 		return nil
 	}
@@ -75,15 +75,16 @@ func buildRequestHelp(op *v3.Operation, requestMediaType string) *OperationBodyH
 		example = renderExampleJSON(firstMediaTypeExample(mt, schema, schemaHelpWrite))
 	}
 	return &OperationBodyHelp{
-		MediaType:  requestMediaType,
-		Schema:     schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, ""),
-		JSONSchema: schemaJSONMap(schema),
-		Example:    example,
-		RawBinary:  rawBinary,
+		MediaType:         requestMediaType,
+		Schema:            schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, ""),
+		JSONSchema:        schemaJSONMap(schema),
+		JSONSchemaDialect: schemaJSONDialect(schema, schemaDialect),
+		Example:           example,
+		RawBinary:         rawBinary,
 	}
 }
 
-func buildRequestHelps(op *v3.Operation) []OperationBodyHelp {
+func buildRequestHelps(op *v3.Operation, schemaDialect string) []OperationBodyHelp {
 	if op == nil || op.RequestBody == nil || op.RequestBody.Content == nil {
 		return nil
 	}
@@ -98,6 +99,7 @@ func buildRequestHelps(op *v3.Operation) []OperationBodyHelp {
 			help.RawBinary = isRawBinaryRequestBody(mediaType, schema)
 			help.Schema = schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, "")
 			help.JSONSchema = schemaJSONMap(schema)
+			help.JSONSchemaDialect = schemaJSONDialect(schema, schemaDialect)
 			if !help.RawBinary {
 				help.Example = renderExampleJSON(firstMediaTypeExample(mt, schema, schemaHelpWrite))
 			}

--- a/internal/spec/schema_help.go
+++ b/internal/spec/schema_help.go
@@ -75,10 +75,11 @@ func buildRequestHelp(op *v3.Operation, requestMediaType string) *OperationBodyH
 		example = renderExampleJSON(firstMediaTypeExample(mt, schema, schemaHelpWrite))
 	}
 	return &OperationBodyHelp{
-		MediaType: requestMediaType,
-		Schema:    schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, ""),
-		Example:   example,
-		RawBinary: rawBinary,
+		MediaType:  requestMediaType,
+		Schema:     schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, ""),
+		JSONSchema: schemaJSONMap(schema),
+		Example:    example,
+		RawBinary:  rawBinary,
 	}
 }
 
@@ -96,6 +97,7 @@ func buildRequestHelps(op *v3.Operation) []OperationBodyHelp {
 		if schema != nil {
 			help.RawBinary = isRawBinaryRequestBody(mediaType, schema)
 			help.Schema = schemaHelpRenderer{mode: schemaHelpWrite, seen: map[uint64]bool{}}.render(schema, "")
+			help.JSONSchema = schemaJSONMap(schema)
 			if !help.RawBinary {
 				help.Example = renderExampleJSON(firstMediaTypeExample(mt, schema, schemaHelpWrite))
 			}

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -108,17 +108,19 @@ type APISpecResponseMsg struct {
 // OpenAPI HTTP operation. It mirrors the generated-command model so command
 // plugins do not need to re-parse raw OpenAPI specs.
 type APIOperation struct {
-	ID               string     `cbor:"id"`
-	Method           string     `cbor:"method"`
-	Path             string     `cbor:"path"`
-	Summary          string     `cbor:"summary,omitempty"`
-	Description      string     `cbor:"description,omitempty"`
-	Deprecated       bool       `cbor:"deprecated,omitempty"`
-	Parameters       []APIParam `cbor:"parameters,omitempty"`
-	HasBody          bool       `cbor:"has_body,omitempty"`
-	BodyRequired     bool       `cbor:"body_required,omitempty"`
-	RequestMediaType string     `cbor:"request_media_type,omitempty"`
-	MCPIgnore        bool       `cbor:"mcp_ignore,omitempty"`
+	ID                   string         `cbor:"id"`
+	Method               string         `cbor:"method"`
+	Path                 string         `cbor:"path"`
+	Summary              string         `cbor:"summary,omitempty"`
+	Description          string         `cbor:"description,omitempty"`
+	Deprecated           bool           `cbor:"deprecated,omitempty"`
+	Parameters           []APIParam     `cbor:"parameters,omitempty"`
+	HasBody              bool           `cbor:"has_body,omitempty"`
+	BodyRequired         bool           `cbor:"body_required,omitempty"`
+	RequestMediaType     string         `cbor:"request_media_type,omitempty"`
+	RequestSchema        map[string]any `cbor:"request_schema,omitempty"`
+	RequestSchemaDialect string         `cbor:"request_schema_dialect,omitempty"`
+	MCPIgnore            bool           `cbor:"mcp_ignore,omitempty"`
 }
 
 // APIParam is a resolved operation parameter for APIOperation.
@@ -134,6 +136,7 @@ type APIParam struct {
 	AllowReserved    bool           `cbor:"allow_reserved,omitempty"`
 	ContentMediaType string         `cbor:"content_media_type,omitempty"`
 	Schema           map[string]any `cbor:"schema,omitempty"`
+	SchemaDialect    string         `cbor:"schema_dialect,omitempty"`
 	Enum             []string       `cbor:"enum,omitempty"`
 }
 

--- a/site/content/en/docs/guides/input.md
+++ b/site/content/en/docs/guides/input.md
@@ -111,6 +111,10 @@ selection, and bounded coercion. They do not reject explicit body fields just
 because the schema says a value has a different type, enum, or shape. Restish
 sends what you ask for and lets the server validate API-specific semantics.
 
+Use `--rsh-validate` on a generated command when you want an optional local
+JSON Schema check before sending a JSON request body. Validation happens after
+Restish builds the body, and it does not rewrite or coerce values.
+
 Restish still fails locally when the CLI cannot build a request, such as a
 missing required path argument, unreadable `@file`, or invalid Restish flag.
 

--- a/site/content/en/docs/reference/global-flags.md
+++ b/site/content/en/docs/reference/global-flags.md
@@ -274,6 +274,10 @@ Generated operation commands may also expose `--rsh-generate-body` when the
 OpenAPI operation has a request body schema. That flag prints an example body
 for the generated operation instead of sending the request.
 
+`--rsh-validate` is opt-in and applies to generated JSON request bodies. It
+checks the assembled body against the operation's OpenAPI schema before sending
+and leaves generic HTTP commands unchanged.
+
 ## Output And Filtering
 
 | Flag | Type | Default | Notes |

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -217,11 +217,12 @@ string, even when the OpenAPI schema says the field is a string.
 Schemas are not full request validators by default. Restish trusts explicit
 input and lets the server validate API semantics. Unknown body fields are
 allowed, enum mismatches are not rejected locally, and schema constraints are
-not enforced unless Restish grows an explicit validation mode. Schema constructs
-such as `oneOf`, `anyOf`, `allOf`, `nullable`, `enum`, `const`, defaults,
-examples, numeric constraints, read-only/write-only fields, additional
-properties, and recursive references are used for help and bounded example
-bodies.
+not enforced unless you opt in with `--rsh-validate` on a generated command.
+That validation runs after body assembly, only for JSON request bodies, and
+does not rewrite or coerce values. Schema constructs such as `oneOf`, `anyOf`,
+`allOf`, `nullable`, `enum`, `const`, defaults, examples, numeric constraints,
+read-only/write-only fields, additional properties, and recursive references
+are used for help, bounded example bodies, and optional local validation.
 
 Restish still fails locally when it cannot build a coherent request, such as a
 missing required path argument, an unreadable `@file`, or an invalid Restish

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -267,6 +267,14 @@ CBOR: `body_required`; type: `bool`; required: no
 
 CBOR: `request_media_type`; type: `string`; required: no
 
+**`RequestSchema`**
+
+CBOR: `request_schema`; type: `map[string]any`; required: no
+
+**`RequestSchemaDialect`**
+
+CBOR: `request_schema_dialect`; type: `string`; required: no
+
 **`MCPIgnore`**
 
 CBOR: `mcp_ignore`; type: `bool`; required: no
@@ -319,6 +327,10 @@ CBOR: `content_media_type`; type: `string`; required: no
 **`Schema`**
 
 CBOR: `schema`; type: `map[string]any`; required: no
+
+**`SchemaDialect`**
+
+CBOR: `schema_dialect`; type: `string`; required: no
 
 **`Enum`**
 


### PR DESCRIPTION
## Summary
- adds generated-command-local `--rsh-validate` for opt-in JSON request body validation against OpenAPI schemas
- validates after Restish assembles the request body without schema-aware coercion or rewriting
- carries request JSON schemas through generated operation metadata and documents the opt-in behavior

Fixes #123

## Validation
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestGeneratedCommandOptionalJSONSchemaValidation|TestGeneratedCommandValidationRequiresJSONBody'\n- env GOCACHE=/tmp/restish-gocache go test ./internal/spec ./internal/cli\n- env GOCACHE=/tmp/restish-gocache go test ./...\n- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...\n- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check\n- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache\n- no-context sub-agent review with follow-up clean