### PR TITLE
fix: shorten generated fallback names with operation base

### DIFF
--- a/docs/design/007-api-command-generation.md
+++ b/docs/design/007-api-command-generation.md
@@ -126,6 +126,11 @@ name from the method and path, for example:
 - `GET /users/{id}` -> `get-users-id`
 - `POST /v1/invoices` -> `post-v1-invoices`
 
+If `operation_base` is configured, fallback names are derived from the operation
+path relative to that base. For example, with `operation_base: /api/rest`,
+`GET /api/rest/foo` becomes `get-foo` rather than `get-api-rest-foo`.
+Explicit `x-cli-name` and `operationId` values are not changed.
+
 The exact normalization may evolve, but it must be deterministic and collision
 aware.
 

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -589,7 +589,7 @@ func (c *CLI) emitGeneratedCommandWarnings(apiName string, apiCfg *config.APICon
 	defer func() {
 		c.quietGeneratedWarnings = quiet
 	}()
-	_ = c.buildAPICommandFromOperationResult(apiName, apiCfg, set, err)
+	_ = c.buildAPICommandFromOperationResult(apiName, apiCfg, set, opOpts.OperationBase, err)
 }
 
 func preserveExistingProfiles(apiCfg, existingAPI *config.APIConfig) error {

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -828,22 +828,23 @@ func (c *CLI) cachedOperationForAPI(ctx context.Context, apiName string, apiCfg 
 	if !ok {
 		return spec.Operation{}, false, nil
 	}
+	operationBase := effectiveOperationBase(apiCfg, profileName)
 	for _, op := range set.Operations {
-		if op.ID == value || operationCommandName(op) == value {
+		if op.ID == value || operationCommandName(op, operationBase) == value {
 			return op, true, nil
 		}
 	}
 	return spec.Operation{}, false, nil
 }
 
-func operationCommandName(op spec.Operation) string {
+func operationCommandName(op spec.Operation, operationBase string) string {
 	if op.XCLI.Name != "" {
 		return op.XCLI.Name
 	}
 	if name := toKebabCase(op.ID); name != "" {
 		return name
 	}
-	return fallbackOperationName(op.Method, op.Path)
+	return fallbackOperationName(op.Method, operationNamePath(op.Path, operationBase))
 }
 
 func configuredCredentialsForProfile(prof *config.ProfileConfig) map[string]bool {

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -498,6 +498,31 @@ func TestAPIAuthInspectOperationLabelsProfileFallbackSource(t *testing.T) {
 	)
 }
 
+func TestAPIAuthInspectFallbackOperationNameUsesOperationBase(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(`"PartnerKey":{"type":"apiKey","in":"header","name":"X-Partner-Key"}`),
+			openAPIPaths(openAPIGet("/api/rest/widgets", "", `"security":[{"PartnerKey":[]}]`)))
+	})
+	env.writeAPIConfig(t, &config.APIConfig{
+		BaseURL:       env.baseURL(t),
+		OperationBase: "/api/rest",
+		Profiles: map[string]*config.ProfileConfig{
+			"default": profileAuth(apiKeyAuth("header", "X-Partner-Key", "sekret")),
+		},
+	})
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "api", "auth", "inspect", "tapi", "--operation", "get-widgets"}); err != nil {
+		t.Fatalf("api auth inspect operation: %v", err)
+	}
+	requireContains(t, out.String(),
+		"X-Partner-Key: sekret",
+	)
+}
+
 func TestAPIAuthInspectUsesImplicitDefaultProfile(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -609,7 +609,7 @@ func (c *CLI) Run(args []string) error {
 			ServerVariables: effectiveServerVariables(apiCfg, startupProfile),
 		}
 		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opOpts, true); ok {
-			if apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set); apiCmd != nil {
+			if apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set, opOpts.OperationBase); apiCmd != nil {
 				root.AddCommand(apiCmd)
 			}
 			continue
@@ -628,7 +628,7 @@ func (c *CLI) Run(args []string) error {
 		if opsErr == nil {
 			_ = spec.StoreOperationSetInCache(c.specCacheDir(), apiName, Version, opOpts, set)
 		}
-		if apiCmd := c.buildAPICommandFromOperationResult(apiName, apiCfg, set, opsErr); apiCmd != nil {
+		if apiCmd := c.buildAPICommandFromOperationResult(apiName, apiCfg, set, opOpts.OperationBase, opsErr); apiCmd != nil {
 			root.AddCommand(apiCmd)
 		}
 	}
@@ -1022,7 +1022,7 @@ func (c *CLI) runSyncedGeneratedAPICommand(cmd *cobra.Command, apiName string, a
 	if !ok {
 		return fmt.Errorf("generated commands for API %q are not available; run %q after fixing spec discovery", apiName, "api sync "+apiName)
 	}
-	apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set)
+	apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set, effectiveOperationBase(apiCfg, profileName))
 	if apiCmd == nil {
 		return fmt.Errorf("generated commands for API %q are unavailable after sync", apiName)
 	}

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -346,11 +346,11 @@ func (c *CLI) handlePluginAPISpec(ctx context.Context, cmd *cobra.Command, write
 		Profile:     profileName,
 		ContentType: s.ContentType,
 		Raw:         s.Raw,
-		Operations:  pluginOperationsFromSpec(opSet.Operations),
+		Operations:  pluginOperationsFromSpec(opSet.Operations, effectiveOperationBase(apiCfg, profileName)),
 	})
 }
 
-func pluginOperationsFromSpec(ops []spec.Operation) []pluginwire.APIOperation {
+func pluginOperationsFromSpec(ops []spec.Operation, operationBase string) []pluginwire.APIOperation {
 	if ops == nil {
 		return nil
 	}
@@ -377,7 +377,7 @@ func pluginOperationsFromSpec(ops []spec.Operation) []pluginwire.APIOperation {
 			})
 		}
 		out = append(out, pluginwire.APIOperation{
-			ID:               operationCommandName(op),
+			ID:               operationCommandName(op, operationBase),
 			Method:           op.Method,
 			Path:             op.Path,
 			Summary:          op.Summary,

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -403,7 +403,20 @@ func TestPluginOperationsFromSpecUsesFallbackOperationName(t *testing.T) {
 	ops := pluginOperationsFromSpec([]spec.Operation{{
 		Method: "GET",
 		Path:   "/pets/{petId}",
-	}})
+	}}, "")
+	if len(ops) != 1 {
+		t.Fatalf("len(ops) = %d, want 1", len(ops))
+	}
+	if got, want := ops[0].ID, "get-pets-petid"; got != want {
+		t.Fatalf("operation ID = %q, want %q", got, want)
+	}
+}
+
+func TestPluginOperationsFromSpecUsesOperationBaseFallbackName(t *testing.T) {
+	ops := pluginOperationsFromSpec([]spec.Operation{{
+		Method: "GET",
+		Path:   "/api/rest/pets/{petId}",
+	}}, "/api/rest")
 	if len(ops) != 1 {
 		t.Fatalf("len(ops) = %d, want 1", len(ops))
 	}
@@ -428,7 +441,7 @@ func TestPluginOperationsFromSpecPreservesParameterContentSchema(t *testing.T) {
 				},
 			},
 		}},
-	}})
+	}}, "")
 	if len(ops) != 1 || len(ops[0].Parameters) != 1 {
 		t.Fatalf("operations = %#v, want one operation with one parameter", ops)
 	}

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"mime"
 	"net/url"
+	urlpath "path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -36,15 +37,16 @@ const (
 // populates it with one subcommand per OpenAPI operation found in s.
 // Returns nil when the spec cannot be built into a v3 model.
 func (c *CLI) buildAPICommand(apiName string, apiCfg *config.APIConfig, s *spec.APISpec) *cobra.Command {
+	operationBase := effectiveOperationBase(apiCfg, "default")
 	set, err := s.OperationSet(spec.OperationOptions{
 		BaseURL:         effectiveProfileBaseURL(apiCfg, "default"),
-		OperationBase:   effectiveOperationBase(apiCfg, "default"),
+		OperationBase:   operationBase,
 		ServerVariables: effectiveServerVariables(apiCfg, "default"),
 	})
-	return c.buildAPICommandFromOperationResult(apiName, apiCfg, set, err)
+	return c.buildAPICommandFromOperationResult(apiName, apiCfg, set, operationBase, err)
 }
 
-func (c *CLI) buildAPICommandFromOperationResult(apiName string, apiCfg *config.APIConfig, set spec.OperationSet, err error) *cobra.Command {
+func (c *CLI) buildAPICommandFromOperationResult(apiName string, apiCfg *config.APIConfig, set spec.OperationSet, operationBase string, err error) *cobra.Command {
 	if err != nil {
 		source := apiCfg.SpecURL
 		if source == "" && len(apiCfg.SpecFiles) > 0 {
@@ -56,10 +58,10 @@ func (c *CLI) buildAPICommandFromOperationResult(apiName string, apiCfg *config.
 		c.warnf("skipping generated commands for API %q from %s: %v", apiName, source, err)
 		return nil
 	}
-	return c.buildAPICommandFromOperationSet(apiName, apiCfg, set)
+	return c.buildAPICommandFromOperationSet(apiName, apiCfg, set, operationBase)
 }
 
-func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.APIConfig, set spec.OperationSet) *cobra.Command {
+func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.APIConfig, set spec.OperationSet, operationBase string) *cobra.Command {
 	ops := set.Operations
 	// ops == nil means no V3 model or no paths section — nothing to generate.
 	if ops == nil {
@@ -119,7 +121,7 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 			tagCommandName = generatedTagCommandName(op.Tags[0], tagCommandNameByTag, tagCommands)
 			examplePrefix = apiName + " " + tagCommandName
 		}
-		cmd, err := c.buildOperationCommand(apiName, examplePrefix, op)
+		cmd, err := c.buildOperationCommand(apiName, examplePrefix, op, operationBase)
 		if err != nil {
 			c.generatedWarnf("skipping %s %s for API %q: %v", op.Method, op.Path, apiName, err)
 			continue
@@ -325,13 +327,13 @@ type paramInfo struct {
 
 // buildOperationCommand creates a Cobra command for one OpenAPI operation.
 // Returns nil when the operation is excluded via x-cli-ignore.
-// operationBase, when non-empty, is resolved against baseURL and replaces the
-// apiName short-name prefix in generated URLs.
-func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Operation) (*cobra.Command, error) {
+// operationBase, when non-empty, is removed from fallback command names derived
+// from paths. It does not affect explicit operationId or x-cli-name values.
+func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Operation, operationBase string) (*cobra.Command, error) {
 	// Derive command name from operationId, with x-cli-name override.
 	cmdName := toKebabCase(op.ID)
 	if cmdName == "" {
-		cmdName = fallbackOperationName(op.Method, op.Path)
+		cmdName = fallbackOperationName(op.Method, operationNamePath(op.Path, operationBase))
 	}
 	if op.XCLI.Name != "" {
 		cmdName = op.XCLI.Name
@@ -1962,6 +1964,36 @@ func normalizeKnownIdentifierAcronyms(s string) string {
 
 func fallbackOperationName(method, path string) string {
 	return slugify(strings.ToLower(method) + "-" + strings.Trim(path, "/"))
+}
+
+func operationNamePath(path, operationBase string) string {
+	path = normalizeOperationNamePath(path)
+	base := normalizeOperationNamePath(operationBase)
+	if base == "" || base == "/" {
+		return path
+	}
+	if path == base {
+		return "/"
+	}
+	if strings.HasPrefix(path, strings.TrimRight(base, "/")+"/") {
+		return strings.TrimPrefix(path, strings.TrimRight(base, "/"))
+	}
+	return path
+}
+
+func normalizeOperationNamePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	path = urlpath.Clean(path)
+	if path == "." {
+		return "/"
+	}
+	return path
 }
 
 func slugify(s string) string {

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -330,14 +330,7 @@ type paramInfo struct {
 // operationBase, when non-empty, is removed from fallback command names derived
 // from paths. It does not affect explicit operationId or x-cli-name values.
 func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Operation, operationBase string) (*cobra.Command, error) {
-	// Derive command name from operationId, with x-cli-name override.
-	cmdName := toKebabCase(op.ID)
-	if cmdName == "" {
-		cmdName = fallbackOperationName(op.Method, operationNamePath(op.Path, operationBase))
-	}
-	if op.XCLI.Name != "" {
-		cmdName = op.XCLI.Name
-	}
+	cmdName := operationCommandName(op, operationBase)
 
 	// Build param lists, honouring per-parameter x-cli-name / x-cli-description.
 	pathParamOrder := extractPathParamNames(op.Path)
@@ -1969,14 +1962,15 @@ func fallbackOperationName(method, path string) string {
 func operationNamePath(path, operationBase string) string {
 	path = normalizeOperationNamePath(path)
 	base := normalizeOperationNamePath(operationBase)
-	if base == "" || base == "/" {
+	base = strings.TrimRight(base, "/")
+	if base == "" {
 		return path
 	}
 	if path == base {
 		return "/"
 	}
-	if strings.HasPrefix(path, strings.TrimRight(base, "/")+"/") {
-		return strings.TrimPrefix(path, strings.TrimRight(base, "/"))
+	if strings.HasPrefix(path, base+"/") {
+		return strings.TrimPrefix(path, base)
 	}
 	return path
 }

--- a/internal/cli/generated_internal_test.go
+++ b/internal/cli/generated_internal_test.go
@@ -67,7 +67,7 @@ func TestBuildOperationCommandDoesNotParseOptionalDefaultsAsFlagValues(t *testin
 		Parameters: []spec.Param{
 			{Name: "enabled", In: "query", Type: "boolean", Default: "definitely", HasDefault: true},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestBuildOperationCommandDisambiguatesOperatorFlagNames(t *testing.T) {
 			{Name: "StartTime=", In: "query", Type: "string"},
 			{Name: "StartTime!=", In: "query", Type: "string"},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestBuildOperationCommandDisambiguatesNonOperatorFlagNames(t *testing.T) {
 			{Name: "foo-bar", In: "query", Type: "string"},
 			{Name: "foo_bar", In: "query", Type: "string"},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestBuildOperationCommandDisambiguatesReservedFlagNames(t *testing.T) {
 			{Name: "help-all", In: "header", Type: "string"},
 			{Name: "rsh-generate-body", In: "cookie", Type: "string"},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}
@@ -203,12 +203,59 @@ func TestBuildOperationCommandDocumentsUndescribedPathArgument(t *testing.T) {
 		Parameters: []spec.Param{
 			{Name: "petId", In: "path", Type: "integer", Required: true},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}
 	if !strings.Contains(cmd.Long, "pet-id") || !strings.Contains(cmd.Long, "path parameter") {
 		t.Fatalf("Long help = %q, want path argument row", cmd.Long)
+	}
+}
+
+func TestBuildOperationCommandFallbackNameUsesOperationBase(t *testing.T) {
+	c := New()
+	cmd, err := c.buildOperationCommand("myapi", "", spec.Operation{
+		Method:     "GET",
+		Path:       "/api/rest/foo/{id}",
+		Parameters: []spec.Param{{Name: "id", In: "path", Type: "string", Required: true}},
+	}, "/api/rest")
+	if err != nil {
+		t.Fatalf("build operation command: %v", err)
+	}
+	if cmd.Name() != "get-foo-id" {
+		t.Fatalf("command name = %q, want get-foo-id", cmd.Name())
+	}
+
+	cmd, err = c.buildOperationCommand("myapi", "", spec.Operation{
+		ID:     "getApiRestFoo",
+		Method: "GET",
+		Path:   "/api/rest/foo",
+	}, "/api/rest")
+	if err != nil {
+		t.Fatalf("build operation command with operationId: %v", err)
+	}
+	if cmd.Name() != "get-api-rest-foo" {
+		t.Fatalf("operationId command name = %q, want get-api-rest-foo", cmd.Name())
+	}
+}
+
+func TestOperationNamePathOnlyStripsOperationBaseSegment(t *testing.T) {
+	tests := []struct {
+		path          string
+		operationBase string
+		want          string
+	}{
+		{path: "/api/rest/foo", operationBase: "/api/rest", want: "/foo"},
+		{path: "/api/rest", operationBase: "/api/rest", want: "/"},
+		{path: "/apiary/foo", operationBase: "/api", want: "/apiary/foo"},
+		{path: "/api/foo", operationBase: "/", want: "/api/foo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := operationNamePath(tc.path, tc.operationBase); got != tc.want {
+				t.Fatalf("operationNamePath(%q, %q) = %q, want %q", tc.path, tc.operationBase, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -263,7 +310,7 @@ func TestValidateGeneratedFlagValueTokensRejectsFlagLikeMissingValue(t *testing.
 			{Name: "federal", In: "query", Type: "string", Enum: []string{"true", "false"}},
 			{Name: "optional", In: "query", Type: "boolean"},
 		},
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("build operation command: %v", err)
 	}

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -4627,6 +4627,60 @@ func TestGeneratedCommandsResolveProfileOperationBaseAtExecutionTime(t *testing.
 	}
 }
 
+func TestGeneratedFallbackCommandNameUsesProfileOperationBase(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/api/rest/foo": {
+      "get": {
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, baseURL)
+	})
+	cfg, err := config.Load(env.cfgFile)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	baseURL := cfg.APIs["tapi"].BaseURL
+	cfg.APIs["tapi"].Profiles = map[string]*config.ProfileConfig{
+		"default": {},
+		"staging": {
+			BaseURL:       baseURL,
+			OperationBase: "/api/rest",
+		},
+	}
+	if err := config.Save(env.cfgFile, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	c := env.newCLI()
+	var out strings.Builder
+	c.Stdout = &out
+	if err := c.Run([]string{"restish", "--rsh-profile", "staging", "tapi", "get-foo", "--help"}); err != nil {
+		t.Fatalf("profile fallback command help failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "Usage:") {
+		t.Fatalf("expected generated command help, got:\n%s", out.String())
+	}
+
+	c = env.newCLI()
+	err = c.Run([]string{"restish", "--rsh-profile", "staging", "tapi", "get-api-rest-foo", "--help"})
+	if err == nil {
+		t.Fatal("expected unstripped fallback command name to be unavailable")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("unexpected unavailable command error: %v", err)
+	}
+}
+
 func TestGeneratedCommandsReloadLocalSpecFilesWhenChanged(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/widgets", func(w http.ResponseWriter, r *http.Request) {

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -62,6 +62,11 @@ Operation-level `x-cli-name` replaces the generated command name.
 `x-cli-aliases` adds command aliases. `x-cli-description` replaces the help
 summary/description shown for the generated command.
 
+When an operation has no `operationId`, Restish falls back to the HTTP method
+and path. If the API config has `operation_base`, that base path is removed from
+fallback names. For example, `operation_base: /api/rest` turns
+`GET /api/rest/foo` into `get-foo`.
+
 Parameters support their own command-shaping extensions:
 
 ```yaml


### PR DESCRIPTION
## Summary
- derives fallback generated command names from paths relative to the active `operation_base`
- keeps explicit `operationId` and `x-cli-name` behavior unchanged
- passes the operation base used for the active profile through generated command construction

Fixes #240

## Validation
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestGeneratedFallbackCommandNameUsesProfileOperationBase|TestBuildOperationCommandFallbackNameUsesOperationBase|TestOperationNamePathOnlyStripsOperationBaseSegment'\n- env GOCACHE=/tmp/restish-gocache go test ./internal/cli\n- env GOCACHE=/tmp/restish-gocache go test ./...\n- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...\n- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache\n- no-context sub-agent review with follow-up clean