### PR TITLE
feat: report OpenAPI x-cli extension effects

### DIFF
--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -169,6 +169,14 @@ The design requirements are:
 - response size limits before parsing
 - cancellation through the CLI context
 
+OpenAPI `x-cli-*` extensions are remote command-surface hints. They must not
+execute local code, but they can still rename, hide, or remove generated
+commands and parameters, and `x-cli-config` can pre-populate local API profile
+defaults during `api connect`. Restish therefore treats them as visible remote
+metadata rather than a separate trust prompt: `api connect` and `api sync`
+summarize behavior-changing `x-cli-*` extension classes, while `doctor api`
+reports the affected paths, operations, and parameters in more detail.
+
 These rules apply both to `Link`-header discovery and well-known-path probes.
 
 ## Sensitive Data Handling

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -267,6 +267,9 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 			c.warnf("could not cache generated commands for API %q: %v; run 'restish api sync %s' before using generated help", apiName, err, apiName)
 		}
 		style := humanTextStyleFor(c.Stdout)
+		if report, err := apiSpec.XCLIExtensionReport(); err == nil {
+			c.printXCLIExtensionSummary(report)
+		}
 		fmt.Fprintf(c.Stdout, "%s spec for %q.\n", style.ok("Synced"), apiName)
 	} else {
 		style := humanTextStyleFor(c.Stdout)
@@ -426,6 +429,11 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 	}
 	c.printConfigWrittenPath()
 	style := humanTextStyleFor(c.Stdout)
+	if apiSpec != nil {
+		if report, err := apiSpec.XCLIExtensionReport(); err == nil {
+			c.printXCLIExtensionSummary(report)
+		}
+	}
 	if len(preservedProfiles) > 0 {
 		fmt.Fprintf(c.Stdout, "%s existing profile(s): %s (%s)\n", style.info("Preserved"), strings.Join(preservedProfiles, ", "), style.hint("use --replace to recreate from discovered defaults"))
 	}

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -42,6 +42,44 @@ func specWithXCLIConfig(baseURL string) string {
 }`, baseURL)
 }
 
+func specWithXCLIVisibility(baseURL string) string {
+	return fmt.Sprintf(`{
+  "openapi": "3.1.0",
+  "info": {"title": "Visible XCLI API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "x-cli-config": {
+    "profiles": {
+      "default": {"headers": ["Accept: application/json"]}
+    }
+  },
+  "paths": {
+    "/hidden": {
+      "get": {
+        "operationId": "hiddenOp",
+        "x-cli-hidden": true,
+        "responses": {"200": {"description": "OK"}}
+      }
+    },
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "x-cli-name": "item",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string"},
+            "x-cli-name": "item-id"
+          }
+        ],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, baseURL)
+}
+
 // TestAPIConnect verifies that "api connect" fetches the spec, reads
 // x-cli-config, and writes a config file with the pre-populated fields.
 func TestAPIConnect(t *testing.T) {
@@ -84,6 +122,31 @@ func TestAPIConnect(t *testing.T) {
 	}
 	if len(prof.Headers) == 0 || !strings.Contains(prof.Headers[0], "application/json") {
 		t.Errorf("expected Accept header in default profile, got: %v", prof.Headers)
+	}
+}
+
+func TestAPIConnectPrintsXCLIExtensionSummary(t *testing.T) {
+	cfgFile := t.TempDir() + "/restish.json"
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	useOpenAPISpecTransport(c, specWithXCLIVisibility("https://api.example.com"))
+
+	if err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com"}); err != nil {
+		t.Fatalf("api connect: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"OpenAPI x-cli extensions:",
+		"x-cli-config",
+		"1 hidden operation",
+		"1 renamed operation",
+		"1 renamed parameter",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("api connect output missing %q:\n%s", want, got)
+		}
 	}
 }
 
@@ -3040,6 +3103,34 @@ func TestAPISyncReportsSuccess(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Synced") {
 		t.Errorf("expected Synced in output, got: %q", out.String())
+	}
+}
+
+func TestAPISyncPrintsXCLIExtensionSummary(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	cfgFile := c.Hooks().ConfigPath
+	cfgData := `{"apis":{"myapi":{"base_url":"https://api.example.com"}}}`
+	if err := os.WriteFile(cfgFile, []byte(cfgData), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c.Hooks().SpecCachePath = t.TempDir()
+	useOpenAPISpecTransport(c, specWithXCLIVisibility("https://api.example.com"))
+
+	if err := c.Run([]string{"restish", "api", "sync", "myapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"OpenAPI x-cli extensions:",
+		"x-cli-config",
+		"1 hidden operation",
+		"1 renamed operation",
+		"1 renamed parameter",
+		`Synced spec for "myapi".`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("api sync output missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -187,6 +187,7 @@ type doctorAPIReport struct {
 	SpecFiles           []string                        `json:"spec_files,omitempty"`
 	SpecCache           doctorStatusReport              `json:"spec_cache"`
 	GeneratedOperations doctorGeneratedOperationsReport `json:"generated_operations"`
+	OpenAPIXCLI         *spec.XCLIExtensionReport       `json:"openapi_x_cli_extensions,omitempty"`
 	Auth                doctorAuthReport                `json:"auth"`
 	Reachability        doctorReachabilityReport        `json:"reachability"`
 }
@@ -340,6 +341,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 		for _, issue := range operationSecurityIssues(opInfo.Set.Operations) {
 			fmt.Fprintf(out, "  %s: %s\n", style.error("Issue"), issue)
 		}
+		printXCLIExtensionDoctorDetails(out, style, opInfo.Set.XCLIExtensions)
 	} else {
 		fmt.Fprintf(out, "Generated operations: %s (%s)\n", style.warn("unavailable"), style.hint("run \"restish api sync "+name+"\""))
 	}
@@ -768,6 +770,9 @@ func (c *CLI) doctorAPIReport(cmd *cobra.Command, name string) doctorAPIReport {
 			Status: "available",
 			Count:  len(opInfo.Set.Operations),
 			Issues: operationSecurityIssues(opInfo.Set.Operations),
+		}
+		if !opInfo.Set.XCLIExtensions.Empty() {
+			report.OpenAPIXCLI = &opInfo.Set.XCLIExtensions
 		}
 		if opInfo.Cached {
 			report.GeneratedOperations.Stale = opInfo.CacheStatus.Stale

--- a/internal/cli/extensions_test.go
+++ b/internal/cli/extensions_test.go
@@ -390,3 +390,50 @@ func TestExtensionXCLIParamHiddenHidesFlagButAllowsUse(t *testing.T) {
 		t.Fatalf("query = %q, want debug=true", gotQuery)
 	}
 }
+
+func TestDoctorAPIReportsXCLIExtensionDetails(t *testing.T) {
+	env := setupExtEnv(t)
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "doctor", "api", "tapi"}); err != nil {
+		t.Fatalf("doctor api: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"OpenAPI x-cli extensions:",
+		"1 ignored operation",
+		"1 hidden operation",
+		"1 renamed operation",
+		"1 operation with aliases",
+		"2 renamed parameters",
+		"x-cli-name: GET /things",
+		"x-cli-hidden: GET /hidden",
+		"x-cli-ignore: GET /ignored",
+		"x-cli-name: GET /items/{id} parameter path id",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctor api output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "x-cli-description") {
+		t.Fatalf("doctor api should not report x-cli-description:\n%s", got)
+	}
+
+	cJSON, jsonOut := env.newCaptureCLI()
+	if err := cJSON.Run([]string{"restish", "doctor", "api", "tapi", "-o", "json"}); err != nil {
+		t.Fatalf("doctor api json: %v", err)
+	}
+	var report struct {
+		OpenAPIXCLI struct {
+			Details []struct {
+				Kind string `json:"kind"`
+			} `json:"details"`
+		} `json:"openapi_x_cli_extensions"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut.String()), &report); err != nil {
+		t.Fatalf("doctor api json should be JSON: %v\n%s", err, jsonOut.String())
+	}
+	if len(report.OpenAPIXCLI.Details) == 0 {
+		t.Fatalf("expected x-cli extension details in doctor JSON:\n%s", jsonOut.String())
+	}
+}

--- a/internal/cli/xcli_extensions.go
+++ b/internal/cli/xcli_extensions.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rest-sh/restish/v2/internal/spec"
+)
+
+func (c *CLI) printXCLIExtensionSummary(report spec.XCLIExtensionReport) {
+	summary := report.Summary()
+	if len(summary) == 0 {
+		return
+	}
+	style := humanTextStyleFor(c.Stdout)
+	fmt.Fprintf(c.Stdout, "%s x-cli extensions: %s\n", style.info("OpenAPI"), strings.Join(summary, ", "))
+}
+
+func printXCLIExtensionDoctorDetails(out io.Writer, style humanTextStyle, report spec.XCLIExtensionReport) {
+	summary := report.Summary()
+	if len(summary) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "OpenAPI x-cli extensions: %s\n", strings.Join(summary, ", "))
+	for _, detail := range report.Details {
+		fmt.Fprintf(out, "  %s %s: %s", style.key(detail.Extension+":"), detail.Location, detail.Effect)
+		if detail.Value != "" {
+			fmt.Fprintf(out, " (%s)", detail.Value)
+		}
+		if detail.Name != "" {
+			fmt.Fprintf(out, " [%s]", detail.Name)
+		}
+		fmt.Fprintln(out)
+	}
+}

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -49,17 +49,18 @@ type cachedRaw struct {
 }
 
 type opsBlob struct {
-	Schema             int         `cbor:"schema"`
-	BaseURL            string      `cbor:"base_url"`
-	OperationBase      string      `cbor:"operation_base,omitempty"`
-	ServerVariablesKey string      `cbor:"server_variables,omitempty"`
-	RawSHA256          string      `cbor:"raw_sha256"`
-	Info               APIInfo     `cbor:"info,omitempty"`
-	Operations         []Operation `cbor:"operations"`
+	Schema             int                 `cbor:"schema"`
+	BaseURL            string              `cbor:"base_url"`
+	OperationBase      string              `cbor:"operation_base,omitempty"`
+	ServerVariablesKey string              `cbor:"server_variables,omitempty"`
+	RawSHA256          string              `cbor:"raw_sha256"`
+	Info               APIInfo             `cbor:"info,omitempty"`
+	Operations         []Operation         `cbor:"operations"`
+	XCLIExtensions     XCLIExtensionReport `cbor:"x_cli_extensions,omitempty"`
 }
 
 const currentCacheSchema = 2
-const currentOperationCacheSchema = 10
+const currentOperationCacheSchema = 11
 
 // OperationCacheStatus describes the freshness of cached operation metadata.
 type OperationCacheStatus struct {
@@ -242,8 +243,9 @@ func LoadOperationSetFromCacheStatus(cacheDir, apiName, version string, specFile
 			blob.ServerVariablesKey == ServerVariablesCacheKey(opts.ServerVariables) &&
 			blob.RawSHA256 == rawHash {
 			set := OperationSet{
-				Info:       blob.Info,
-				Operations: append([]Operation(nil), blob.Operations...),
+				Info:           blob.Info,
+				Operations:     append([]Operation(nil), blob.Operations...),
+				XCLIExtensions: blob.XCLIExtensions,
 			}
 			if blob.Operations == nil {
 				set.Operations = []Operation{}
@@ -310,6 +312,7 @@ func (e *cacheEntry) upsertOperationSet(opts OperationOptions, set OperationSet)
 		RawSHA256:          rawHash,
 		Info:               set.Info,
 		Operations:         append([]Operation(nil), set.Operations...),
+		XCLIExtensions:     set.XCLIExtensions,
 	}
 	for i := range e.Operations {
 		if e.Operations[i].BaseURL == opts.BaseURL &&

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -161,9 +161,10 @@ type Operation struct {
 // OperationSet is the extracted operation list plus API-level metadata needed
 // to present the generated command group without reparsing the raw spec.
 type OperationSet struct {
-	Info       APIInfo
-	Operations []Operation
-	Warnings   []string
+	Info           APIInfo
+	Operations     []Operation
+	Warnings       []string
+	XCLIExtensions XCLIExtensionReport
 }
 
 // OperationSet returns all operations with top-level API metadata. The result
@@ -178,7 +179,11 @@ func (s *APISpec) OperationSet(opts OperationOptions) (OperationSet, error) {
 	if err != nil {
 		return OperationSet{}, err
 	}
-	return OperationSet{Info: info, Operations: ops, Warnings: warnings}, nil
+	xcliExtensions, err := s.XCLIExtensionReport()
+	if err != nil {
+		return OperationSet{}, err
+	}
+	return OperationSet{Info: info, Operations: ops, Warnings: warnings, XCLIExtensions: xcliExtensions}, nil
 }
 
 // Operations returns all HTTP operations extracted from the spec's V3 model,

--- a/internal/spec/xcli_extensions.go
+++ b/internal/spec/xcli_extensions.go
@@ -1,0 +1,179 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+)
+
+// XCLIExtensionReport describes behavior-changing x-cli-* OpenAPI extensions
+// found in a document. It intentionally excludes x-cli-description, which only
+// changes help prose.
+type XCLIExtensionReport struct {
+	Details []XCLIExtensionDetail `json:"details,omitempty" cbor:"details,omitempty"`
+}
+
+// XCLIExtensionDetail is one behavior-changing x-cli-* extension use.
+type XCLIExtensionDetail struct {
+	Kind      string `json:"kind" cbor:"kind"`
+	Extension string `json:"extension" cbor:"extension"`
+	Location  string `json:"location" cbor:"location"`
+	Name      string `json:"name,omitempty" cbor:"name,omitempty"`
+	Value     string `json:"value,omitempty" cbor:"value,omitempty"`
+	Effect    string `json:"effect" cbor:"effect"`
+}
+
+// Empty reports whether the document had any behavior-changing x-cli-* uses.
+func (r XCLIExtensionReport) Empty() bool {
+	return len(r.Details) == 0
+}
+
+// Summary returns stable, compact phrases for human connect/sync output.
+func (r XCLIExtensionReport) Summary() []string {
+	if len(r.Details) == 0 {
+		return nil
+	}
+	counts := map[string]int{}
+	for _, detail := range r.Details {
+		counts[detail.Kind]++
+	}
+	var summary []string
+	for _, item := range xcliExtensionSummaryOrder {
+		count := counts[item.kind]
+		if count == 0 {
+			continue
+		}
+		if item.noCount {
+			summary = append(summary, item.singular)
+			continue
+		}
+		summary = append(summary, fmt.Sprintf("%d %s", count, pluralize(count, item.singular, item.plural)))
+	}
+	return summary
+}
+
+// XCLIExtensionReport extracts behavior-changing x-cli-* extension uses from
+// the parsed OpenAPI document before generated command filtering is applied.
+func (s *APISpec) XCLIExtensionReport() (XCLIExtensionReport, error) {
+	var report xcliExtensionReportBuilder
+	if xcli, err := ReadXCLIConfig(s); err == nil && xcli != nil {
+		report.add("config", "x-cli-config", "document", "", "", "pre-populates API config profiles")
+	}
+	model, err := s.V3Model()
+	if err != nil || model == nil || model.Model.Paths == nil {
+		return XCLIExtensionReport{Details: report.details()}, err
+	}
+	for rawPath, pathItem := range model.Model.Paths.PathItems.FromOldest() {
+		if pathItem == nil {
+			continue
+		}
+		if PathItemExtBool(pathItem, "x-cli-ignore") {
+			report.add("path_ignored", "x-cli-ignore", rawPath, "", "true", "removes operations under this path from generated commands")
+			continue
+		}
+		if PathItemExtBool(pathItem, "x-cli-hidden") {
+			report.add("path_hidden", "x-cli-hidden", rawPath, "", "true", "hides operations under this path from generated help")
+		}
+		for _, methodOp := range PathItemMethods(pathItem) {
+			if methodOp.Op == nil {
+				continue
+			}
+			report.addOperationDetails(methodOp.Method, rawPath, pathItem.Parameters, methodOp.Op)
+		}
+	}
+	return XCLIExtensionReport{Details: report.details()}, nil
+}
+
+type xcliExtensionReportBuilder struct {
+	d []XCLIExtensionDetail
+}
+
+func (b *xcliExtensionReportBuilder) add(kind, extension, location, name, value, effect string) {
+	b.d = append(b.d, XCLIExtensionDetail{
+		Kind:      kind,
+		Extension: extension,
+		Location:  location,
+		Name:      name,
+		Value:     value,
+		Effect:    effect,
+	})
+}
+
+func (b *xcliExtensionReportBuilder) addOperationDetails(method, rawPath string, pathParams []*v3.Parameter, op *v3.Operation) {
+	location := method + " " + rawPath
+	name := op.OperationId
+	if OpExtBool(op, "x-cli-ignore") {
+		b.add("operation_ignored", "x-cli-ignore", location, name, "true", "removes this operation from generated commands")
+	}
+	if OpExtBool(op, "x-cli-hidden") {
+		b.add("operation_hidden", "x-cli-hidden", location, name, "true", "hides this operation from generated help")
+	}
+	if value := OpExtString(op, "x-cli-name"); value != "" {
+		b.add("operation_renamed", "x-cli-name", location, name, value, "renames the generated command")
+	}
+	if aliases := OpExtStrings(op, "x-cli-aliases"); len(aliases) > 0 {
+		b.add("operation_aliases", "x-cli-aliases", location, name, strings.Join(aliases, ", "), "adds generated command aliases")
+	}
+	for _, param := range MergeParameters(pathParams, op.Parameters) {
+		if param == nil {
+			continue
+		}
+		paramLocation := fmt.Sprintf("%s parameter %s %s", location, param.In, param.Name)
+		paramName := param.In + " " + param.Name
+		if ParamExtBool(param, "x-cli-ignore") {
+			b.add("parameter_ignored", "x-cli-ignore", paramLocation, paramName, "true", "removes this parameter from the generated command")
+		}
+		if ParamExtBool(param, "x-cli-hidden") {
+			b.add("parameter_hidden", "x-cli-hidden", paramLocation, paramName, "true", "hides this parameter from generated help")
+		}
+		if value := ParamExtString(param, "x-cli-name"); value != "" {
+			b.add("parameter_renamed", "x-cli-name", paramLocation, paramName, value, "renames the generated argument or flag")
+		}
+	}
+}
+
+func (b *xcliExtensionReportBuilder) details() []XCLIExtensionDetail {
+	out := append([]XCLIExtensionDetail(nil), b.d...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Location != out[j].Location {
+			return out[i].Location < out[j].Location
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Extension < out[j].Extension
+	})
+	return out
+}
+
+type xcliExtensionSummaryItem struct {
+	kind     string
+	singular string
+	plural   string
+	noCount  bool
+}
+
+var xcliExtensionSummaryOrder = []xcliExtensionSummaryItem{
+	{kind: "config", singular: "x-cli-config", noCount: true},
+	{kind: "path_ignored", singular: "ignored path", plural: "ignored paths"},
+	{kind: "path_hidden", singular: "hidden path", plural: "hidden paths"},
+	{kind: "operation_ignored", singular: "ignored operation", plural: "ignored operations"},
+	{kind: "operation_hidden", singular: "hidden operation", plural: "hidden operations"},
+	{kind: "operation_renamed", singular: "renamed operation", plural: "renamed operations"},
+	{kind: "operation_aliases", singular: "operation with aliases", plural: "operations with aliases"},
+	{kind: "parameter_ignored", singular: "ignored parameter", plural: "ignored parameters"},
+	{kind: "parameter_hidden", singular: "hidden parameter", plural: "hidden parameters"},
+	{kind: "parameter_renamed", singular: "renamed parameter", plural: "renamed parameters"},
+}
+
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/spec/xcli_extensions.go
+++ b/internal/spec/xcli_extensions.go
@@ -106,6 +106,7 @@ func (b *xcliExtensionReportBuilder) addOperationDetails(method, rawPath string,
 	name := op.OperationId
 	if OpExtBool(op, "x-cli-ignore") {
 		b.add("operation_ignored", "x-cli-ignore", location, name, "true", "removes this operation from generated commands")
+		return
 	}
 	if OpExtBool(op, "x-cli-hidden") {
 		b.add("operation_hidden", "x-cli-hidden", location, name, "true", "hides this operation from generated help")
@@ -124,6 +125,7 @@ func (b *xcliExtensionReportBuilder) addOperationDetails(method, rawPath string,
 		paramName := param.In + " " + param.Name
 		if ParamExtBool(param, "x-cli-ignore") {
 			b.add("parameter_ignored", "x-cli-ignore", paramLocation, paramName, "true", "removes this parameter from the generated command")
+			continue
 		}
 		if ParamExtBool(param, "x-cli-hidden") {
 			b.add("parameter_hidden", "x-cli-hidden", paramLocation, paramName, "true", "hides this parameter from generated help")

--- a/internal/spec/xcli_extensions_test.go
+++ b/internal/spec/xcli_extensions_test.go
@@ -1,0 +1,158 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestXCLIExtensionReportFindsBehaviorChangingExtensions(t *testing.T) {
+	raw := []byte(`openapi: 3.1.0
+info:
+  title: XCLI API
+  version: "1.0"
+x-cli-config:
+  profiles:
+    default:
+      headers: ["Accept: application/json"]
+paths:
+  /admin:
+    x-cli-hidden: true
+    get:
+      operationId: listAdmin
+      responses:
+        "200": {}
+  /hidden:
+    get:
+      operationId: hiddenOp
+      x-cli-hidden: true
+      responses:
+        "200": {}
+  /ignored:
+    get:
+      operationId: ignoredOp
+      x-cli-ignore: true
+      responses:
+        "200": {}
+  /items/{id}:
+    get:
+      operationId: getItem
+      x-cli-name: item
+      x-cli-aliases: [it]
+      x-cli-description: harmless help text
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          x-cli-name: item-id
+        - name: debug
+          in: query
+          schema:
+            type: string
+          x-cli-hidden: true
+        - name: internal
+          in: query
+          schema:
+            type: string
+          x-cli-ignore: true
+      responses:
+        "200": {}`)
+	loaded, err := (OpenAPILoader{}).Load(raw)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	report, err := loaded.XCLIExtensionReport()
+	if err != nil {
+		t.Fatalf("XCLIExtensionReport: %v", err)
+	}
+	gotSummary := strings.Join(report.Summary(), ", ")
+	for _, want := range []string{
+		"x-cli-config",
+		"1 hidden path",
+		"1 ignored operation",
+		"1 hidden operation",
+		"1 renamed operation",
+		"1 operation with aliases",
+		"1 ignored parameter",
+		"1 hidden parameter",
+		"1 renamed parameter",
+	} {
+		if !strings.Contains(gotSummary, want) {
+			t.Fatalf("summary %q missing %q", gotSummary, want)
+		}
+	}
+	if strings.Contains(gotSummary, "description") {
+		t.Fatalf("x-cli-description should not be summarized: %q", gotSummary)
+	}
+	wantKinds := map[string]bool{
+		"config":            false,
+		"path_hidden":       false,
+		"operation_ignored": false,
+		"operation_hidden":  false,
+		"operation_renamed": false,
+		"operation_aliases": false,
+		"parameter_ignored": false,
+		"parameter_hidden":  false,
+		"parameter_renamed": false,
+	}
+	for _, detail := range report.Details {
+		if _, ok := wantKinds[detail.Kind]; ok {
+			wantKinds[detail.Kind] = true
+		}
+		if detail.Extension == "x-cli-description" {
+			t.Fatalf("x-cli-description should be omitted from details: %#v", detail)
+		}
+	}
+	for kind, seen := range wantKinds {
+		if !seen {
+			t.Fatalf("missing detail kind %q in %#v", kind, report.Details)
+		}
+	}
+}
+
+func TestXCLIExtensionReportStopsAtIgnoredPath(t *testing.T) {
+	raw := []byte(`openapi: 3.1.0
+info:
+  title: XCLI API
+  version: "1.0"
+paths:
+  /ignored:
+    x-cli-ignore: true
+    get:
+      operationId: ignoredOp
+      x-cli-name: renamed-ignored
+      parameters:
+        - name: hidden
+          in: query
+          schema:
+            type: string
+          x-cli-hidden: true
+      responses:
+        "200": {}
+  /visible:
+    get:
+      operationId: visibleOp
+      x-cli-name: visible
+      responses:
+        "200": {}`)
+	loaded, err := (OpenAPILoader{}).Load(raw)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	report, err := loaded.XCLIExtensionReport()
+	if err != nil {
+		t.Fatalf("XCLIExtensionReport: %v", err)
+	}
+	gotSummary := strings.Join(report.Summary(), ", ")
+	for _, want := range []string{"1 ignored path", "1 renamed operation"} {
+		if !strings.Contains(gotSummary, want) {
+			t.Fatalf("summary %q missing %q", gotSummary, want)
+		}
+	}
+	for _, detail := range report.Details {
+		if detail.Location == "GET /ignored" || strings.Contains(detail.Location, "GET /ignored parameter") {
+			t.Fatalf("ignored path should not report nested extension detail: %#v", detail)
+		}
+	}
+}

--- a/internal/spec/xcli_extensions_test.go
+++ b/internal/spec/xcli_extensions_test.go
@@ -31,6 +31,9 @@ paths:
     get:
       operationId: ignoredOp
       x-cli-ignore: true
+      x-cli-hidden: true
+      x-cli-name: renamed-ignored
+      x-cli-aliases: [ig]
       responses:
         "200": {}
   /items/{id}:
@@ -56,6 +59,8 @@ paths:
           schema:
             type: string
           x-cli-ignore: true
+          x-cli-hidden: true
+          x-cli-name: ignored-internal
       responses:
         "200": {}`)
 	loaded, err := (OpenAPILoader{}).Load(raw)

--- a/site/content/en/docs/guides/api-setup-and-discovery.md
+++ b/site/content/en/docs/guides/api-setup-and-discovery.md
@@ -27,6 +27,10 @@ Cross-origin discovery still rejects private, loopback, link-local, multicast,
 and unspecified follow targets unless the original API is already private or
 local. Use `--spec` when you need to name a private spec URL directly.
 
+If the spec contains behavior-changing `x-cli-*` extensions, `api connect`
+prints a compact summary. Run `restish doctor api <name>` after connecting when
+you want to see the exact operations or parameters affected.
+
 ## Configure With An Explicit Spec
 
 ```bash
@@ -93,6 +97,8 @@ OpenAPI extensions that shape the CLI. Sync can also save spec-derived API
 metadata that changed after registration, such as a Link-discovered `spec_url`
 or newly discovered operation-server origins. It does not overwrite profiles or
 apply new `x-cli-config` profile defaults, so local credentials remain intact.
+When the refreshed spec contains behavior-changing `x-cli-*` extensions, sync
+prints the same compact summary as connect.
 
 Use `--yes` when an automated sync should accept safe metadata prompts such as
 allowing a newly discovered cross-origin operation server:

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -99,6 +99,24 @@ Hidden operations remain callable by exact name when supported. Ignored
 operations are left out of the generated command surface. `x-mcp-ignore`
 excludes an operation from MCP tool exposure.
 
+## Inspect Extension Effects
+
+When `api connect` or `api sync` sees behavior-changing `x-cli-*` extensions,
+Restish prints a compact summary such as renamed operations, aliases,
+hidden/ignored operations, hidden/ignored parameters, and `x-cli-config`.
+This is informational only; Restish does not block connection or prompt for
+extension approval.
+
+For a detailed view after connecting, run:
+
+```bash
+restish doctor api myapi
+```
+
+The doctor report lists where behavior-changing `x-cli-*` extensions appear
+and what each one changes. Plain `x-cli-description` help text overrides are
+not reported because they do not change which commands or inputs are available.
+
 ## Query Parameter Serialization
 
 Restish maps required parameters to positional arguments and optional


### PR DESCRIPTION
## Summary
- add an informational x-cli extension report for behavior-changing OpenAPI extensions
- show compact summaries during api connect/api sync and detailed entries in doctor api JSON/text output
- document the visibility behavior and trust-boundary decision

Supersedes and credits the original draft direction in #317.

## Tests
- env GOCACHE=/tmp/restish-gocache go test ./internal/spec ./internal/cli -run 'TestXCLIExtensionReportFindsBehaviorChangingExtensions|TestXCLIExtensionReportStopsAtIgnoredPath|TestAPIConnectPrintsXCLIExtensionSummary|TestAPISyncPrintsXCLIExtensionSummary|TestDoctorAPIReportsXCLIExtensionDetails'
- env GOCACHE=/tmp/restish-gocache go test ./internal/spec ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./...
- env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...
- env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check
- hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache