### PR TITLE
feat(config): add trusted project config discovery

### DIFF
--- a/docs/design/002-config-and-profiles.md
+++ b/docs/design/002-config-and-profiles.md
@@ -101,6 +101,14 @@ config and refuse to mutate APIs that came from trusted project config. Passing
 is the complete config source of truth and sidecar state follows that explicit
 config root.
 
+Auto-discovered project config is intended to be a committed, shareable project
+manifest. It may use normal repository file permissions, but it must not contain
+inline secret material. Secret-bearing auth params such as API key values,
+bearer tokens, HTTP Basic passwords, and OAuth client secrets must be omitted or
+use `env:NAME` references. Non-secret OAuth parameters such as `client_id`,
+`audience`, `resource`, `organization`, issuer URLs, token URLs, and scopes are
+valid project config.
+
 Sidecar state that belongs to the selected config trust root, such as OAuth
 token caches and external-tool approval records, lives next to the explicit
 config file. Response and spec caches remain under the cache root, but explicit
@@ -108,7 +116,7 @@ configs get a cache namespace derived from the config path so two project
 configs do not reuse each other's cached HTTP responses or discovered specs.
 In discovered layered mode, response cache, spec cache, and API-scoped OAuth
 tokens for project APIs use a project namespace derived from the canonical
-project config path and content hash. Credentials and caches stay in the user's
+project config path and content hash. Tokens and caches stay in the user's
 Restish state/cache roots, never in the repository.
 
 Cache directory selection mirrors config selection with `RSH_CACHE_DIR`,

--- a/docs/design/002-config-and-profiles.md
+++ b/docs/design/002-config-and-profiles.md
@@ -81,17 +81,35 @@ explicit config file is an error so operators do not accidentally run with the
 global default after mistyping a project path. The ordinary platform-default
 config path keeps the v1 migration and auto-create behavior described below.
 
-Restish v2 does not search the current working directory or parent directories
-for project config. Project-local configuration is selected explicitly with
-`--rsh-config` or `RSH_CONFIG`. That keeps repository checkout state from
-silently changing request behavior; an implicit project-discovery mode can be
-designed later if a real workflow needs it.
+When neither explicit config selector is present, Restish also walks from the
+current directory toward the filesystem root looking for `.restish.json`.
+Discovered project config is ignored until the user trusts that exact file
+content with `restish config trust` or an interactive first-run prompt. Trust is
+stored outside the repository in the user's Restish config directory and is keyed
+by canonical project config path plus SHA-256 content hash, so a repository
+cannot trust itself and changed project config requires renewed trust.
+
+Trusted project config is layered over the global config, not written back into
+it. Global APIs and auth profiles remain available. Project APIs override global
+APIs with the same name at the API-entry boundary; individual API entries are
+not deep-merged. The first version accepts only project `apis` and `theme`.
+Project theme entries overlay the global theme so teams can make environment
+context visible, while `auth_profiles`, `plugins`, `cache`, and `theme_source`
+remain global-only. Normal config mutation commands still write the global
+config and refuse to mutate APIs that came from trusted project config. Passing
+`--rsh-config .restish.json` keeps explicit-config semantics: the selected file
+is the complete config source of truth and sidecar state follows that explicit
+config root.
 
 Sidecar state that belongs to the selected config trust root, such as OAuth
 token caches and external-tool approval records, lives next to the explicit
 config file. Response and spec caches remain under the cache root, but explicit
 configs get a cache namespace derived from the config path so two project
 configs do not reuse each other's cached HTTP responses or discovered specs.
+In discovered layered mode, response cache, spec cache, and API-scoped OAuth
+tokens for project APIs use a project namespace derived from the canonical
+project config path and content hash. Credentials and caches stay in the user's
+Restish state/cache roots, never in the repository.
 
 Cache directory selection mirrors config selection with `RSH_CACHE_DIR`,
 `XDG_CACHE_HOME/restish`, `~/.cache/restish` on Unix-like systems, and the

--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -117,21 +117,25 @@ validated. Examples:
 - response middleware can request specific follow-up actions, not arbitrary host
   behavior
 
-### Explicit Config Roots
+### Project Config Trust
 
-Restish does not implicitly discover project config files from the current
-working directory in v2. Project config is selected with `--rsh-config` or
-`RSH_CONFIG`, and that selected file is the entire config source of truth rather
-than an overlay on top of the operator's global config.
+Restish discovers `.restish.json` from the current working directory or a parent
+only when the user has not selected an explicit config with `--rsh-config` or
+`RSH_CONFIG`. Discovered project config is not executed or layered until trust is
+established. Interactive users can accept the first-run prompt; non-interactive
+scripts must run `restish config trust` first or choose the file explicitly.
 
-This avoids surprise trust transfer from a checked-out repository into normal
-requests. It also makes command review easier: the config trust root is visible
-in the command line or environment, and missing explicit files fail instead of
-falling back to the platform default.
+Trust is stored in user Restish state outside the repository and records the
+canonical config path plus content hash. If the file changes, Restish ignores it
+again until the user reviews and trusts the new content. This avoids surprise
+trust transfer from a checked-out repository into normal requests.
 
-This is a deliberate v2 boundary, not a claim that project config discovery is
-never useful. A future design may add an explicit opt-in mode for repository
-config, but v2 should not infer it from the local directory.
+The initial layered project-config surface is intentionally narrow: `apis` and
+`theme` only. Global config remains the source for shared auth profiles,
+plugins, cache settings, and writes. Project APIs are read-only through normal
+mutation commands, and API-scoped caches/tokens use a project namespace outside
+the repository. Explicit config selection still means the selected file is the
+entire config source of truth.
 
 ### Least Necessary Exposure
 

--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -137,6 +137,14 @@ mutation commands, and API-scoped caches/tokens use a project namespace outside
 the repository. Explicit config selection still means the selected file is the
 entire config source of truth.
 
+Project config is allowed to be a normal committed repository file, so Unix
+mode bits are not used as the safety boundary for `.restish.json`. The safety
+boundary is content validation plus explicit trust: project config must not
+contain inline secret values or executable secret sources. Secret-bearing auth
+params must be omitted or written as `env:NAME` references, while non-secret
+OAuth params such as `client_id`, `audience`, issuer URLs, token URLs, and
+scopes remain valid shared project setup.
+
 ### Least Necessary Exposure
 
 Restish should only expose sensitive data where it is required:

--- a/docs/design/031-compatibility-and-migration.md
+++ b/docs/design/031-compatibility-and-migration.md
@@ -131,10 +131,13 @@ with a setup error instead of creating relative config state in the current
 working directory. Cache-only state can use a temporary fallback, but persistent
 configuration cannot.
 
-V2 also does not discover project config by walking the current directory or
-parent directories. Users who want project-local config should pass
-`--rsh-config ./restish.json` or set `RSH_CONFIG`; implicit repository config
-discovery can be considered after v2 if the workflow proves valuable.
+V1-to-v2 migration does not use project config discovery. Migration reads and
+writes only the selected/global user config root so a checked-out repository
+cannot affect one-time migration behavior. Normal v2 config loading may discover
+trusted `.restish.json` project overlays after migration, as described in the
+config and security design records. Users who want a project file to be the
+complete config source of truth can still pass `--rsh-config .restish.json` or
+set `RSH_CONFIG`.
 
 ### API Registrations
 

--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -60,8 +60,32 @@ and `%APPDATA%\restish\restish.json` on Windows.
 merge them with the default config. Token and external-tool approval sidecars
 live next to the selected explicit config. HTTP response and spec caches stay
 under the cache root, with a namespace derived from the explicit config path.
-Restish v2 does not search the current directory or ancestors for project
-config files; project-local config is explicit only.
+When no explicit config file is selected, Restish may discover `.restish.json`
+from the current directory or an ancestor. A discovered project config is used
+only after trust is recorded with `restish config trust` or an interactive TTY
+prompt. Trust is stored outside the repository in user Restish state and is
+keyed by canonical project config path plus content hash, so a changed project
+config must be trusted again.
+
+Trusted project config is layered over the selected/global config for reads. The
+first project layer honors only `apis` and `theme`: project APIs shadow global
+APIs by name without deep-merging individual API definitions, and project theme
+entries override global theme entries by key. Other top-level keys such as
+`auth_profiles`, `plugins`, `cache`, and `theme_source` are invalid in
+auto-discovered project config and produce a clear diagnostic when the project
+config is otherwise trusted. Project config may use normal repository file
+permissions, but it must not contain inline secret values; secret-bearing auth
+params must be omitted or use `env:NAME` references. Non-interactive runs do not
+prompt for trust; when they discover an untrusted project config, they continue
+with the selected/global config and print a concise stderr warning naming the
+file and `restish config trust`. Auto-discovered project config is read-only for
+normal mutation commands; writes continue to target the selected/global config
+unless `--rsh-config` or `RSH_CONFIG` explicitly selects the project file.
+
+Project-local machine state is not written into the repository. OAuth/token
+caches, HTTP response caches, and spec/generated-command caches for trusted
+project APIs live in user Restish state/cache roots under a namespace derived
+from the trusted project config path and content hash.
 
 Windows ACL inspection is not implemented for the first v2 release. Existing
 config and token-cache files on Windows therefore report permission diagnostics

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -474,6 +474,10 @@ func (c *CLI) configureAllowedOperationOrigins(cmd *cobra.Command, apiName strin
 	if len(suggestions) == 0 {
 		return nil
 	}
+	if c.projectAPI(apiName) {
+		c.warnf("cross-origin operation servers ignored for read-only project API %q: %s; edit %s and add allowed_operation_origins[]: %s, or run with --rsh-config %s to make it the selected config", apiName, strings.Join(origins, ", "), c.projectConfig.Path, suggestions[0], c.projectConfig.Path)
+		return nil
+	}
 	if yes {
 		apiCfg.AllowedOperationOrigins = append(apiCfg.AllowedOperationOrigins, suggestions...)
 		return nil

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -165,7 +165,7 @@ func (c *CLI) runAPIAuthLogout(cmd *cobra.Command, args []string) error {
 	allProfiles, _ := cmd.Flags().GetBool("all-profiles")
 
 	if allProfiles {
-		if err := tc.DeletePrefix(apiName + ":"); err != nil {
+		if err := tc.DeletePrefix(c.apiStateName(apiName) + ":"); err != nil {
 			return fmt.Errorf("auth logout: %w", err)
 		}
 		for _, prof := range apiCfg.Profiles {
@@ -182,7 +182,7 @@ func (c *CLI) runAPIAuthLogout(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(c.Stdout, "Cleared auth cache for %q (all profiles)\n", apiName)
 		return nil
 	}
-	key := apiName + ":" + profileName
+	key := c.apiCacheNamespace(apiName, profileName)
 	if err := tc.Delete(key); err != nil {
 		return fmt.Errorf("auth logout: %w", err)
 	}
@@ -221,7 +221,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 		defer closer.Close()
 	}
 	discCfg := spec.DiscoverConfig{
-		APIName:          apiName,
+		APIName:          c.apiStateName(apiName),
 		BaseURL:          effectiveProfileBaseURL(apiCfg, profileName),
 		SpecURL:          apiCfg.SpecURL,
 		SpecFiles:        apiCfg.SpecFiles,
@@ -250,7 +250,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 		if err := c.configureAllowedOperationOrigins(cmd, apiName, syncedCfg, apiSpec, profileName, yes); err != nil {
 			return err
 		}
-		if !reflect.DeepEqual(apiCfg, syncedCfg) {
+		if !reflect.DeepEqual(apiCfg, syncedCfg) && !c.projectAPI(apiName) {
 			if err := c.saveAPIConfig("api sync", apiName, c.cfg, syncedCfg); err != nil {
 				return err
 			}
@@ -263,7 +263,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 			OperationBase:   effectiveOperationBase(apiCfg, profileName),
 			ServerVariables: effectiveServerVariables(apiCfg, profileName),
 		}
-		if err := spec.StoreSpecInCache(c.specCacheDir(), apiName, Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
+		if err := spec.StoreSpecInCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
 			c.warnf("could not cache generated commands for API %q: %v; run 'restish api sync %s' before using generated help", apiName, err, apiName)
 		}
 		style := humanTextStyleFor(c.Stdout)
@@ -420,7 +420,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 			OperationBase:   effectiveOperationBase(apiCfg, "default"),
 			ServerVariables: effectiveServerVariables(apiCfg, "default"),
 		}
-		if err := spec.StoreSpecInCache(c.specCacheDir(), apiName, Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
+		if err := spec.StoreSpecInCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
 			c.warnf("could not cache generated commands for API %q: %v; run 'restish api sync %s' before using generated help", apiName, err, apiName)
 		}
 	}
@@ -1451,6 +1451,9 @@ func (c *CLI) apiListOperationCount(apiName string, apiCfg *config.APIConfig) in
 // runAPIRemove removes a configured API and saves the updated config.
 func (c *CLI) runAPIRemove(cmd *cobra.Command, args []string) error {
 	apiName := args[0]
+	if err := c.ensureMutableAPI(apiName); err != nil {
+		return err
+	}
 	apiCfg, err := c.requireAPI(apiName)
 	if err != nil {
 		return err
@@ -1478,12 +1481,13 @@ func (c *CLI) removeAPILocalState(apiName string, sharedAuthRefs []string) error
 	if err != nil {
 		return fmt.Errorf("api remove: clear HTTP cache: %w", err)
 	}
-	if _, err := dc.ClearNamespacePrefix(apiName + ":"); err != nil {
+	namespace := c.apiStateName(apiName)
+	if _, err := dc.ClearNamespacePrefix(namespace + ":"); err != nil {
 		return fmt.Errorf("api remove: clear HTTP cache for %q: %w", apiName, err)
 	}
 
 	tc := auth.NewTokenCache(c.tokenCachePath())
-	if err := tc.DeletePrefix(apiName + ":"); err != nil {
+	if err := tc.DeletePrefix(namespace + ":"); err != nil {
 		return fmt.Errorf("api remove: clear auth cache for %q: %w", apiName, err)
 	}
 	for _, ref := range sharedAuthRefs {

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -760,12 +760,13 @@ func (c *CLI) cachedOperationSetStatusForAPI(apiName string, apiCfg *config.APIC
 		ServerVariables: effectiveServerVariables(apiCfg, profileName),
 		Warnf:           c.warnf,
 	}
-	if set, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opts, true); ok {
+	stateName := c.apiStateName(apiName)
+	if set, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, true); ok {
 		return set, status, true
 	}
 	opts.BaseURL = apiCfg.BaseURL
 	opts.OperationBase = apiCfg.OperationBase
-	return spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opts, true)
+	return spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, true)
 }
 
 func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName string, forceRefresh bool) (spec.OperationSet, bool, error) {
@@ -779,7 +780,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 		Warnf:           c.warnf,
 	}
 	if !forceRefresh {
-		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opts, true); ok {
+		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), c.apiStateName(apiName), Version, apiCfg.SpecFiles, opts, true); ok {
 			c.warnOperationSetWarnings(set)
 			return set, true, nil
 		}
@@ -789,14 +790,14 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	if forceRefresh {
 		s, err = c.discoverSpecForProfile(ctx, apiName, profileName, true, 0)
 	} else {
-		s, err = spec.LoadFromCache(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, c.loaders)
+		s, err = spec.LoadFromCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiCfg.SpecFiles, c.loaders)
 	}
 	if err != nil || s == nil {
 		if !spec.HasLocalSpecFiles(apiCfg.SpecFiles) {
 			return spec.OperationSet{}, false, err
 		}
 		s, err = spec.Discover(ctx, spec.DiscoverConfig{
-			APIName:         apiName,
+			APIName:         c.apiStateName(apiName),
 			BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
 			SpecFiles:       apiCfg.SpecFiles,
 			CacheDir:        c.specCacheDir(),
@@ -813,7 +814,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	if err != nil {
 		return spec.OperationSet{}, false, err
 	}
-	_ = spec.StoreOperationSetInCache(c.specCacheDir(), apiName, Version, opts, set)
+	_ = spec.StoreOperationSetInCache(c.specCacheDir(), c.apiStateName(apiName), Version, opts, set)
 	return set, true, nil
 }
 
@@ -1017,7 +1018,7 @@ func (c *CLI) cachedAuthConfigForCredential(apiName string, apiCfg *config.APICo
 	if apiCfg == nil {
 		return nil, false, nil
 	}
-	apiSpec, err := spec.LoadFromCache(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, c.loaders)
+	apiSpec, err := spec.LoadFromCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiCfg.SpecFiles, c.loaders)
 	if err != nil || apiSpec == nil {
 		return nil, false, err
 	}
@@ -1039,6 +1040,9 @@ func (c *CLI) cachedAuthConfigForCredential(apiName string, apiCfg *config.APICo
 }
 
 func (c *CLI) saveAPIAuthCredentialConfig(apiName, profileName, credentialID string, credential *config.CredentialConfig) error {
+	if err := c.ensureMutableAPI(apiName); err != nil {
+		return err
+	}
 	return c.saveConfigMutation("api auth", func(cfg *config.Config) error {
 		apiCfg := cfg.APIs[apiName]
 		if apiCfg == nil {
@@ -1064,6 +1068,9 @@ func (c *CLI) saveAPIAuthCredentialConfig(apiName, profileName, credentialID str
 }
 
 func (c *CLI) removeAPIAuthCredentialConfig(apiName, profileName, credentialID string) error {
+	if err := c.ensureMutableAPI(apiName); err != nil {
+		return err
+	}
 	return c.saveConfigMutation("api auth", func(cfg *config.Config) error {
 		apiCfg := cfg.APIs[apiName]
 		if apiCfg == nil {

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -242,7 +242,7 @@ func (c *CLI) cachedOAuthTokenEntry(authType string, cacheKey, apiName, profileN
 		return nil
 	}
 	if cacheKey == "" {
-		cacheKey = apiName + ":" + profileName
+		cacheKey = c.apiCacheNamespace(apiName, profileName)
 	}
 	if cacheKey == ":" || cacheKey == "" {
 		return nil
@@ -286,7 +286,10 @@ func (c *CLI) resolveProfileAuth(apiName, profileName string, prof *config.Profi
 		return resolvedAuthConfig{}, fmt.Errorf("profile %q of API %q has both auth and auth_ref", profileName, apiName)
 	}
 	if prof.AuthRef == "" {
-		return resolvedAuthConfig{Config: prof.Auth}, nil
+		return resolvedAuthConfig{
+			Config:   prof.Auth,
+			CacheKey: c.apiCacheNamespace(apiName, profileName),
+		}, nil
 	}
 	if c.cfg == nil || c.cfg.AuthProfiles == nil || c.cfg.AuthProfiles[prof.AuthRef] == nil {
 		return resolvedAuthConfig{}, fmt.Errorf("profile %q of API %q references unknown auth profile %q", profileName, apiName, prof.AuthRef)

--- a/internal/cli/cache_cmd.go
+++ b/internal/cli/cache_cmd.go
@@ -273,7 +273,11 @@ func (c *CLI) newCacheClearCmd() *cobra.Command {
 			if len(args) == 1 {
 				apiName := args[0]
 				registered := c.cfg != nil && c.cfg.APIs != nil && c.cfg.APIs[apiName] != nil
-				cleared, err := dc.ClearNamespacePrefix(apiName + ":")
+				namespace := apiName
+				if registered {
+					namespace = c.apiStateName(apiName)
+				}
+				cleared, err := dc.ClearNamespacePrefix(namespace + ":")
 				if err != nil {
 					return err
 				}

--- a/internal/cli/cache_cmd.go
+++ b/internal/cli/cache_cmd.go
@@ -62,7 +62,7 @@ func (c *CLI) newCacheInfoCmd() *cobra.Command {
 					SizeBytes:      info.SizeBytes,
 					Size:           formatBytes(info.SizeBytes),
 					Entries:        info.EntryCount,
-					TopAPIProfiles: cacheAPIProfileOutputs(info.Namespaces, info.SizeBytes, c.cfg, 10),
+					TopAPIProfiles: cacheAPIProfileOutputs(info.Namespaces, info.SizeBytes, c.cfg, c.projectConfig, 10),
 					TopHosts:       cacheBreakdownOutputs(info.Hosts, info.SizeBytes, 10),
 				}
 				if !info.OldestEntry.IsZero() {
@@ -79,9 +79,9 @@ func (c *CLI) newCacheInfoCmd() *cobra.Command {
 			}
 			if c.stdoutIsTerminal() {
 				width, height := cacheTreemapSize(c.Stdout)
-				printCacheTreemap(c.Stdout, style, "Usage map by API/profile:", info.Namespaces, c.cfg, width, height, 10)
+				printCacheTreemap(c.Stdout, style, "Usage map by API/profile:", info.Namespaces, c.cfg, c.projectConfig, width, height, 10)
 			}
-			printCacheAPIBreakdown(c.Stdout, style, "Largest APIs/profiles:", info.Namespaces, info.SizeBytes, c.cfg, 10)
+			printCacheAPIBreakdown(c.Stdout, style, "Largest APIs/profiles:", info.Namespaces, info.SizeBytes, c.cfg, c.projectConfig, 10)
 			printCacheBreakdown(c.Stdout, style, "Largest hosts:", info.Hosts, info.SizeBytes, 10)
 			return nil
 		},
@@ -139,13 +139,13 @@ func cacheBreakdownOutputs(items []cache.Breakdown, totalBytes int64, limit int)
 	return out
 }
 
-func cacheAPIProfileOutputs(items []cache.Breakdown, totalBytes int64, cfg *config.Config, limit int) []cacheAPIProfileOutput {
+func cacheAPIProfileOutputs(items []cache.Breakdown, totalBytes int64, cfg *config.Config, project *projectConfigState, limit int) []cacheAPIProfileOutput {
 	if limit > 0 && len(items) > limit {
 		items = items[:limit]
 	}
 	out := make([]cacheAPIProfileOutput, 0, len(items))
 	for _, item := range items {
-		details := cacheNamespaceInfo(item.Name, cfg)
+		details := cacheNamespaceInfo(item.Name, cfg, project)
 		entry := cacheAPIProfileOutput{
 			Name:      details.name,
 			Namespace: details.namespace,
@@ -186,7 +186,7 @@ func printCacheBreakdown(w io.Writer, style humanTextStyle, title string, items 
 	}
 }
 
-func printCacheAPIBreakdown(w io.Writer, style humanTextStyle, title string, items []cache.Breakdown, totalBytes int64, cfg *config.Config, limit int) {
+func printCacheAPIBreakdown(w io.Writer, style humanTextStyle, title string, items []cache.Breakdown, totalBytes int64, cfg *config.Config, project *projectConfigState, limit int) {
 	if len(items) == 0 {
 		return
 	}
@@ -197,7 +197,7 @@ func printCacheAPIBreakdown(w io.Writer, style humanTextStyle, title string, ite
 	}
 	fmt.Fprintf(w, "  %s\n", style.hint(fmt.Sprintf("%-32s %*s  %6s  %s", "Name", cacheSizeColumnWidth, "Size", "%", "Entries")))
 	for _, item := range items[:shown] {
-		details := cacheNamespaceInfo(item.Name, cfg)
+		details := cacheNamespaceInfo(item.Name, cfg, project)
 		entryWord := "entries"
 		if item.EntryCount == 1 {
 			entryWord = "entry"
@@ -209,7 +209,7 @@ func printCacheAPIBreakdown(w io.Writer, style humanTextStyle, title string, ite
 	}
 }
 
-func cacheNamespaceInfo(namespace string, cfg *config.Config) cacheNamespaceDetails {
+func cacheNamespaceInfo(namespace string, cfg *config.Config, project *projectConfigState) cacheNamespaceDetails {
 	details := cacheNamespaceDetails{
 		name:      namespace,
 		namespace: namespace,
@@ -222,6 +222,9 @@ func cacheNamespaceInfo(namespace string, cfg *config.Config) cacheNamespaceDeta
 	if !ok || apiName == "" || profileName == "" {
 		return details
 	}
+	if logicalAPIName, ok := projectCacheNamespaceAPI(apiName, project); ok {
+		apiName = logicalAPIName
+	}
 	details.api = apiName
 	details.profile = profileName
 	if cfg != nil && cfg.APIs != nil && cfg.APIs[apiName] != nil {
@@ -230,6 +233,18 @@ func cacheNamespaceInfo(namespace string, cfg *config.Config) cacheNamespaceDeta
 		details.name = fmt.Sprintf("%s (%s, unregistered)", apiName, profileName)
 	}
 	return details
+}
+
+func projectCacheNamespaceAPI(stateName string, project *projectConfigState) (string, bool) {
+	if project == nil || !project.Trusted || project.Namespace == "" {
+		return "", false
+	}
+	prefix := "project-" + project.Namespace + "-"
+	apiName, ok := strings.CutPrefix(stateName, prefix)
+	if !ok || apiName == "" || !project.APIs[apiName] {
+		return "", false
+	}
+	return apiName, true
 }
 
 func formatCachePercent(sizeBytes, totalBytes int64) string {

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -525,6 +525,61 @@ func TestCacheInfoShowsAndClearsUnregisteredNamespace(t *testing.T) {
 	}
 }
 
+func TestCacheInfoShowsProjectAPINamespaceAsRegistered(t *testing.T) {
+	var hits atomic.Int32
+	srv := newCacheableServer(t, &hits)
+	_, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "svc": {"base_url": "`+srv.URL+`"}
+  }
+}`)
+	t.Chdir(projectDir)
+
+	trust, _, _ := newProjectConfigTestCLI(t)
+	if err := trust.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+
+	prime, _, _ := newProjectConfigTestCLI(t)
+	if err := prime.Run([]string{"restish", "get", "svc"}); err != nil {
+		t.Fatalf("get svc: %v", err)
+	}
+
+	info, out, _ := newProjectConfigTestCLI(t)
+	if err := info.Run([]string{"restish", "cache", "info"}); err != nil {
+		t.Fatalf("cache info: %v", err)
+	}
+	got := out.String()
+	requireContains(t, got, "Largest APIs/profiles:", "svc (default)", "100.0%")
+	if strings.Contains(got, "unregistered") || strings.Contains(got, "project-") {
+		t.Fatalf("cache info output = %q, want project API shown as registered logical API", got)
+	}
+
+	jsonInfo, jsonOut, _ := newProjectConfigTestCLI(t)
+	if err := jsonInfo.Run([]string{"restish", "cache", "info", "-o", "json"}); err != nil {
+		t.Fatalf("cache info json: %v", err)
+	}
+	var decoded struct {
+		TopAPIProfiles []struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+			API       string `json:"api"`
+			Profile   string `json:"profile"`
+		} `json:"top_api_profiles"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &decoded); err != nil {
+		t.Fatalf("parse cache info JSON: %v\n%s", err, jsonOut.String())
+	}
+	if len(decoded.TopAPIProfiles) == 0 {
+		t.Fatalf("cache info JSON top_api_profiles empty: %s", jsonOut.String())
+	}
+	top := decoded.TopAPIProfiles[0]
+	if top.Name != "svc (default)" || top.API != "svc" || top.Profile != "default" || !strings.HasPrefix(top.Namespace, "project-") {
+		t.Fatalf("top API profile = %#v, want logical project API with project namespace", top)
+	}
+}
+
 func TestCacheInfoTTYShowsTreemap(t *testing.T) {
 	cacheDir := t.TempDir()
 	demoCache, err := cachepkg.New(cacheDir, cachepkg.DefaultMaxBytes, "demo:default")

--- a/internal/cli/cache_treemap.go
+++ b/internal/cli/cache_treemap.go
@@ -24,8 +24,8 @@ type cacheTreemapRect struct {
 	x, y, w, h int
 }
 
-func printCacheTreemap(w io.Writer, style humanTextStyle, title string, items []cache.Breakdown, cfg *config.Config, width, height, limit int) {
-	treemapItems := cacheTreemapItems(items, cfg, limit)
+func printCacheTreemap(w io.Writer, style humanTextStyle, title string, items []cache.Breakdown, cfg *config.Config, project *projectConfigState, width, height, limit int) {
+	treemapItems := cacheTreemapItems(items, cfg, project, limit)
 	if len(treemapItems) == 0 {
 		return
 	}
@@ -72,7 +72,7 @@ func printCacheTreemap(w io.Writer, style humanTextStyle, title string, items []
 	fmt.Fprintf(w, "  %s%s%s\n", style.hint("╰"), style.hint(strings.Repeat("─", innerWidth)), style.hint("╯"))
 }
 
-func cacheTreemapItems(items []cache.Breakdown, cfg *config.Config, limit int) []cacheTreemapItem {
+func cacheTreemapItems(items []cache.Breakdown, cfg *config.Config, project *projectConfigState, limit int) []cacheTreemapItem {
 	if limit > 0 && len(items) > limit {
 		items = items[:limit]
 	}
@@ -83,7 +83,7 @@ func cacheTreemapItems(items []cache.Breakdown, cfg *config.Config, limit int) [
 		if item.SizeBytes <= 0 {
 			continue
 		}
-		details := cacheNamespaceInfo(item.Name, cfg)
+		details := cacheNamespaceInfo(item.Name, cfg, project)
 		out = append(out, cacheTreemapItem{
 			label: details.name,
 			size:  item.SizeBytes,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -127,6 +127,7 @@ type CLI struct {
 	requestExecutionStarted bool
 	bodyPrefixHinted        bool
 	runCtx                  context.Context
+	projectConfig           *projectConfigState
 }
 
 // New returns a CLI wired to the real OS stdin/stdout/stderr.
@@ -361,6 +362,25 @@ func (c *CLI) configScopedCacheDir(base string) string {
 }
 
 func (c *CLI) loadConfig() (*config.Config, error) {
+	cfg, err := c.loadBaseConfig()
+	if err != nil {
+		return nil, err
+	}
+	merged := mergeDefaultConfigForEmbedding(c.defaultConfig, cfg)
+	if c.projectConfig != nil && c.projectConfig.Trusted {
+		projectCfg, err := c.loadTrustedProjectConfig()
+		if err != nil {
+			return nil, err
+		}
+		merged = mergeProjectConfig(merged, projectCfg)
+		if err := config.Validate(merged); err != nil {
+			return nil, fmt.Errorf("project config %s: %w", c.projectConfig.Path, err)
+		}
+	}
+	return merged, nil
+}
+
+func (c *CLI) loadBaseConfig() (*config.Config, error) {
 	var cfg *config.Config
 	var err error
 	if c.explicitConfigFile && c.createExplicitConfig {
@@ -373,7 +393,7 @@ func (c *CLI) loadConfig() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return mergeDefaultConfigForEmbedding(c.defaultConfig, cfg), nil
+	return cfg, nil
 }
 
 func cloneConfigForEmbedding(src *config.Config) *config.Config {
@@ -449,7 +469,7 @@ func (c *CLI) discoverSpecForProfile(ctx context.Context, apiName, profileName s
 		defer closer.Close()
 	}
 	cfg := spec.DiscoverConfig{
-		APIName:          apiName,
+		APIName:          c.apiStateName(apiName),
 		BaseURL:          effectiveProfileBaseURL(api, profileName),
 		SpecURL:          api.SpecURL,
 		SpecFiles:        api.SpecFiles,
@@ -489,11 +509,13 @@ func (c *CLI) Run(args []string) error {
 	c.requestExecutionStarted = false
 	c.bodyPrefixHinted = false
 	c.createExplicitConfig = false
+	c.projectConfig = nil
 	defer func() {
 		c.silentMode = false
 		c.requestExecutionStarted = false
 		c.bodyPrefixHinted = false
 		c.createExplicitConfig = false
+		c.projectConfig = nil
 	}()
 
 	if c.hooks.ConfigPath == "" {
@@ -504,6 +526,9 @@ func (c *CLI) Run(args []string) error {
 		} else if os.Getenv("RSH_CONFIG") != "" {
 			c.explicitConfigFile = true
 		}
+	}
+	if err := c.prepareProjectConfig(ctx, argScan); err != nil {
+		return err
 	}
 	if pathErr := c.paths().ConfigError(); pathErr != nil && c.hooks.ConfigPath == "" && !c.explicitConfigFile && !argScan.Bootstrap {
 		return pathErr
@@ -608,13 +633,14 @@ func (c *CLI) Run(args []string) error {
 			OperationBase:   effectiveOperationBase(apiCfg, startupProfile),
 			ServerVariables: effectiveServerVariables(apiCfg, startupProfile),
 		}
-		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opOpts, true); ok {
+		stateName := c.apiStateName(apiName)
+		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opOpts, true); ok {
 			if apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set); apiCmd != nil {
 				root.AddCommand(apiCmd)
 			}
 			continue
 		}
-		s, err := spec.LoadFromCache(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, c.loaders)
+		s, err := spec.LoadFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
 		if err != nil {
 			continue
 		}
@@ -626,7 +652,7 @@ func (c *CLI) Run(args []string) error {
 		}
 		set, opsErr := s.OperationSet(opOpts)
 		if opsErr == nil {
-			_ = spec.StoreOperationSetInCache(c.specCacheDir(), apiName, Version, opOpts, set)
+			_ = spec.StoreOperationSetInCache(c.specCacheDir(), stateName, Version, opOpts, set)
 		}
 		if apiCmd := c.buildAPICommandFromOperationResult(apiName, apiCfg, set, opsErr); apiCmd != nil {
 			root.AddCommand(apiCmd)
@@ -859,7 +885,7 @@ func (c *CLI) refreshStaleGeneratedMetadataForCommand(ctx context.Context, scan 
 		OperationBase:   effectiveOperationBase(apiCfg, scan.ProfileName),
 		ServerVariables: effectiveServerVariables(apiCfg, scan.ProfileName),
 	}
-	_, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), scan.FirstCommand, Version, apiCfg.SpecFiles, opts, true)
+	_, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), c.apiStateName(scan.FirstCommand), Version, apiCfg.SpecFiles, opts, true)
 	if !ok || !status.Stale {
 		return
 	}

--- a/internal/cli/command_plugin_handlers.go
+++ b/internal/cli/command_plugin_handlers.go
@@ -293,7 +293,7 @@ func (c *CLI) handlePluginAPISpec(ctx context.Context, cmd *cobra.Command, write
 	}
 	apiCfg := c.cfg.APIs[msg.Name]
 
-	s, err := spec.LoadFromCache(c.specCacheDir(), msg.Name, Version, apiCfg.SpecFiles, c.loaders)
+	s, err := spec.LoadFromCache(c.specCacheDir(), c.apiStateName(msg.Name), Version, apiCfg.SpecFiles, c.loaders)
 	if err != nil {
 		return writer.WriteMessage(pluginwire.APISpecResponseMsg{
 			Type:      pluginwire.MsgTypeAPISpecResponse,

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -225,10 +225,11 @@ func (c *CLI) completionOperationSet(cmd *cobra.Command, apiName string, apiCfg 
 		OperationBase:   effectiveOperationBase(apiCfg, profileName),
 		ServerVariables: effectiveServerVariables(apiCfg, profileName),
 	}
-	if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, opOpts, true); ok {
+	stateName := c.apiStateName(apiName)
+	if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opOpts, true); ok {
 		return set, true
 	}
-	s, err := spec.LoadFromCache(c.specCacheDir(), apiName, Version, apiCfg.SpecFiles, c.loaders)
+	s, err := spec.LoadFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
 	if err != nil {
 		return spec.OperationSet{}, false
 	}
@@ -242,7 +243,7 @@ func (c *CLI) completionOperationSet(cmd *cobra.Command, apiName string, apiCfg 
 	if err != nil {
 		return spec.OperationSet{}, false
 	}
-	_ = spec.StoreOperationSetInCache(c.specCacheDir(), apiName, Version, opOpts, set)
+	_ = spec.StoreOperationSetInCache(c.specCacheDir(), stateName, Version, opOpts, set)
 	return set, true
 }
 

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -112,7 +112,11 @@ func (c *CLI) runConfigShow(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Config file:"), c.configSourceSummary())
 	if c.projectConfig != nil && c.projectConfig.Trusted {
 		names := sortedProjectAPINames(c.projectConfig.APIs)
-		fmt.Fprintf(c.Stdout, "%s %s (%s)\n", style.key("Project config:"), c.projectConfig.Path, strings.Join(names, ", "))
+		if len(names) > 0 {
+			fmt.Fprintf(c.Stdout, "%s %s (%s)\n", style.key("Project config:"), c.projectConfig.Path, strings.Join(names, ", "))
+		} else {
+			fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Project config:"), c.projectConfig.Path)
+		}
 	}
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Cache max size:"), configShowCacheMaxSize(cfg))
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Theme:"), configShowTheme(cfg))

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -35,6 +35,14 @@ func (c *CLI) addConfigCommand(root *cobra.Command) {
 		Args:    usageNoArgs,
 		RunE:    c.runConfigPath,
 	})
+	configCmd.AddCommand(&cobra.Command{
+		Use:     "trust",
+		Short:   "Trust the project config discovered from this directory",
+		Long:    configTrustLong,
+		Example: fmt.Sprintf("  %s config trust", c.commandNameOrDefault()),
+		Args:    usageNoArgs,
+		RunE:    c.runConfigTrust,
+	})
 	showCmd := &cobra.Command{
 		Use:   "show",
 		Short: "Print the active config summary or redacted JSON",
@@ -101,12 +109,44 @@ func (c *CLI) runConfigShow(cmd *cobra.Command, args []string) error {
 		cfg = &config.Config{}
 	}
 	style := humanTextStyleFor(c.Stdout)
-	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Config file:"), c.configFilePath())
+	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Config file:"), c.configSourceSummary())
+	if c.projectConfig != nil && c.projectConfig.Trusted {
+		names := sortedProjectAPINames(c.projectConfig.APIs)
+		fmt.Fprintf(c.Stdout, "%s %s (%s)\n", style.key("Project config:"), c.projectConfig.Path, strings.Join(names, ", "))
+	}
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Cache max size:"), configShowCacheMaxSize(cfg))
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Theme:"), configShowTheme(cfg))
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Auth profiles:"), configShowNamedMapSummary(cfg.AuthProfiles))
 	fmt.Fprintf(c.Stdout, "%s %s\n", style.key("Configured plugins:"), configShowRawMessageMapSummary(cfg.Plugins))
 	c.printConfigShowAPIs(style, cfg)
+	return nil
+}
+
+func (c *CLI) runConfigTrust(cmd *cobra.Command, args []string) error {
+	if err := rejectResponseTransformFlags(cmd); err != nil {
+		return err
+	}
+	project := c.projectConfig
+	if project == nil {
+		discovered, err := discoverProjectConfig()
+		if err != nil {
+			return err
+		}
+		project = discovered
+	}
+	if project == nil {
+		return fmt.Errorf("no %s found in this directory or its parents", projectConfigFileName)
+	}
+	summary, err := c.projectConfigTrustSummary(project)
+	if err != nil {
+		return err
+	}
+	if err := c.trustProjectConfig(project); err != nil {
+		return err
+	}
+	project.Trusted = true
+	style := humanTextStyleFor(c.Stdout)
+	fmt.Fprintf(c.Stdout, "%s project config: %s%s\n", style.ok("Trusted"), project.Path, summary)
 	return nil
 }
 

--- a/internal/cli/config_mutation.go
+++ b/internal/cli/config_mutation.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/rest-sh/restish/v2/internal/config"
 	"github.com/rest-sh/restish/v2/internal/request"
@@ -21,6 +22,9 @@ func (c *CLI) unknownAPIError(apiName string) error {
 }
 
 func (c *CLI) saveConfigValues(label string, ops []config.ConfigPatchOperation) error {
+	if err := c.ensureMutableConfigPatch(ops); err != nil {
+		return err
+	}
 	oldCfg := c.cfg
 	if err := config.SaveConfigValues(c.configFilePath(), ops); err != nil {
 		return err
@@ -29,6 +33,9 @@ func (c *CLI) saveConfigValues(label string, ops []config.ConfigPatchOperation) 
 }
 
 func (c *CLI) saveConfigShorthand(label string, rootPath []string, exprs []string) error {
+	if err := c.ensureMutableConfigShorthand(rootPath, exprs); err != nil {
+		return err
+	}
 	oldCfg := c.cfg
 	if err := config.SaveConfigShorthand(c.configFilePath(), rootPath, exprs, c.validateConfigRuntime); err != nil {
 		return err
@@ -95,6 +102,9 @@ func (c *CLI) validateAuthConfig(authCfg *config.AuthConfig) error {
 }
 
 func (c *CLI) saveAPIConfig(label, apiName string, cfg *config.Config, apiCfg *config.APIConfig) error {
+	if err := c.ensureMutableAPI(apiName); err != nil {
+		return err
+	}
 	oldCfg := c.cfg
 	cfgPath := c.configFilePath()
 	if err := config.SaveAPIConfig(cfgPath, apiName, apiCfg); err != nil {
@@ -112,13 +122,28 @@ func (c *CLI) saveConfigMutation(label string, mutate func(*config.Config) error
 }
 
 func (c *CLI) deleteAPIConfig(label, apiName string, cfg *config.Config, oldCfg *config.Config) error {
+	if err := c.ensureMutableAPI(apiName); err != nil {
+		return err
+	}
 	cfgPath := c.configFilePath()
 	if config.NeedsPatchToPreserveFormatting(cfgPath) {
 		if err := config.DeleteAPIConfig(cfgPath, apiName); err != nil {
 			return err
 		}
-	} else if err := config.Save(cfgPath, cfg); err != nil {
-		return err
+	} else {
+		fileCfg, err := c.loadBaseConfig()
+		if err != nil {
+			return err
+		}
+		if fileCfg.APIs != nil {
+			delete(fileCfg.APIs, apiName)
+			if len(fileCfg.APIs) == 0 {
+				fileCfg.APIs = nil
+			}
+		}
+		if err := config.Save(cfgPath, fileCfg); err != nil {
+			return err
+		}
 	}
 	return c.reloadConfigAfterMutation(label, oldCfg)
 }
@@ -162,7 +187,7 @@ func (c *CLI) reloadConfigAfterMutation(label string, oldCfg *config.Config) err
 		return err
 	}
 	for _, apiName := range apiNamesWithSpecCacheRelevantChanges(oldCfg, newCfg) {
-		if err := spec.InvalidateCache(c.specCacheDir(), apiName); err != nil {
+		if err := spec.InvalidateCache(c.specCacheDir(), c.apiStateName(apiName)); err != nil {
 			return fmt.Errorf("%s: invalidate spec cache for %q: %w", label, apiName, err)
 		}
 	}
@@ -176,12 +201,66 @@ func (c *CLI) reloadConfigAfterAPIMutation(label string, oldCfg *config.Config, 
 		return err
 	}
 	if apiSpecCacheRelevantFieldsChanged(apiConfigByName(oldCfg, apiName), apiConfigByName(newCfg, apiName)) {
-		if err := spec.InvalidateCache(c.specCacheDir(), apiName); err != nil {
+		if err := spec.InvalidateCache(c.specCacheDir(), c.apiStateName(apiName)); err != nil {
 			return fmt.Errorf("%s: invalidate spec cache for %q: %w", label, apiName, err)
 		}
 	}
 	c.cfg = newCfg
 	return nil
+}
+
+func (c *CLI) ensureMutableConfigPatch(ops []config.ConfigPatchOperation) error {
+	for _, op := range ops {
+		if err := c.ensureMutableConfigPath(op.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CLI) ensureMutableConfigShorthand(rootPath []string, exprs []string) error {
+	if err := c.ensureMutableConfigPath(rootPath); err != nil {
+		return err
+	}
+	for _, expr := range exprs {
+		key, _, _, err := parseShorthandAssignment(expr)
+		if err != nil {
+			if !strings.Contains(expr, "^") {
+				return err
+			}
+			left, right, ok := strings.Cut(expr, "^")
+			if !ok {
+				return err
+			}
+			for _, key := range []string{strings.TrimSpace(left), strings.TrimSpace(right)} {
+				if key == "" {
+					continue
+				}
+				path := append([]string{}, rootPath...)
+				path = append(path, strings.Split(key, ".")...)
+				if err := c.ensureMutableConfigPath(path); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		path := append([]string{}, rootPath...)
+		path = append(path, strings.Split(key, ".")...)
+		if err := c.ensureMutableConfigPath(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CLI) ensureMutableConfigPath(path []string) error {
+	if !c.hasProjectAPIs() || len(path) == 0 || path[0] != "apis" {
+		return nil
+	}
+	if len(path) == 1 {
+		return fmt.Errorf("config write targets all APIs while trusted project config %s is active; edit the global config directly or pass --rsh-config to choose a single file", c.projectConfig.Path)
+	}
+	return c.ensureMutableAPI(path[1])
 }
 
 func apiConfigByName(cfg *config.Config, apiName string) *config.APIConfig {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -320,7 +320,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 	}
 	profileName := c.profileFromCmd(cmd)
 	opInfo := c.doctorOperationSetStatus(requestContext(cmd), name, api, profileName)
-	if _, ok := configFileExists(filepath.Join(c.specCacheDir(), name+".cbor")); ok {
+	if _, ok := configFileExists(filepath.Join(c.specCacheDir(), c.apiStateName(name)+".cbor")); ok {
 		if opInfo.Cached && opInfo.CacheStatus.Stale {
 			fmt.Fprintf(out, "Spec cache: %s (last synced %s, expired %s)\n", style.warn("stale"), formatCacheTime(opInfo.CacheStatus.FetchedAt), formatCacheTime(opInfo.CacheStatus.ExpiresAt))
 		} else if opInfo.Cached {
@@ -751,7 +751,7 @@ func (c *CLI) doctorAPIReport(cmd *cobra.Command, name string) doctorAPIReport {
 	report.SpecFiles = append([]string(nil), api.SpecFiles...)
 	profileName := c.profileFromCmd(cmd)
 	opInfo := c.doctorOperationSetStatus(requestContext(cmd), name, api, profileName)
-	if _, ok := configFileExists(filepath.Join(c.specCacheDir(), name+".cbor")); ok {
+	if _, ok := configFileExists(filepath.Join(c.specCacheDir(), c.apiStateName(name)+".cbor")); ok {
 		report.SpecCache = doctorStatusReport{Status: "present"}
 		if opInfo.Cached {
 			report.SpecCache.FetchedAt = opInfo.CacheStatus.FetchedAt.Format(time.RFC3339)

--- a/internal/cli/help_text.go
+++ b/internal/cli/help_text.go
@@ -67,6 +67,9 @@ const configLong = "Manage local Restish configuration.\n\n" +
 const configPathLong = "Print the active Restish config file path.\n\n" +
 	"This honors `--rsh-config` and `RSH_CONFIG`, so it is the safest way to confirm which config a command will read or write."
 
+const configTrustLong = "Trust the `.restish.json` project config discovered from the current directory or a parent.\n\n" +
+	"Trusted project config is layered over the global config for this working tree. Trust is stored outside the repository and includes the file's content hash, so Restish asks again if the file changes. In non-interactive scripts, run this command once before relying on discovered project config, or select a config explicitly with `--rsh-config`."
+
 const configShowLong = "Print the active config summary, or redacted JSON with `-o json`.\n\n" +
 	"Human output shows the selected file, cache/theme settings, shared auth profiles, plugin config, and registered API details without printing credential values. JSON output is intended for inspection and support; sensitive auth values, credential-like headers, and credential-like query parameters are redacted where Restish recognizes them."
 

--- a/internal/cli/help_text.go
+++ b/internal/cli/help_text.go
@@ -68,7 +68,7 @@ const configPathLong = "Print the active Restish config file path.\n\n" +
 	"This honors `--rsh-config` and `RSH_CONFIG`, so it is the safest way to confirm which config a command will read or write."
 
 const configTrustLong = "Trust the `.restish.json` project config discovered from the current directory or a parent.\n\n" +
-	"Trusted project config is layered over the global config for this working tree. Trust is stored outside the repository and includes the file's content hash, so Restish asks again if the file changes. In non-interactive scripts, run this command once before relying on discovered project config, or select a config explicitly with `--rsh-config`."
+	"Trusted project config is layered over the global config for this working tree. Trust is stored outside the repository and includes the file's content hash, so Restish asks again if the file changes. Project config is meant for shared, secret-free setup; secret auth params should be omitted or use env:NAME references. In non-interactive scripts, run this command once before relying on discovered project config, or select a config explicitly with `--rsh-config`."
 
 const configShowLong = "Print the active config summary, or redacted JSON with `-o json`.\n\n" +
 	"Human output shows the selected file, cache/theme settings, shared auth profiles, plugin config, and registered API details without printing credential values. JSON output is intended for inspection and support; sensitive auth values, credential-like headers, and credential-like query parameters are redacted where Restish recognizes them."

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -1851,7 +1851,7 @@ func (c *CLI) applyAPIProfile(rawURL, profileName string, opts request.Options, 
 		}
 	}
 	if match.apiName != "" {
-		opts.CacheNamespace = match.apiName + ":" + profileName
+		opts.CacheNamespace = c.apiCacheNamespace(match.apiName, profileName)
 	}
 
 	return rawURL, match.apiName, opts, nil

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -297,7 +297,7 @@ func (c *CLI) resolveCredentialAuth(apiName, profileName, credentialID string, c
 	if credential.AuthRef == "" {
 		return resolvedAuthConfig{
 			Config:   credential.Auth,
-			CacheKey: apiName + ":" + profileName + ":credential:" + credentialID,
+			CacheKey: c.apiCacheNamespace(apiName, profileName) + ":credential:" + credentialID,
 		}, nil
 	}
 	if c.cfg == nil || c.cfg.AuthProfiles == nil || c.cfg.AuthProfiles[credential.AuthRef] == nil {

--- a/internal/cli/project_config.go
+++ b/internal/cli/project_config.go
@@ -375,7 +375,7 @@ func (c *CLI) validateProjectAuthNoInlineSecrets(path string, authCfg *config.Au
 	}
 	handler, err := c.authHandlerFor(authCfg, authHandlerOptions{})
 	if err != nil {
-		return nil
+		return fmt.Errorf("%s: %w", path, err)
 	}
 	for _, param := range handler.Parameters() {
 		if !param.Secret {

--- a/internal/cli/project_config.go
+++ b/internal/cli/project_config.go
@@ -303,9 +303,9 @@ func parseProjectConfigFile(path string) (*config.Config, error) {
 	if err := decodeProjectConfigJSON(path, stripped, &raw); err != nil {
 		return nil, err
 	}
-	for key := range raw {
+	for _, key := range sortedProjectConfigKeys(raw) {
 		if key != "apis" && key != "theme" {
-			return nil, fmt.Errorf("project config: only apis and theme are supported in %s for now", projectConfigFileName)
+			return nil, fmt.Errorf("project config %s: unsupported top-level key %q; only apis and theme are supported for now", path, key)
 		}
 	}
 	var cfg config.Config
@@ -313,6 +313,15 @@ func parseProjectConfigFile(path string) (*config.Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func sortedProjectConfigKeys(raw map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(raw))
+	for key := range raw {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (c *CLI) validateProjectConfigNoInlineSecrets(project *projectConfigState, cfg *config.Config) error {

--- a/internal/cli/project_config.go
+++ b/internal/cli/project_config.go
@@ -18,6 +18,8 @@ import (
 	"github.com/rest-sh/restish/v2/internal/config"
 	"github.com/rest-sh/restish/v2/internal/fileutil"
 	"github.com/rest-sh/restish/v2/internal/output"
+	"github.com/rest-sh/restish/v2/internal/request"
+	"github.com/rest-sh/restish/v2/internal/secrets"
 	"github.com/tidwall/jsonc"
 )
 
@@ -260,11 +262,11 @@ func (c *CLI) projectConfigRuntimeSubset(project *projectConfigState) (*config.C
 	if project == nil {
 		return nil, nil, nil
 	}
-	if insecure, permErr := config.ConfigFileHasInsecurePermissions(project.Path); permErr == nil && insecure {
-		return nil, nil, fmt.Errorf("%s is group/world-readable; project config can contain credentials (chmod 600)", project.Path)
-	}
 	cfg, err := parseProjectConfigFile(project.Path)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.validateProjectConfigNoInlineSecrets(project, cfg); err != nil {
 		return nil, nil, err
 	}
 	subset := &config.Config{}
@@ -311,6 +313,87 @@ func parseProjectConfigFile(path string) (*config.Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+func (c *CLI) validateProjectConfigNoInlineSecrets(project *projectConfigState, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for apiName, apiCfg := range cfg.APIs {
+		if apiCfg == nil {
+			continue
+		}
+		for profileName, prof := range apiCfg.Profiles {
+			if prof == nil {
+				continue
+			}
+			path := fmt.Sprintf("apis.%s.profiles.%s", apiName, profileName)
+			if err := c.validateProjectProfileNoInlineSecrets(path, prof); err != nil {
+				return fmt.Errorf("project config %s: %w", project.Path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *CLI) validateProjectProfileNoInlineSecrets(path string, prof *config.ProfileConfig) error {
+	if err := c.validateProjectAuthNoInlineSecrets(path+".auth", prof.Auth); err != nil {
+		return err
+	}
+	for i, header := range prof.Headers {
+		name, value, err := request.ParseHeaderOption(header)
+		if err != nil {
+			return fmt.Errorf("%s.headers[%d]: %w", path, i, err)
+		}
+		if secrets.IsHeaderName(name) || secrets.IsHeaderValue(name, value) {
+			return fmt.Errorf("%s.headers[%d]: project config cannot contain credential-bearing header %q; use auth with env:NAME secret references instead", path, i, name)
+		}
+	}
+	for i, query := range prof.Query {
+		name, value, err := request.ParseQueryOption(query)
+		if err != nil {
+			return fmt.Errorf("%s.query[%d]: %w", path, i, err)
+		}
+		if secrets.IsQueryParamValue(name, value) {
+			return fmt.Errorf("%s.query[%d]: project config cannot contain credential-bearing query parameter %q; use auth with env:NAME secret references instead", path, i, name)
+		}
+	}
+	for credentialID, credential := range prof.Credentials {
+		if credential == nil {
+			continue
+		}
+		if err := c.validateProjectAuthNoInlineSecrets(path+".credentials."+credentialID+".auth", credential.Auth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *CLI) validateProjectAuthNoInlineSecrets(path string, authCfg *config.AuthConfig) error {
+	if authCfg == nil || authCfg.Type == "" {
+		return nil
+	}
+	handler, err := c.authHandlerFor(authCfg, authHandlerOptions{})
+	if err != nil {
+		return nil
+	}
+	for _, param := range handler.Parameters() {
+		if !param.Secret {
+			continue
+		}
+		value := authCfg.Params[param.Name]
+		if value == "" {
+			continue
+		}
+		if strings.HasPrefix(value, "env:") {
+			if strings.TrimPrefix(value, "env:") == "" {
+				return fmt.Errorf("%s.params.%s: env secret source is missing a variable name", path, param.Name)
+			}
+			continue
+		}
+		return fmt.Errorf("%s.params.%s: project config cannot contain inline secret values; use env:NAME or omit the value", path, param.Name)
+	}
+	return nil
 }
 
 func decodeProjectConfigJSON(path string, data []byte, v any) error {

--- a/internal/cli/project_config.go
+++ b/internal/cli/project_config.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rest-sh/restish/v2/internal/config"
+	"github.com/rest-sh/restish/v2/internal/fileutil"
+	"github.com/rest-sh/restish/v2/internal/output"
+	"github.com/tidwall/jsonc"
+)
+
+const projectConfigFileName = ".restish.json"
+
+type projectConfigState struct {
+	Path      string
+	Hash      string
+	Namespace string
+	Trusted   bool
+	APIs      map[string]bool
+}
+
+type projectTrustFile struct {
+	Projects map[string]projectTrustEntry `json:"projects,omitempty"`
+}
+
+type projectTrustEntry struct {
+	SHA256    string `json:"sha256"`
+	TrustedAt string `json:"trusted_at,omitempty"`
+}
+
+func (c *CLI) prepareProjectConfig(ctx context.Context, scan cliArgScan) error {
+	if c.hooks.ConfigPath != "" || c.explicitConfigFile {
+		return nil
+	}
+	if c.paths().ConfigError() != nil {
+		return nil
+	}
+	project, err := discoverProjectConfig()
+	if err != nil || project == nil {
+		return err
+	}
+	c.projectConfig = project
+	trusted, err := c.projectConfigTrusted(project)
+	if err != nil {
+		return err
+	}
+	if trusted {
+		project.Trusted = true
+		return nil
+	}
+	if scan.Bootstrap {
+		return nil
+	}
+	if scan.FirstCommand == "config" && scan.SecondCommand == "trust" {
+		return nil
+	}
+	if !output.IsTerminalReader(c.Stdin) {
+		c.warnf("project config %s is not trusted; run %q to use it", project.Path, c.commandNameOrDefault()+" config trust")
+		return nil
+	}
+	summary, err := c.projectConfigTrustSummary(project)
+	if err != nil {
+		return err
+	}
+	label := fmt.Sprintf("Trust and use project config %s%s? [y/N] ", project.Path, summary)
+	ok, err := c.promptYesNoDefault(ctx, label, false)
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := c.trustProjectConfig(project); err != nil {
+			return err
+		}
+		project.Trusted = true
+	}
+	return nil
+}
+
+func discoverProjectConfig() (*projectConfigState, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		candidate := filepath.Join(wd, projectConfigFileName)
+		info, statErr := os.Stat(candidate)
+		if statErr == nil {
+			if info.IsDir() {
+				return nil, fmt.Errorf("project config %s is a directory", candidate)
+			}
+			return newProjectConfigState(candidate)
+		}
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return nil, statErr
+		}
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			return nil, nil
+		}
+		wd = parent
+	}
+}
+
+func newProjectConfigState(path string) (*projectConfigState, error) {
+	canonical, err := canonicalProjectConfigPath(path)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := projectConfigHash(canonical)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256([]byte(canonical + "\x00" + hash))
+	return &projectConfigState{
+		Path:      canonical,
+		Hash:      hash,
+		Namespace: hex.EncodeToString(sum[:8]),
+		APIs:      map[string]bool{},
+	}, nil
+}
+
+func canonicalProjectConfigPath(path string) (string, error) {
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return filepath.Clean(path), nil
+}
+
+func projectConfigHash(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func (c *CLI) projectTrustPath() string {
+	return filepath.Join(c.paths().Config(), "project-trust.json")
+}
+
+func (c *CLI) projectConfigTrusted(project *projectConfigState) (bool, error) {
+	trust, err := c.loadProjectTrust()
+	if err != nil {
+		return false, err
+	}
+	entry, ok := trust.Projects[project.Path]
+	if !ok {
+		return false, nil
+	}
+	return entry.SHA256 == project.Hash, nil
+}
+
+func (c *CLI) trustProjectConfig(project *projectConfigState) error {
+	if project == nil {
+		return fmt.Errorf("project config: no %s found from the current directory", projectConfigFileName)
+	}
+	projectCfg, _, err := c.projectConfigRuntimeSubset(project)
+	if err != nil {
+		return err
+	}
+	if err := c.validateProjectConfigWithBase(project, projectCfg); err != nil {
+		return err
+	}
+	trust, err := c.loadProjectTrust()
+	if err != nil {
+		return err
+	}
+	if trust.Projects == nil {
+		trust.Projects = map[string]projectTrustEntry{}
+	}
+	trust.Projects[project.Path] = projectTrustEntry{
+		SHA256:    project.Hash,
+		TrustedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.MarshalIndent(trust, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return fileutil.AtomicWriteFile(c.projectTrustPath(), data, fileutil.AtomicWriteOptions{
+		FileMode: 0o600,
+		DirMode:  0o700,
+	})
+}
+
+func (c *CLI) loadProjectTrust() (projectTrustFile, error) {
+	path := c.projectTrustPath()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return projectTrustFile{Projects: map[string]projectTrustEntry{}}, nil
+	}
+	if err != nil {
+		return projectTrustFile{}, err
+	}
+	var trust projectTrustFile
+	if err := json.Unmarshal(data, &trust); err != nil {
+		return projectTrustFile{}, fmt.Errorf("project config trust: cannot parse %s: %w", path, err)
+	}
+	if trust.Projects == nil {
+		trust.Projects = map[string]projectTrustEntry{}
+	}
+	return trust, nil
+}
+
+func (c *CLI) loadTrustedProjectConfig() (*config.Config, error) {
+	project := c.projectConfig
+	if project == nil || !project.Trusted {
+		return nil, nil
+	}
+	currentHash, err := projectConfigHash(project.Path)
+	if err != nil {
+		return nil, err
+	}
+	if currentHash != project.Hash {
+		return nil, fmt.Errorf("project config %s changed since it was trusted; run %q again to review and trust the new contents", project.Path, c.commandNameOrDefault()+" config trust")
+	}
+	projectCfg, apiNames, err := c.projectConfigRuntimeSubset(project)
+	if err != nil {
+		return nil, err
+	}
+	project.APIs = apiNames
+	return projectCfg, nil
+}
+
+func (c *CLI) projectConfigTrustSummary(project *projectConfigState) (string, error) {
+	projectCfg, apiNames, err := c.projectConfigRuntimeSubset(project)
+	if err != nil {
+		return "", err
+	}
+	var parts []string
+	if len(apiNames) > 0 {
+		parts = append(parts, fmt.Sprintf("APIs: %s", strings.Join(sortedProjectAPINames(apiNames), ", ")))
+	}
+	if len(projectCfg.Theme) > 0 {
+		parts = append(parts, fmt.Sprintf("theme overrides: %d", len(projectCfg.Theme)))
+	}
+	if len(parts) == 0 {
+		return " (no APIs or theme overrides)", nil
+	}
+	return " (" + strings.Join(parts, "; ") + ")", nil
+}
+
+func (c *CLI) projectConfigRuntimeSubset(project *projectConfigState) (*config.Config, map[string]bool, error) {
+	if project == nil {
+		return nil, nil, nil
+	}
+	if insecure, permErr := config.ConfigFileHasInsecurePermissions(project.Path); permErr == nil && insecure {
+		return nil, nil, fmt.Errorf("%s is group/world-readable; project config can contain credentials (chmod 600)", project.Path)
+	}
+	cfg, err := parseProjectConfigFile(project.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if projectConfigHasUnsupportedTopLevel(cfg) {
+		return nil, nil, fmt.Errorf("project config: only apis and theme are supported in %s for now", projectConfigFileName)
+	}
+	subset := &config.Config{}
+	apiNames := map[string]bool{}
+	if len(cfg.APIs) > 0 {
+		subset.APIs = map[string]*config.APIConfig{}
+		baseDir := filepath.Dir(project.Path)
+		for name, apiCfg := range cfg.APIs {
+			cloned, err := cloneAPIConfig(apiCfg)
+			if err != nil {
+				return nil, nil, err
+			}
+			resolveProjectAPIPaths(cloned, baseDir)
+			subset.APIs[name] = cloned
+			apiNames[name] = true
+		}
+	}
+	if len(cfg.Theme) > 0 {
+		subset.Theme = map[string]string{}
+		for key, value := range cfg.Theme {
+			subset.Theme[key] = value
+		}
+	}
+	return subset, apiNames, nil
+}
+
+func parseProjectConfigFile(path string) (*config.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config: cannot read %s: %w", path, err)
+	}
+	stripped := jsonc.ToJSON(data)
+	var cfg config.Config
+	dec := json.NewDecoder(bytes.NewReader(stripped))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	}
+	if err := dec.Decode(new(struct{})); err == nil {
+		return nil, fmt.Errorf("config: invalid config %s\n  unexpected trailing content", path)
+	} else if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	}
+	return &cfg, nil
+}
+
+func (c *CLI) validateProjectConfigWithBase(project *projectConfigState, projectCfg *config.Config) error {
+	base, err := c.loadBaseConfig()
+	if err != nil {
+		return err
+	}
+	merged := mergeDefaultConfigForEmbedding(c.defaultConfig, base)
+	merged = mergeProjectConfig(merged, projectCfg)
+	if err := config.Validate(merged); err != nil {
+		return fmt.Errorf("project config %s: %w", project.Path, err)
+	}
+	return nil
+}
+
+func projectConfigHasUnsupportedTopLevel(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return len(cfg.AuthProfiles) > 0 ||
+		cfg.Cache != (config.CacheConfig{}) ||
+		len(cfg.Plugins) > 0 ||
+		cfg.ThemeSource != ""
+}
+
+func resolveProjectAPIPaths(apiCfg *config.APIConfig, baseDir string) {
+	if apiCfg == nil {
+		return
+	}
+	for i, file := range apiCfg.SpecFiles {
+		if file == "" || strings.Contains(file, "://") || filepath.IsAbs(file) {
+			continue
+		}
+		apiCfg.SpecFiles[i] = filepath.Join(baseDir, file)
+	}
+}
+
+func mergeProjectConfig(base, project *config.Config) *config.Config {
+	if project == nil {
+		return base
+	}
+	if base == nil {
+		base = &config.Config{}
+	}
+	if len(project.APIs) > 0 {
+		if base.APIs == nil {
+			base.APIs = map[string]*config.APIConfig{}
+		}
+		for name, apiCfg := range project.APIs {
+			base.APIs[name] = apiCfg
+		}
+	}
+	if len(project.Theme) > 0 {
+		if base.Theme == nil {
+			base.Theme = map[string]string{}
+		}
+		for key, value := range project.Theme {
+			base.Theme[key] = value
+		}
+	}
+	return base
+}
+
+func (c *CLI) projectAPI(apiName string) bool {
+	return c.projectConfig != nil && c.projectConfig.Trusted && c.projectConfig.APIs[apiName]
+}
+
+func (c *CLI) hasProjectAPIs() bool {
+	return c.projectConfig != nil && c.projectConfig.Trusted && len(c.projectConfig.APIs) > 0
+}
+
+func (c *CLI) ensureMutableAPI(apiName string) error {
+	if c.projectAPI(apiName) {
+		return fmt.Errorf("API %q comes from trusted project config %s and is read-only; edit that file directly or pass --rsh-config %s to make it the selected config", apiName, c.projectConfig.Path, c.projectConfig.Path)
+	}
+	return nil
+}
+
+func (c *CLI) apiStateName(apiName string) string {
+	if c.projectAPI(apiName) {
+		return "project-" + c.projectConfig.Namespace + "-" + apiName
+	}
+	return apiName
+}
+
+func (c *CLI) apiCacheNamespace(apiName, profileName string) string {
+	return c.apiStateName(apiName) + ":" + profileName
+}
+
+func (c *CLI) configSourceSummary() string {
+	if c.projectConfig != nil && c.projectConfig.Trusted {
+		return fmt.Sprintf("%s + %s", c.configFilePath(), c.projectConfig.Path)
+	}
+	return c.configFilePath()
+}
+
+func sortedProjectAPINames(items map[string]bool) []string {
+	names := make([]string, 0, len(items))
+	for name := range items {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/cli/project_config.go
+++ b/internal/cli/project_config.go
@@ -267,9 +267,6 @@ func (c *CLI) projectConfigRuntimeSubset(project *projectConfigState) (*config.C
 	if err != nil {
 		return nil, nil, err
 	}
-	if projectConfigHasUnsupportedTopLevel(cfg) {
-		return nil, nil, fmt.Errorf("project config: only apis and theme are supported in %s for now", projectConfigFileName)
-	}
 	subset := &config.Config{}
 	apiNames := map[string]bool{}
 	if len(cfg.APIs) > 0 {
@@ -300,18 +297,34 @@ func parseProjectConfigFile(path string) (*config.Config, error) {
 		return nil, fmt.Errorf("config: cannot read %s: %w", path, err)
 	}
 	stripped := jsonc.ToJSON(data)
-	var cfg config.Config
-	dec := json.NewDecoder(bytes.NewReader(stripped))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	var raw map[string]json.RawMessage
+	if err := decodeProjectConfigJSON(path, stripped, &raw); err != nil {
+		return nil, err
 	}
-	if err := dec.Decode(new(struct{})); err == nil {
-		return nil, fmt.Errorf("config: invalid config %s\n  unexpected trailing content", path)
-	} else if !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	for key := range raw {
+		if key != "apis" && key != "theme" {
+			return nil, fmt.Errorf("project config: only apis and theme are supported in %s for now", projectConfigFileName)
+		}
+	}
+	var cfg config.Config
+	if err := decodeProjectConfigJSON(path, stripped, &cfg); err != nil {
+		return nil, err
 	}
 	return &cfg, nil
+}
+
+func decodeProjectConfigJSON(path string, data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	}
+	if err := dec.Decode(new(struct{})); err == nil {
+		return fmt.Errorf("config: invalid config %s\n  unexpected trailing content", path)
+	} else if !errors.Is(err, io.EOF) {
+		return fmt.Errorf("config: invalid config %s\n  %w", path, err)
+	}
+	return nil
 }
 
 func (c *CLI) validateProjectConfigWithBase(project *projectConfigState, projectCfg *config.Config) error {
@@ -325,16 +338,6 @@ func (c *CLI) validateProjectConfigWithBase(project *projectConfigState, project
 		return fmt.Errorf("project config %s: %w", project.Path, err)
 	}
 	return nil
-}
-
-func projectConfigHasUnsupportedTopLevel(cfg *config.Config) bool {
-	if cfg == nil {
-		return false
-	}
-	return len(cfg.AuthProfiles) > 0 ||
-		cfg.Cache != (config.CacheConfig{}) ||
-		len(cfg.Plugins) > 0 ||
-		cfg.ThemeSource != ""
 }
 
 func resolveProjectAPIPaths(apiCfg *config.APIConfig, baseDir string) {

--- a/internal/cli/project_config_test.go
+++ b/internal/cli/project_config_test.go
@@ -293,6 +293,34 @@ func TestProjectConfigRejectsInlineSecrets(t *testing.T) {
 	}
 }
 
+func TestProjectConfigRejectsUnknownAuthType(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "svc": {
+      "base_url": "https://project.example.com",
+      "profiles": {
+        "default": {
+          "auth": {
+            "type": "mystery-auth",
+            "params": {
+              "token": "inline-secret"
+            }
+          }
+        }
+      }
+    }
+  }
+}`)
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	err := c.Run([]string{"restish", "config", "trust"})
+	if err == nil || !strings.Contains(err.Error(), "unknown auth type") || !strings.Contains(err.Error(), "apis.svc.profiles.default.auth") {
+		t.Fatalf("config trust err = %v, want unknown auth type path", err)
+	}
+}
+
 func TestProjectConfigAPIsAreReadOnlyForMutatingCommands(t *testing.T) {
 	_, _, projectDir := setupProjectConfigTest(t)
 	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
@@ -348,6 +376,63 @@ func TestProjectConfigDoesNotPersistThroughGlobalAPIRemove(t *testing.T) {
 	}
 	if strings.Contains(string(data), "global.example.com") {
 		t.Fatalf("global API was not removed: %s", data)
+	}
+}
+
+func TestProjectConfigAPISyncWarnsWhenOperationOriginsNeedProjectEdit(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	var specURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+  "openapi": "3.1.0",
+  "info": {"title": "Project API", "version": "1.0"},
+  "servers": [{"url": %q}],
+  "paths": {
+    "/upload": {
+      "post": {
+        "operationId": "uploadFile",
+        "servers": [{"url": "https://uploads.example.com"}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`, strings.TrimSuffix(specURL, "/openapi.json"))
+	}))
+	defer server.Close()
+	specURL = server.URL + "/openapi.json"
+
+	projectPath := filepath.Join(projectDir, ".restish.json")
+	writeProjectConfigTestFile(t, projectPath, fmt.Sprintf(`{
+  "apis": {
+    "svc": {
+      "base_url": %q,
+      "spec_url": %q
+    }
+  }
+}`, server.URL, specURL))
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+
+	c, out, stderr := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "api", "sync", "svc", "--yes"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if strings.Contains(out.String(), "Wrote config:") {
+		t.Fatalf("api sync wrote read-only project config:\n%s", out.String())
+	}
+	gotErr := stderr.String()
+	for _, want := range []string{"read-only project API", "allowed_operation_origins[]", projectPath, "--rsh-config"} {
+		if !strings.Contains(gotErr, want) {
+			t.Fatalf("stderr = %q, want %q", gotErr, want)
+		}
+	}
+	if strings.Contains(gotErr, "restish api set") {
+		t.Fatalf("stderr suggested mutating read-only project API:\n%s", gotErr)
 	}
 }
 

--- a/internal/cli/project_config_test.go
+++ b/internal/cli/project_config_test.go
@@ -168,7 +168,8 @@ func TestProjectConfigShowOmitsEmptyAPIList(t *testing.T) {
 
 func TestProjectConfigRejectsEmptyUnsupportedTopLevelKeys(t *testing.T) {
 	_, _, projectDir := setupProjectConfigTest(t)
-	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+	projectPath := filepath.Join(projectDir, ".restish.json")
+	writeProjectConfigTestFile(t, projectPath, `{
   "apis": {},
   "auth_profiles": {}
 }`)
@@ -176,8 +177,14 @@ func TestProjectConfigRejectsEmptyUnsupportedTopLevelKeys(t *testing.T) {
 
 	c, _, _ := newProjectConfigTestCLI(t)
 	err := c.Run([]string{"restish", "config", "trust"})
-	if err == nil || !strings.Contains(err.Error(), "only apis and theme are supported") {
-		t.Fatalf("config trust err = %v, want unsupported top-level key error", err)
+	if err == nil {
+		t.Fatal("config trust err = nil, want unsupported top-level key error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "unsupported top-level key \"auth_profiles\"") ||
+		!strings.Contains(got, projectPath) ||
+		!strings.Contains(got, "only apis and theme are supported") {
+		t.Fatalf("config trust err = %v, want path and unsupported top-level key", err)
 	}
 }
 

--- a/internal/cli/project_config_test.go
+++ b/internal/cli/project_config_test.go
@@ -135,6 +135,47 @@ func TestConfigTrustLayersProjectConfigAndRetrustsOnChange(t *testing.T) {
 	}
 }
 
+func TestProjectConfigShowOmitsEmptyAPIList(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	projectPath := filepath.Join(projectDir, ".restish.json")
+	writeProjectConfigTestFile(t, projectPath, `{
+  "theme": {"keyword": "#ff00ff"}
+}`)
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+
+	c, out, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "show"}); err != nil {
+		t.Fatalf("config show: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Project config: ") || !strings.Contains(got, ".restish.json") {
+		t.Fatalf("config show output = %q, want project config path", got)
+	}
+	if strings.Contains(got, "()") {
+		t.Fatalf("config show output = %q, want no empty project API list", got)
+	}
+}
+
+func TestProjectConfigRejectsEmptyUnsupportedTopLevelKeys(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {},
+  "auth_profiles": {}
+}`)
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	err := c.Run([]string{"restish", "config", "trust"})
+	if err == nil || !strings.Contains(err.Error(), "only apis and theme are supported") {
+		t.Fatalf("config trust err = %v, want unsupported top-level key error", err)
+	}
+}
+
 func TestProjectConfigAPIsAreReadOnlyForMutatingCommands(t *testing.T) {
 	_, _, projectDir := setupProjectConfigTest(t)
 	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{

--- a/internal/cli/project_config_test.go
+++ b/internal/cli/project_config_test.go
@@ -1,0 +1,313 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	restishcli "github.com/rest-sh/restish/v2/internal/cli"
+)
+
+func newProjectConfigTestCLI(t *testing.T) (*restishcli.CLI, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	c := restishcli.New()
+	c.Stdin = strings.NewReader("")
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	c.Hooks().PassReader = strings.NewReader("")
+	c.Hooks().RetryBaseDelay = time.Millisecond
+	return c, &stdout, &stderr
+}
+
+func setupProjectConfigTest(t *testing.T) (configDir, cacheDir, projectDir string) {
+	t.Helper()
+	root := t.TempDir()
+	configDir = filepath.Join(root, "config")
+	cacheDir = filepath.Join(root, "cache")
+	projectDir = filepath.Join(root, "repo")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	t.Setenv("RSH_CONFIG_DIR", configDir)
+	t.Setenv("RSH_CACHE_DIR", cacheDir)
+	return configDir, cacheDir, projectDir
+}
+
+func writeProjectConfigTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestProjectConfigRequiresTrustBeforeLayering(t *testing.T) {
+	configDir, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(configDir, "restish.json"), `{
+  "apis": {
+    "global": {"base_url": "https://global.example.com"}
+  }
+}`)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "project": {"base_url": "https://project.example.com"}
+  }
+}`)
+	t.Chdir(projectDir)
+
+	c, out, stderr := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "show"}); err != nil {
+		t.Fatalf("config show: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "global") || strings.Contains(got, "project.example.com") {
+		t.Fatalf("config show output = %q, want global only", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "is not trusted") || !strings.Contains(got, "config trust") {
+		t.Fatalf("stderr = %q, want untrusted project config warning", got)
+	}
+}
+
+func TestConfigTrustLayersProjectConfigAndRetrustsOnChange(t *testing.T) {
+	configDir, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(configDir, "restish.json"), `{
+  "apis": {
+    "svc": {"base_url": "https://global.example.com"},
+    "global": {"base_url": "https://only-global.example.com"}
+  },
+  "theme": {"string": "#00ff00"}
+}`)
+	projectPath := filepath.Join(projectDir, ".restish.json")
+	writeProjectConfigTestFile(t, projectPath, `{
+  "apis": {
+    "svc": {"base_url": "https://project.example.com"}
+  },
+  "theme": {"keyword": "#ff00ff"}
+}`)
+	t.Chdir(filepath.Join(projectDir))
+
+	c, out, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "Trusted project config") || !strings.Contains(got, "svc") {
+		t.Fatalf("config trust output = %q", got)
+	}
+
+	c, out, _ = newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "show"}); err != nil {
+		t.Fatalf("trusted config show: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Project config:") || !strings.Contains(got, projectPath) {
+		t.Fatalf("config show output = %q, want project config line", got)
+	}
+	if !strings.Contains(got, "https://project.example.com") || strings.Contains(got, "https://global.example.com") {
+		t.Fatalf("config show output = %q, want project API to shadow global API", got)
+	}
+	if !strings.Contains(got, "global") {
+		t.Fatalf("config show output = %q, want unrelated global API preserved", got)
+	}
+
+	writeProjectConfigTestFile(t, projectPath, `{
+  "apis": {
+    "svc": {"base_url": "https://changed.example.com"}
+  }
+}`)
+	c, out, stderr := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "show"}); err != nil {
+		t.Fatalf("changed config show: %v", err)
+	}
+	if strings.Contains(out.String(), "changed.example.com") {
+		t.Fatalf("changed untrusted project config was loaded: %q", out.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "is not trusted") {
+		t.Fatalf("stderr = %q, want retrust warning", got)
+	}
+}
+
+func TestProjectConfigAPIsAreReadOnlyForMutatingCommands(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "project": {"base_url": "https://project.example.com"}
+  }
+}`)
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+
+	c, _, _ = newProjectConfigTestCLI(t)
+	err := c.Run([]string{"restish", "api", "set", "project", "base_url: https://other.example.com"})
+	if err == nil || !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("api set err = %v, want read-only project API error", err)
+	}
+}
+
+func TestProjectConfigDoesNotPersistThroughGlobalAPIRemove(t *testing.T) {
+	configDir, _, projectDir := setupProjectConfigTest(t)
+	globalPath := filepath.Join(configDir, "restish.json")
+	writeProjectConfigTestFile(t, globalPath, `{
+  "apis": {
+    "global": {"base_url": "https://global.example.com"}
+  }
+}`)
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "project": {"base_url": "https://project.example.com"}
+  },
+  "theme": {"keyword": "#ff00ff"}
+}`)
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+	c, _, _ = newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "api", "remove", "global"}); err != nil {
+		t.Fatalf("api remove global: %v", err)
+	}
+
+	data, err := os.ReadFile(globalPath)
+	if err != nil {
+		t.Fatalf("read global config: %v", err)
+	}
+	if strings.Contains(string(data), "project.example.com") || strings.Contains(string(data), "ff00ff") {
+		t.Fatalf("global config persisted project config: %s", data)
+	}
+	if strings.Contains(string(data), "global.example.com") {
+		t.Fatalf("global API was not removed: %s", data)
+	}
+}
+
+func TestProjectConfigCanReferenceGlobalAuthProfiles(t *testing.T) {
+	configDir, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFile(t, filepath.Join(configDir, "restish.json"), `{
+  "auth_profiles": {
+    "shared": {"type": "bearer", "params": {"token": "global-token"}}
+  }
+}`)
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), fmt.Sprintf(`{
+  "apis": {
+    "svc": {
+      "base_url": %q,
+      "profiles": {
+        "default": {"auth_ref": "shared"}
+      }
+    }
+  }
+}`, server.URL))
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+	c, _, _ = newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "get", "svc/anything", "-f", "body", "-o", "json"}); err != nil {
+		t.Fatalf("project API request: %v", err)
+	}
+	if authHeader != "Bearer global-token" {
+		t.Fatalf("Authorization = %q, want Bearer global-token", authHeader)
+	}
+}
+
+func TestProjectConfigRelativeSpecFilesGenerateCommandsInProjectNamespace(t *testing.T) {
+	_, cacheDir, projectDir := setupProjectConfigTest(t)
+	var requestedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, "openapi.yaml"), fmt.Sprintf(`openapi: "3.1.0"
+info:
+  title: Project API
+  version: "1.0"
+servers:
+  - url: %s
+paths:
+  /ping:
+    get:
+      operationId: getPing
+      responses:
+        "200":
+          description: OK
+`, server.URL))
+	writeProjectConfigTestFile(t, filepath.Join(projectDir, ".restish.json"), fmt.Sprintf(`{
+  "apis": {
+    "svc": {
+      "base_url": %q,
+      "spec_files": ["openapi.yaml"]
+    }
+  }
+}`, server.URL))
+	t.Chdir(projectDir)
+
+	c, _, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+
+	c, out, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "svc", "get-ping", "-f", "body", "-o", "json"}); err != nil {
+		t.Fatalf("generated command: %v", err)
+	}
+	if requestedPath != "/ping" {
+		t.Fatalf("requested path = %q, want /ping", requestedPath)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(out.Bytes(), &body); err != nil {
+		t.Fatalf("decode output %q: %v", out.String(), err)
+	}
+	if body["ok"] != true {
+		t.Fatalf("output body = %#v, want ok true", body)
+	}
+
+	specFiles, err := filepath.Glob(filepath.Join(cacheDir, "specs", "project-*-svc.cbor"))
+	if err != nil {
+		t.Fatalf("glob spec cache: %v", err)
+	}
+	if len(specFiles) != 1 {
+		t.Fatalf("project spec cache files = %v, want one namespaced cache file", specFiles)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "specs", "svc.cbor")); !os.IsNotExist(err) {
+		t.Fatalf("global spec cache exists for project API: %v", err)
+	}
+
+	c, out, _ = newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "svc", "--help"}); err != nil {
+		t.Fatalf("project API help: %v", err)
+	}
+	if !strings.Contains(out.String(), "get-ping") {
+		t.Fatalf("project API help = %q, want generated command from trusted project config", out.String())
+	}
+
+	c, out, _ = newProjectConfigTestCLI(t)
+	_ = c.Run([]string{"restish", "__complete", "svc", ""})
+	if !strings.Contains(out.String(), "get-ping") {
+		t.Fatalf("project API completion = %q, want generated command from trusted project config", out.String())
+	}
+}

--- a/internal/cli/project_config_test.go
+++ b/internal/cli/project_config_test.go
@@ -43,10 +43,15 @@ func setupProjectConfigTest(t *testing.T) (configDir, cacheDir, projectDir strin
 
 func writeProjectConfigTestFile(t *testing.T, path, body string) {
 	t.Helper()
+	writeProjectConfigTestFileMode(t, path, body, 0o600)
+}
+
+func writeProjectConfigTestFileMode(t *testing.T, path, body string, mode os.FileMode) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }
@@ -173,6 +178,118 @@ func TestProjectConfigRejectsEmptyUnsupportedTopLevelKeys(t *testing.T) {
 	err := c.Run([]string{"restish", "config", "trust"})
 	if err == nil || !strings.Contains(err.Error(), "only apis and theme are supported") {
 		t.Fatalf("config trust err = %v, want unsupported top-level key error", err)
+	}
+}
+
+func TestProjectConfigAllowsCommittedFileWithEnvSecretReferences(t *testing.T) {
+	_, _, projectDir := setupProjectConfigTest(t)
+	writeProjectConfigTestFileMode(t, filepath.Join(projectDir, ".restish.json"), `{
+  "apis": {
+    "svc": {
+      "base_url": "https://project.example.com",
+      "profiles": {
+        "default": {
+          "auth": {
+            "type": "oauth-client-credentials",
+            "params": {
+              "client_id": "public-client",
+              "client_secret": "env:PROJECT_CLIENT_SECRET",
+              "token_url": "https://auth.example.com/token",
+              "audience": "https://api.example.com"
+            }
+          }
+        }
+      }
+    }
+  }
+}`, 0o644)
+	t.Chdir(projectDir)
+
+	c, out, _ := newProjectConfigTestCLI(t)
+	if err := c.Run([]string{"restish", "config", "trust"}); err != nil {
+		t.Fatalf("config trust: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "Trusted project config") || !strings.Contains(got, "svc") {
+		t.Fatalf("config trust output = %q", got)
+	}
+}
+
+func TestProjectConfigRejectsInlineSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "auth secret param",
+			body: `{
+  "apis": {
+    "svc": {
+      "base_url": "https://project.example.com",
+      "profiles": {
+        "default": {
+          "auth": {
+            "type": "oauth-client-credentials",
+            "params": {
+              "client_id": "public-client",
+              "client_secret": "inline-secret",
+              "token_url": "https://auth.example.com/token",
+              "audience": "https://api.example.com"
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+			want: "params.client_secret",
+		},
+		{
+			name: "credential-bearing header",
+			body: `{
+  "apis": {
+    "svc": {
+      "base_url": "https://project.example.com",
+      "profiles": {
+        "default": {
+          "headers": ["Authorization: Bearer inline-secret"]
+        }
+      }
+    }
+  }
+}`,
+			want: "credential-bearing header",
+		},
+		{
+			name: "credential-bearing query param",
+			body: `{
+  "apis": {
+    "svc": {
+      "base_url": "https://project.example.com",
+      "profiles": {
+        "default": {
+          "query": ["api_key=inline-secret"]
+        }
+      }
+    }
+  }
+}`,
+			want: "credential-bearing query parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, projectDir := setupProjectConfigTest(t)
+			writeProjectConfigTestFileMode(t, filepath.Join(projectDir, ".restish.json"), tt.body, 0o644)
+			t.Chdir(projectDir)
+
+			c, _, _ := newProjectConfigTestCLI(t)
+			err := c.Run([]string{"restish", "config", "trust"})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("config trust err = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -61,7 +61,7 @@ func (c *CLI) prepareRequest(
 		}
 		apiName = explicitAPIName
 		if opts.CacheNamespace == "" {
-			opts.CacheNamespace = apiName + ":" + profileName
+			opts.CacheNamespace = c.apiCacheNamespace(apiName, profileName)
 		}
 	}
 	if !noAuth && operationAuth == nil && apiName != "" && !explicitCredentialContext {

--- a/site/content/en/docs/getting-started/connect-to-an-api.md
+++ b/site/content/en/docs/getting-started/connect-to-an-api.md
@@ -87,17 +87,18 @@ prefix.
 
 ## Project Config
 
-Use an explicit config file when a project should carry its own Restish setup:
+Use `.restish.json` when a project should carry shared Restish API setup:
 
 ```bash
-restish --rsh-config ./restish.json api connect example api.rest.sh
-restish --rsh-config ./restish.json example list-images
+restish config trust
+restish example list-images
 ```
 
-An explicit config file is the source of truth for that invocation. It is not
-merged with the global config. Restish does not automatically discover
-`./restish.json`; keep passing `--rsh-config` or set `RSH_CONFIG` when a project
-should use that file.
+Restish discovers `.restish.json` in the current directory or a parent, but only
+uses it after you trust the file. Trusted project config layers project APIs and
+theme over your global config. If you want one command to use a project file as
+the complete config source, pass `--rsh-config .restish.json` or set
+`RSH_CONFIG`.
 
 ## Next Step
 

--- a/site/content/en/docs/getting-started/connect-to-an-api.md
+++ b/site/content/en/docs/getting-started/connect-to-an-api.md
@@ -100,6 +100,11 @@ theme over your global config. If you want one command to use a project file as
 the complete config source, pass `--rsh-config .restish.json` or set
 `RSH_CONFIG`.
 
+Keep committed project config secret-free. Shared OAuth values such as
+`client_id`, `audience`, scopes, and endpoint URLs can live there; API key
+values, bearer tokens, passwords, and OAuth client secrets should be omitted or
+referenced as `env:NAME`.
+
 ## Next Step
 
 [Set Up Profiles](../set-up-profiles/) when repeated headers, auth, environment

--- a/site/content/en/docs/guides/api-setup-and-discovery.md
+++ b/site/content/en/docs/guides/api-setup-and-discovery.md
@@ -88,6 +88,11 @@ global config and refuse to mutate project APIs; edit `.restish.json` directly
 or pass `--rsh-config .restish.json` when you intentionally want that file to be
 the complete config source for the command.
 
+Committed `.restish.json` files should contain shared setup, not inline secrets.
+Use non-secret values such as OAuth `client_id`, `audience`, scopes, and endpoint
+URLs directly; use `env:NAME` references or omit values for API key values,
+bearer tokens, passwords, and OAuth client secrets.
+
 ## Sync After Spec Changes
 
 ```bash

--- a/site/content/en/docs/guides/api-setup-and-discovery.md
+++ b/site/content/en/docs/guides/api-setup-and-discovery.md
@@ -72,14 +72,21 @@ Keep it path-only. Use `base_url` for scheme and host.
 ## Project Config Files
 
 ```bash
-restish --rsh-config ./restish.json api connect example api.rest.sh
-restish --rsh-config ./restish.json api list
+restish config trust
+restish api list
 ```
 
-An explicit config file is not merged with the global config. Missing explicit
-files fail clearly instead of silently falling back. Restish does not
-automatically discover project config from the current directory; pass
-`--rsh-config` or set `RSH_CONFIG` when a repository should use its own config.
+If a repository has `.restish.json`, Restish discovers it from the current
+directory or a parent but does not use it until you trust it. Trust is stored in
+your user config state and includes the file's content hash, so changed project
+config has to be trusted again.
+
+Trusted project config layers project `apis` and `theme` over your global
+config. Project APIs override global APIs with the same name, but unrelated
+global APIs remain available. Normal config-writing commands still write your
+global config and refuse to mutate project APIs; edit `.restish.json` directly
+or pass `--rsh-config .restish.json` when you intentionally want that file to be
+the complete config source for the command.
 
 ## Sync After Spec Changes
 

--- a/site/content/en/docs/guides/troubleshooting.md
+++ b/site/content/en/docs/guides/troubleshooting.md
@@ -87,8 +87,9 @@ export RSH_CONFIG_DIR="$HOME/.config/restish"
 export RSH_CACHE_DIR="$HOME/.cache/restish"
 ```
 
-For project-local config, use `RSH_CONFIG=/absolute/path/restish.json` or
-`--rsh-config /absolute/path/restish.json`.
+For project-local config, use `.restish.json` plus `restish config trust`, or
+select a complete config explicitly with `RSH_CONFIG=/absolute/path/.restish.json`
+or `--rsh-config /absolute/path/.restish.json`.
 
 **Related docs:** [Config](/docs/reference/config/), [Environment Variables](/docs/reference/environment-variables/).
 

--- a/site/content/en/docs/reference/config-command.md
+++ b/site/content/en/docs/reference/config-command.md
@@ -19,6 +19,7 @@ For field-level config structure and precedence, see [Config](../config/).
 restish config path
 restish config show
 restish config show -o json
+restish config trust
 restish config set 'cache.max_size: 500MB'
 restish config theme list
 restish config theme set one-dark-pro
@@ -67,6 +68,8 @@ Subcommands:
 **`restish config show`**: Print the active config summary or redacted JSON
 
 **`restish config theme`**: Manage terminal output highlighting theme
+
+**`restish config trust`**: Trust the project config discovered from this directory
 
 
 ### `restish config path`

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -56,9 +56,10 @@ APIs override global APIs with the same name, while unrelated global APIs remain
 available. Normal config-writing commands still write the global config and
 refuse to mutate APIs that came from trusted project config.
 
-Use `--rsh-config ./restish.json` or `RSH_CONFIG=./restish.json` when a command
-should use one complete project config file instead of layering trusted project
-config over the global config.
+Use `--rsh-config ./.restish.json` or `RSH_CONFIG=./.restish.json` when a
+command should use one complete project config file instead of layering trusted
+project config over the global config. Explicit config selection can point to
+any filename; `.restish.json` is only the auto-discovered project filename.
 
 On Unix-like systems, Restish refuses group/world-readable config files because
 profiles and auth settings may contain secrets:

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -41,9 +41,24 @@ If no default config directory can be determined, set `RSH_CONFIG` or
 Cache-only state may use a temporary directory until `RSH_CACHE_DIR` or
 `XDG_CACHE_HOME` is available.
 
-Restish does not search the current directory or parent directories for project
-config in v2. Use `--rsh-config ./restish.json` or `RSH_CONFIG=./restish.json`
-when a repository should carry its own config.
+When no explicit config is selected, Restish searches the current directory and
+parents for `.restish.json`. A discovered project config is ignored until you
+trust it:
+
+```bash
+restish config trust
+```
+
+Trust is stored outside the repository and includes the file's content hash. If
+`.restish.json` changes, run `restish config trust` again after reviewing it.
+Trusted project config layers `apis` and `theme` over your global config. Project
+APIs override global APIs with the same name, while unrelated global APIs remain
+available. Normal config-writing commands still write the global config and
+refuse to mutate APIs that came from trusted project config.
+
+Use `--rsh-config ./restish.json` or `RSH_CONFIG=./restish.json` when a command
+should use one complete project config file instead of layering trusted project
+config over the global config.
 
 On Unix-like systems, Restish refuses group/world-readable config files because
 profiles and auth settings may contain secrets:

--- a/site/content/en/docs/reference/config.md
+++ b/site/content/en/docs/reference/config.md
@@ -56,6 +56,12 @@ APIs override global APIs with the same name, while unrelated global APIs remain
 available. Normal config-writing commands still write the global config and
 refuse to mutate APIs that came from trusted project config.
 
+Project config is safe to commit when it contains only shared, non-secret setup.
+Secret auth params such as API key values, bearer tokens, passwords, and OAuth
+client secrets must be omitted or written as `env:NAME` references. Non-secret
+values such as OAuth `client_id`, `audience`, issuer URLs, token URLs, and scopes
+can live in `.restish.json`.
+
 Use `--rsh-config ./.restish.json` or `RSH_CONFIG=./.restish.json` when a
 command should use one complete project config file instead of layering trusted
 project config over the global config. Explicit config selection can point to


### PR DESCRIPTION
## Summary

- Adds trusted `.restish.json` discovery from the current directory or parents.
- Adds `restish config trust` with path+content-hash trust stored outside the repo.
- Layers trusted project `apis` and `theme` over global config while keeping project APIs read-only for normal mutation commands.
- Namespaces project API spec cache, HTTP cache, and API-scoped OAuth token cache outside the repo.
- Updates design docs and user docs for the new trust model.

Fixes #239.

Related to #263 by @tarunKoyalwar and #303 by @richard-hajek. Thanks to both original authors for exploring the project-config workflow and edge cases.

## Validation

- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run TestProjectConfig`
- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli`
- `env GOCACHE=/tmp/restish-gocache go test ./...`
- `env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check`
- `hugo --source site --quiet --gc --minify --cacheDir /tmp/restish-hugo-cache`
- `git diff --check`
- `env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...`

## Review

Ran a no-context sub-agent review. It found three issues: project config could leak into global config on `api remove`, trusted project APIs were skipped for help/completion bootstrap commands, and project APIs could not reference global auth profiles. All three were fixed with targeted tests.
