### PR TITLE
refactor: replace interface{} with any (Go 1.18+ alias)

### DIFF
--- a/internal/content/registry.go
+++ b/internal/content/registry.go
@@ -234,7 +234,7 @@ func (r *Registry) Decode(mimeType string, data []byte) (any, error) {
 
 // makeJSONSafe recursively converts all map keys to strings so that the
 // result can always be marshalled by encoding/json. Some decoders (e.g.
-// CBOR, msgpack) produce map[interface{}]interface{} with non-string keys.
+// CBOR, msgpack) produce map[any]any with non-string keys.
 func makeJSONSafe(v any) any {
 	val := reflect.ValueOf(v)
 	for val.Kind() == reflect.Ptr {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -15,7 +15,7 @@ const (
 )
 
 // DecMode is a CBOR decode mode configured to use map[string]any for all CBOR
-// maps (including nested ones), rather than the default map[interface{}]interface{}.
+// maps (including nested ones), rather than the default map[any]any.
 // It also applies the same structural limits that Restish uses for plugin
 // messages, so buggy plugins cannot force unbounded map, array, or nesting
 // allocations before typed validation runs.


### PR DESCRIPTION
Replaces all deprecated interface{} with the any type alias available since Go 1.18. The project already uses Go 1.24.

Fixes #315