### PR TITLE
fix: reuse stale raw spec for generated commands

### DIFF
--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -790,7 +790,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	if forceRefresh {
 		s, err = c.discoverSpecForProfile(ctx, apiName, profileName, true, 0)
 	} else {
-		s, err = spec.LoadFromCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiCfg.SpecFiles, c.loaders)
+		s, err = spec.LoadStaleFromCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiCfg.SpecFiles, c.loaders)
 	}
 	if err != nil || s == nil {
 		if !spec.HasLocalSpecFiles(apiCfg.SpecFiles) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -640,7 +640,7 @@ func (c *CLI) Run(args []string) error {
 			}
 			continue
 		}
-		s, err := spec.LoadFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
+		s, err := spec.LoadStaleFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
 		if err != nil {
 			continue
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -885,7 +885,11 @@ func (c *CLI) refreshStaleGeneratedMetadataForCommand(ctx context.Context, scan 
 		OperationBase:   effectiveOperationBase(apiCfg, scan.ProfileName),
 		ServerVariables: effectiveServerVariables(apiCfg, scan.ProfileName),
 	}
-	_, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), c.apiStateName(scan.FirstCommand), Version, apiCfg.SpecFiles, opts, true)
+	stateName := c.apiStateName(scan.FirstCommand)
+	_, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, true)
+	if !ok {
+		status, ok = spec.RawSpecCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles)
+	}
 	if !ok || !status.Stale {
 		return
 	}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -229,7 +229,7 @@ func (c *CLI) completionOperationSet(cmd *cobra.Command, apiName string, apiCfg 
 	if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opOpts, true); ok {
 		return set, true
 	}
-	s, err := spec.LoadFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
+	s, err := spec.LoadStaleFromCache(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, c.loaders)
 	if err != nil {
 		return spec.OperationSet{}, false
 	}

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -551,6 +551,53 @@ func TestGeneratedCommandRefreshesStaleOperationCacheOnUse(t *testing.T) {
 	}
 }
 
+func TestGeneratedCommandRefreshesStaleRawSpecWhenOperationCacheMissing(t *testing.T) {
+	var specHits atomic.Int32
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		specHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, specWithOperations(serverURL))
+	})
+	mux.HandleFunc("/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	serverURL = srv.URL
+
+	cfgData, _ := json.Marshal(&config.Config{
+		APIs: map[string]*config.APIConfig{
+			"tapi": {BaseURL: srv.URL},
+		},
+	})
+	cfgFile := t.TempDir() + "/restish.json"
+	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	env := &generatedEnv{cfgFile: cfgFile, cacheDir: t.TempDir()}
+	syncCLI := env.newCLI()
+	if err := syncCLI.Run([]string{"restish", "api", "sync", "tapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	hitsAfterSync := specHits.Load()
+	expireGeneratedSpecCache(t, env.cacheDir, "tapi")
+	removeGeneratedOperationCache(t, env.cacheDir, "tapi")
+
+	c := env.newCLI()
+	var out strings.Builder
+	c.Stdout = &out
+	if err := c.Run([]string{"restish", "tapi", "list-items"}); err != nil {
+		t.Fatalf("generated command from stale raw spec: %v", err)
+	}
+	if got := specHits.Load(); got <= hitsAfterSync {
+		t.Fatalf("expected stale raw spec command to refresh spec metadata; spec hits before=%d after=%d", hitsAfterSync, got)
+	}
+}
+
 func TestGeneratedCommandUsesOperationCacheForExternalRefsOffline(t *testing.T) {
 	var paramsAvailable atomic.Bool
 	paramsAvailable.Store(true)

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -332,6 +332,27 @@ func expireGeneratedSpecCache(t *testing.T, cacheDir, apiName string) {
 	}
 }
 
+func removeGeneratedOperationCache(t *testing.T, cacheDir, apiName string) {
+	t.Helper()
+	path := filepath.Join(cacheDir, apiName+".cbor")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read spec cache: %v", err)
+	}
+	var entry map[string]any
+	if err := cbor.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("decode spec cache: %v", err)
+	}
+	delete(entry, "operations")
+	data, err = cbor.Marshal(entry)
+	if err != nil {
+		t.Fatalf("encode spec cache: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write spec cache: %v", err)
+	}
+}
+
 type countingLoader struct {
 	detects atomic.Int32
 }
@@ -453,6 +474,34 @@ func TestGeneratedAPIHelpUsesStaleOperationCache(t *testing.T) {
 	}
 	if got := loader.detects.Load(); got != 0 {
 		t.Fatalf("loader Detect called %d times, want 0 when API help loads from stale cached operations", got)
+	}
+}
+
+func TestGeneratedAPIHelpRebuildsMissingOperationCacheFromStaleRawSpec(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupGeneratedEnv(t, mux)
+	expireGeneratedSpecCache(t, env.cacheDir, "tapi")
+	removeGeneratedOperationCache(t, env.cacheDir, "tapi")
+	c, out := env.newCaptureCLI()
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		return nil, errors.New("generated help should use the stale raw spec cache")
+	})
+
+	if err := c.Run([]string{"restish", "tapi", "--help"}); err != nil {
+		t.Fatalf("tapi --help: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "list-items") {
+		t.Fatalf("expected generated operations rebuilt from stale raw spec, got:\n%s", got)
+	}
+	if strings.Contains(got, "Generic requests using") {
+		t.Fatalf("expected generated API help, got generic short-name help:\n%s", got)
 	}
 }
 

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -267,6 +267,27 @@ func LoadOperationSetFromCacheStatus(cacheDir, apiName, version string, specFile
 	return OperationSet{}, status, false
 }
 
+// RawSpecCacheStatus reports the freshness of the cached raw spec. Expired
+// remote specs can still report status; local spec file changes invalidate the
+// cache because the local source is authoritative.
+func RawSpecCacheStatus(cacheDir, apiName, version string, specFiles []string) (OperationCacheStatus, bool) {
+	entry, ok := readCacheEntry(cacheDir, apiName, version, true)
+	if !ok {
+		return OperationCacheStatus{}, false
+	}
+	if !cacheSpecFilesMatch(specFiles, entry) {
+		return OperationCacheStatus{}, false
+	}
+	if specFilesChangedSince(specFiles, entry.FetchedAt) {
+		return OperationCacheStatus{}, false
+	}
+	return OperationCacheStatus{
+		FetchedAt: entry.FetchedAt,
+		ExpiresAt: entry.ExpiresAt,
+		Stale:     !entry.ExpiresAt.IsZero() && time.Now().After(entry.ExpiresAt),
+	}, true
+}
+
 // StoreOperationSetInCache updates an existing raw cache entry with extracted
 // operations and API metadata. It is best-effort for callers; failed upgrades
 // should not make startup fail when the raw cache can still be parsed. Expired

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -183,7 +183,18 @@ func (e *cacheEntry) loadOptions() LoadOptions {
 // LoadFromCache reads the cached spec for apiName, re-parses it using loaders,
 // and returns the result. Returns nil, nil when the cache is empty or expired.
 func LoadFromCache(cacheDir, apiName, version string, specFiles []string, loaders []Loader) (*APISpec, error) {
-	entry, ok := readCache(cacheDir, apiName, version)
+	return loadFromCache(cacheDir, apiName, version, specFiles, loaders, false)
+}
+
+// LoadStaleFromCache reads the cached spec for apiName even when the remote
+// cache entry has expired. Local spec files still invalidate stale cache data
+// when they changed after the cache was written.
+func LoadStaleFromCache(cacheDir, apiName, version string, specFiles []string, loaders []Loader) (*APISpec, error) {
+	return loadFromCache(cacheDir, apiName, version, specFiles, loaders, true)
+}
+
+func loadFromCache(cacheDir, apiName, version string, specFiles []string, loaders []Loader, allowExpired bool) (*APISpec, error) {
+	entry, ok := readCacheEntry(cacheDir, apiName, version, allowExpired)
 	if !ok {
 		return nil, nil
 	}
@@ -258,11 +269,12 @@ func LoadOperationSetFromCacheStatus(cacheDir, apiName, version string, specFile
 
 // StoreOperationSetInCache updates an existing raw cache entry with extracted
 // operations and API metadata. It is best-effort for callers; failed upgrades
-// should not make startup fail when the raw cache can still be parsed. The
-// cache entry is keyed by base URL, operation base, and server variable values
-// (via opts).
+// should not make startup fail when the raw cache can still be parsed. Expired
+// entries can be upgraded so rebuilt operation metadata is durable, but the
+// original cache TTL is preserved. The cache entry is keyed by base URL,
+// operation base, and server variable values (via opts).
 func StoreOperationSetInCache(cacheDir, apiName, version string, opts OperationOptions, set OperationSet) error {
-	entry, ok := readCache(cacheDir, apiName, version)
+	entry, ok := readCacheEntry(cacheDir, apiName, version, true)
 	if !ok {
 		return nil
 	}

--- a/internal/spec/cache_test.go
+++ b/internal/spec/cache_test.go
@@ -156,6 +156,33 @@ func TestLoadFromCache(t *testing.T) {
 	}
 }
 
+func TestLoadStaleFromCacheAllowsExpiredRemoteSpec(t *testing.T) {
+	dir := t.TempDir()
+	entry := &cacheEntry{
+		Version:     "v2",
+		ExpiresAt:   time.Now().Add(-time.Hour),
+		ContentType: "application/json",
+		Raw:         []byte(testSpecRaw),
+	}
+	writeCache(dir, "testapi", entry)
+
+	fresh, err := LoadFromCache(dir, "testapi", "v2", nil, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("LoadFromCache: %v", err)
+	}
+	if fresh != nil {
+		t.Fatal("expected regular cache load to reject expired entry")
+	}
+
+	stale, err := LoadStaleFromCache(dir, "testapi", "v2", nil, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("LoadStaleFromCache: %v", err)
+	}
+	if stale == nil {
+		t.Fatal("expected stale cache load to allow expired entry")
+	}
+}
+
 func TestLoadFromCache_Miss(t *testing.T) {
 	spec, err := LoadFromCache(t.TempDir(), "nonexistent", "v2", nil, DefaultLoaders())
 	if err != nil {
@@ -267,6 +294,54 @@ func TestLoadOperationSetFromCacheStatusAllowsStaleRemoteMetadata(t *testing.T) 
 	}
 	if !status.Stale {
 		t.Fatal("expected stale status")
+	}
+	if len(got.Operations) != 1 || got.Operations[0].ID != "listItems" {
+		t.Fatalf("unexpected operations: %#v", got.Operations)
+	}
+}
+
+func TestStoreOperationSetInCacheUpgradesExpiredRemoteCache(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte(`{"openapi":"3.1.0","info":{"title":"Test","version":"1.0.0"},"paths":{"/items":{"get":{"operationId":"listItems","responses":{"200":{"description":"OK"}}}}}}`)
+	loaded, err := load("application/json", raw, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	set, err := loaded.OperationSet(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("operation set: %v", err)
+	}
+
+	expiresAt := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	entry := &cacheEntry{
+		Version:   "v2",
+		FetchedAt: time.Now().Add(-48 * time.Hour),
+		ExpiresAt: expiresAt,
+		Spec: cachedRaw{
+			ContentType: "application/json",
+			Raw:         raw,
+		},
+	}
+	if err := writeCache(dir, "testapi", entry); err != nil {
+		t.Fatalf("writeCache: %v", err)
+	}
+
+	opts := OperationOptions{BaseURL: "https://api.example.com"}
+	if err := StoreOperationSetInCache(dir, "testapi", "v2", opts, set); err != nil {
+		t.Fatalf("StoreOperationSetInCache: %v", err)
+	}
+	if _, ok := LoadOperationSetFromCache(dir, "testapi", "v2", nil, opts); ok {
+		t.Fatal("fresh-only operation cache should still miss expired metadata")
+	}
+	got, status, ok := LoadOperationSetFromCacheStatus(dir, "testapi", "v2", nil, opts, true)
+	if !ok {
+		t.Fatal("expected stale operation cache hit after upgrade")
+	}
+	if !status.Stale {
+		t.Fatal("expected cache to remain stale after operation upgrade")
+	}
+	if !status.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expires_at = %v, want %v", status.ExpiresAt, expiresAt)
 	}
 	if len(got.Operations) != 1 || got.Operations[0].ID != "listItems" {
 		t.Fatalf("unexpected operations: %#v", got.Operations)

--- a/internal/spec/cache_test.go
+++ b/internal/spec/cache_test.go
@@ -183,6 +183,34 @@ func TestLoadStaleFromCacheAllowsExpiredRemoteSpec(t *testing.T) {
 	}
 }
 
+func TestRawSpecCacheStatusReportsExpiredRemoteSpec(t *testing.T) {
+	dir := t.TempDir()
+	fetchedAt := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	expiresAt := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	entry := &cacheEntry{
+		Version:     "v2",
+		FetchedAt:   fetchedAt,
+		ExpiresAt:   expiresAt,
+		ContentType: "application/json",
+		Raw:         []byte(testSpecRaw),
+	}
+	writeCache(dir, "testapi", entry)
+
+	status, ok := RawSpecCacheStatus(dir, "testapi", "v2", nil)
+	if !ok {
+		t.Fatal("expected raw spec cache status")
+	}
+	if !status.Stale {
+		t.Fatal("expected expired raw spec to report stale")
+	}
+	if !status.FetchedAt.Equal(fetchedAt) {
+		t.Fatalf("fetched_at = %v, want %v", status.FetchedAt, fetchedAt)
+	}
+	if !status.ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("expires_at = %v, want %v", status.ExpiresAt, expiresAt)
+	}
+}
+
 func TestLoadFromCache_Miss(t *testing.T) {
 	spec, err := LoadFromCache(t.TempDir(), "nonexistent", "v2", nil, DefaultLoaders())
 	if err != nil {


### PR DESCRIPTION
## Summary
- rebuild generated API commands from stale raw spec cache when operation metadata is missing or incompatible
- apply the same recovery path to startup registration, completions, and operation lookup
- add a regression test for expired raw spec cache with missing generated operation metadata

## Tests
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./internal/spec