### PR TITLE
fix(cli): color filtered TTY output

### DIFF
--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -302,6 +302,27 @@ func TestFilteredStructuredOutputPrettyByDefault(t *testing.T) {
 	}
 }
 
+func TestFilteredTTYOutputColorsPrettyJSONByDefault(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("NOCOLOR", "")
+	t.Setenv("COLOR", "1")
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return true }
+	useJSONResponse(c, 200, `{"object":{"url":"https://api.example.com","z":1}}`)
+	if err := c.Run([]string{"restish", "get", "-f", "body.object", "https://api.example.com/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "\x1b[") {
+		t.Fatalf("expected filtered TTY output to include ANSI color, got:\n%s", got)
+	}
+	if stripped, want := stripANSI(got), "{\n  \"url\": \"https://api.example.com\",\n  \"z\": 1\n}\n"; stripped != want {
+		t.Fatalf("filtered TTY output stripped ANSI = %q, want pretty JSON %q", stripped, want)
+	}
+}
+
 func TestExplicitPrintBodyKeepsAutoOutputCompact(t *testing.T) {
 	c, out, _ := newTestCLI(t)
 	useJSONResponse(c, 200, `{"object":{"z":1}}`)

--- a/internal/cli/print.go
+++ b/internal/cli/print.go
@@ -61,7 +61,11 @@ func (c *CLI) resolvePrintSpec(gf GlobalFlags, tty bool, kind printResponseKind)
 
 func (c *CLI) autoPrintSpec(gf GlobalFlags, tty bool, kind printResponseKind) printSpec {
 	if explicitOutputFilter(gf) {
-		return printSpec{order: []rune{printRenderedBody}, pretty: true}
+		return printSpec{
+			order:  []rune{printRenderedBody},
+			pretty: true,
+			color:  tty && output.ColorEnabled(c.Stdout),
+		}
 	}
 	if tty {
 		return printSpec{


### PR DESCRIPTION
## Summary
- keep filtered auto output colorized on TTYs
- add regression coverage for pretty filtered JSON with ANSI color

## Tests
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run TestFilteredTTYOutputColorsPrettyJSONByDefault
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli
- env GOCACHE=/tmp/restish-gocache go test ./...