### PR TITLE
fix: suppress unchanged config edit writes

### DIFF
--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/rest-sh/restish/v2/internal/auth"
 	"github.com/rest-sh/restish/v2/internal/cache"
@@ -1142,6 +1144,10 @@ func (c *CLI) runAPIInspect(cmd *cobra.Command, args []string) error {
 func (c *CLI) runConfigEdit(cmd *cobra.Command, args []string) error {
 	cfgPath := c.configFilePath()
 	oldCfg := c.cfg
+	before, err := statConfigEditFile(cfgPath)
+	if err != nil {
+		return err
+	}
 	editorCmd, err := c.editorCommand(cfgPath)
 	if err != nil {
 		return err
@@ -1155,8 +1161,45 @@ func (c *CLI) runConfigEdit(cmd *cobra.Command, args []string) error {
 	if err := c.reloadConfigAfterMutation("config edit", oldCfg); err != nil {
 		return err
 	}
-	c.printConfigWrittenPath()
+	after, err := statConfigEditFile(cfgPath)
+	if err != nil {
+		return err
+	}
+	if after.changedFrom(before) {
+		c.printConfigWrittenPath()
+	}
 	return nil
+}
+
+type configEditFileState struct {
+	exists  bool
+	modTime time.Time
+	size    int64
+}
+
+func statConfigEditFile(path string) (configEditFileState, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return configEditFileState{}, nil
+	}
+	if err != nil {
+		return configEditFileState{}, err
+	}
+	return configEditFileState{
+		exists:  true,
+		modTime: info.ModTime(),
+		size:    info.Size(),
+	}, nil
+}
+
+func (s configEditFileState) changedFrom(old configEditFileState) bool {
+	if s.exists != old.exists {
+		return true
+	}
+	if !s.exists {
+		return false
+	}
+	return !s.modTime.Equal(old.modTime) || s.size != old.size
 }
 
 func apiNamesWithSpecCacheRelevantChanges(oldCfg, newCfg *config.Config) []string {

--- a/internal/cli/api_test.go
+++ b/internal/cli/api_test.go
@@ -222,10 +222,10 @@ func TestFlagHeaderTakesPrecedenceOverProfile(t *testing.T) {
 	}
 }
 
-// TestAPIEditUsesCliStdout verifies that runAPIEdit wires the editor subprocess
-// to c.Stdout rather than os.Stdout, so embedders that redirect c.Stdout capture
-// any output the editor produces.
-func TestAPIEditUsesCliStdout(t *testing.T) {
+// TestConfigEditUsesCliStdout verifies that runConfigEdit wires the editor
+// subprocess to c.Stdout rather than os.Stdout, so embedders that redirect
+// c.Stdout capture any output the editor produces.
+func TestConfigEditUsesCliStdout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("editor test uses a POSIX shell script")
 	}
@@ -252,6 +252,35 @@ func TestAPIEditUsesCliStdout(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "editor-stdout") {
 		t.Errorf("expected editor stdout in c.Stdout, got: %q", out.String())
+	}
+	if strings.Contains(out.String(), "Wrote config:") {
+		t.Errorf("expected unchanged config edit not to print written path, got: %q", out.String())
+	}
+}
+
+func TestConfigEditPrintsWrittenPathWhenFileChanges(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("editor test uses a POSIX shell script")
+	}
+
+	dir := t.TempDir()
+
+	scriptPath := filepath.Join(dir, "editor.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '{\"theme\":{\"ok\":\"green\"}}\\n' > \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VISUAL", scriptPath)
+	t.Setenv("EDITOR", "")
+
+	c, out, _ := newTestCLI(t)
+	cfgPath := filepath.Join(dir, "restish.json")
+	if err := os.WriteFile(cfgPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c.Hooks().ConfigPath = cfgPath
+
+	if err := c.Run([]string{"restish", "config", "edit"}); err != nil {
+		t.Fatalf("config edit: %v", err)
 	}
 	if !strings.Contains(out.String(), "Wrote config: "+cfgPath) {
 		t.Errorf("expected written config path in c.Stdout, got: %q", out.String())


### PR DESCRIPTION
## Summary
- only print the config write message after config edit when the file changed
- cover unchanged editor exits and real editor writes

## Tests
- env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestConfigEdit'