### PR TITLE
fix: send auth credentials during spec discovery; fix xdg-open on Linux

### DIFF
--- a/.agents/skills/rsh-review/SKILL.md
+++ b/.agents/skills/rsh-review/SKILL.md
@@ -36,7 +36,8 @@ Review code changes with a bug-finding mindset. Prioritize correctness, regressi
 4. Challenge assumptions around error paths, cancellation, timeouts, cleanup, concurrency, config precedence, and backward compatibility.
 5. Check whether tests cover intended behavior and important failure modes.
 6. Check whether `site/` docs or `docs/design/` should change.
-7. Report findings first, ordered by severity. Keep summaries brief.
+7. Keep the review scoped to the current PR unless the user asks for a broader audit. Distinguish required fixes from optional hardening or follow-on cleanup.
+8. Report findings first, ordered by severity. Keep summaries brief.
 
 ## Output Expectations
 
@@ -47,6 +48,7 @@ Review code changes with a bug-finding mindset. Prioritize correctness, regressi
 - If no findings are present, say so explicitly and call out any residual risk or untested areas.
 - Do not pad the review with praise or low-value nits unless the user asks for them.
 - Do not report speculative issues unless there is a plausible failure mode in the changed code.
+- Do not turn a scoped PR review into general codebase cleanup. If you notice unrelated risks, list them as out-of-scope follow-ups only when they are important.
 - Treat missing coverage as a test gap unless the diff shows a confirmed bug.
 
 ## Severity Guide
@@ -104,6 +106,8 @@ Intentional formatter changes should usually come with targeted regression cover
 ### Auth, pagination, filtering, and caching flows
 
 Changes in these areas often regress behavior only in realistic end-to-end paths. Review interactions, not just isolated helpers.
+
+For auth, redaction, and cache metadata changes, check both positive behavior and negative leakage boundaries: where credentials are applied, where they must not be applied, what gets persisted, and what appears in errors or traces. Keep findings tied to the PR's changed paths.
 
 ### Test buffer races
 

--- a/.agents/skills/rsh-simplify/SKILL.md
+++ b/.agents/skills/rsh-simplify/SKILL.md
@@ -27,6 +27,19 @@ Identify and eliminate unnecessary complexity in the Restish codebase. Fewer lin
 
 User experience comes first. Developer experience comes second. Simplifications that improve both are highest value. Simplifications that improve only developer experience at some user cost are not acceptable.
 
+## Post-Review Shrink Pass
+
+After a PR has gone through review/fix loops, do a focused simplification pass before final handoff when the diff has grown substantially. Compare `git diff --stat` or `git diff --shortstat` before and after. Target duplicated test setup, repeated assertions, over-large inline fixtures, and helper code that obscures the behavior under test. Prefer deleting ceremony over deleting coverage.
+
+Good shrink-pass moves:
+
+- Table-drive cases that share setup and assertion shape.
+- Add small helpers for repeated config/cache/server setup when they make tests read more directly.
+- Share behavioral assertions that are repeated verbatim.
+- Keep edge-case tests for auth, redaction, redirects, cache metadata, migrations, and subprocess behavior when those edge cases are the point of the PR.
+
+Avoid code golf. A shorter diff that is harder to audit, especially around security/auth/cache behavior, is not a simplification.
+
 ## Process
 
 ### 1. Analyze

--- a/.agents/skills/rsh-test/SKILL.md
+++ b/.agents/skills/rsh-test/SKILL.md
@@ -59,6 +59,9 @@ Prefer plain Go tests with a small Restish-specific helper vocabulary over Gherk
 
 - One test should usually cover one behavior from input through observable result.
 - Combine cases when they differ only by inputs and expected outputs. Split cases when setup or failure meaning differs.
+- For review-driven edge cases, first preserve the behavioral boundary, then reduce scaffolding. Table-drive repeated redirect, redaction, cache, migration, or auth-origin cases only when the setup and assertion shape truly match.
+- Use focused helpers for repeated config/cache/server setup, but keep the request, persisted state, error, or output assertion visible in the test.
+- When covering credential handling, assert both where credentials are applied and where they are not applied, plus what gets persisted and what appears in diagnostics.
 - Avoid asserting private call sequences unless ordering is the contract.
 - Avoid mocks for HTTP, files, and CLI I/O when standard library fakes or temp resources are clearer.
 - Keep fixtures tiny but believable: real OpenAPI fragments, real response headers, real shorthand, real config snippets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ The core design is a `CLI` struct in `internal/cli/cli.go` that owns all state â
 
 `TODO.md` and `review.md` are local working files for planning, code reviews, and in-progress implementation notes only. They must never be committed to git history. Keep them ignored/untracked, and if they are accidentally staged, unstage them before committing.
 
+## PR Review and Cleanup Discipline
+
+Keep review and fix loops scoped to the current PR's behavioral surface unless the user explicitly asks for broader cleanup. After substantial review loops, do a simplification pass before final handoff: reduce repeated scaffolding, table-drive genuinely similar cases, and consolidate helpers where that preserves readability. Do not shrink a PR by deleting important coverage or making security/auth/cache behavior harder to audit.
+
 ## Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) for all commits:

--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -785,7 +785,7 @@ func defaultOpenBrowserCommand(rawURL string) *exec.Cmd {
 		// cmd /c start flags.
 		return exec.Command("cmd", "/c", "start", "", "--", rawURL)
 	default:
-		return exec.Command("xdg-open", "--", rawURL)
+		return exec.Command("xdg-open", rawURL)
 	}
 }
 

--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -776,7 +776,11 @@ func DefaultOpenBrowser(rawURL string) error {
 var openBrowserCommand = defaultOpenBrowserCommand
 
 func defaultOpenBrowserCommand(rawURL string) *exec.Cmd {
-	switch runtime.GOOS {
+	return defaultOpenBrowserCommandForGOOS(runtime.GOOS, rawURL)
+}
+
+func defaultOpenBrowserCommandForGOOS(goos, rawURL string) *exec.Cmd {
+	switch goos {
 	case "darwin":
 		return exec.Command("open", "--", rawURL)
 	case "windows":

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -1199,6 +1199,11 @@ func TestDefaultOpenBrowserReturnsAfterStart(t *testing.T) {
 }
 
 func TestDefaultOpenBrowserCommandUsesArgumentSeparator(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		// xdg-open does not support --, so we skip the separator check on Linux.
+		// Real OAuth URLs always start with https://, so this is safe in practice.
+		t.Skip("xdg-open does not accept --")
+	}
 	cmd := defaultOpenBrowserCommand("-https://example.com")
 	args := strings.Join(cmd.Args, "\x00")
 	if !strings.Contains(args, "\x00--\x00-https://example.com") {

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -1208,6 +1209,14 @@ func TestDefaultOpenBrowserCommandUsesArgumentSeparator(t *testing.T) {
 	args := strings.Join(cmd.Args, "\x00")
 	if !strings.Contains(args, "\x00--\x00-https://example.com") {
 		t.Fatalf("browser command should pass -- before URL, got %#v", cmd.Args)
+	}
+}
+
+func TestDefaultOpenBrowserCommandLinuxUsesXDGOpenWithoutSeparator(t *testing.T) {
+	cmd := defaultOpenBrowserCommandForGOOS("linux", "https://example.com/callback?code=abc")
+	want := []string{"xdg-open", "https://example.com/callback?code=abc"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("linux browser command args = %#v, want %#v", cmd.Args, want)
 	}
 }
 

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"sort"
@@ -215,13 +217,14 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 	allowCrossOrigin, _ := cmd.Flags().GetBool("allow-cross-origin-spec")
 	yes, _ := cmd.Flags().GetBool("yes")
 	profileName := c.profileFromCmd(cmd)
-	transport, closer, err := c.discoveryTransport(requestContext(cmd), apiName, apiCfg, profileName)
+	transport, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, profileName)
 	if err != nil {
 		return err
 	}
 	if closer != nil {
 		defer closer.Close()
 	}
+	fetch := c.discoveryFetcher(requestContext(cmd), apiName, apiCfg, profileName)
 	discCfg := spec.DiscoverConfig{
 		APIName:          c.apiStateName(apiName),
 		BaseURL:          effectiveProfileBaseURL(apiCfg, profileName),
@@ -232,6 +235,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 		ServerVariables:  effectiveServerVariables(apiCfg, profileName),
 		Version:          Version,
 		Transport:        transport,
+		Fetch:            fetch,
 		AllowCrossOrigin: apiCfg.AllowCrossOriginSpec || allowCrossOrigin,
 		ForceRefresh:     true,
 		Trace:            c.discoveryTrace(cmd),
@@ -329,13 +333,14 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 
 	var apiSpec *spec.APISpec
 	if !noDiscover {
-		transport, closer, err := c.discoveryTransport(requestContext(cmd), apiName, apiCfg, "default")
+		transport, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, "default")
 		if err != nil {
 			return err
 		}
 		if closer != nil {
 			defer closer.Close()
 		}
+		fetch := c.discoveryFetcher(requestContext(cmd), apiName, apiCfg, "default")
 		discCfg := spec.DiscoverConfig{
 			APIName:          apiName,
 			BaseURL:          baseURL,
@@ -345,6 +350,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 			ServerVariables:  nil,
 			Version:          Version,
 			Transport:        transport,
+			Fetch:            fetch,
 			AllowCrossOrigin: allowCrossOrigin,
 			ForceRefresh:     true,
 			Trace:            c.discoveryTrace(cmd),
@@ -1060,7 +1066,7 @@ func (c *CLI) applyXCLIConfig(apiCfg *config.APIConfig, xcli *spec.XCLIConfig) {
 	}
 }
 
-func (c *CLI) discoveryTransport(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName string) (http.RoundTripper, interface{ Close() error }, error) {
+func (c *CLI) discoveryTransport(ctx context.Context, apiCfg *config.APIConfig, profileName string) (http.RoundTripper, interface{ Close() error }, error) {
 	gf := globalFlagsFromContext(ctx)
 	if gf.Insecure {
 		c.warnf("TLS certificate verification is disabled (--rsh-insecure); connections are not secure")
@@ -1111,32 +1117,128 @@ func (c *CLI) discoveryTransport(ctx context.Context, apiName string, apiCfg *co
 	}
 	transport := request.BuildTransport(opts)
 	closer, _ := transport.(interface{ Close() error })
-	if apiName != "" && apiCfg != nil {
-		pn := profileName
-		if pn == "" {
-			pn = "default"
-		}
-		callbacks := c.authOnRequest(apiName, pn, profileForName(apiCfg, pn), authHandlerOptions{})
-		if callbacks.OnRequest != nil {
-			transport = discoveryAuthTransport{inner: transport, onRequest: callbacks.OnRequest}
-		}
-	}
 	return transport, closer, nil
 }
 
-// discoveryAuthTransport wraps a transport and applies auth headers to each request.
-// Used so that spec discovery fetches are authenticated when the API requires it.
-type discoveryAuthTransport struct {
-	inner     http.RoundTripper
-	onRequest func(*http.Request) error
+func (c *CLI) discoveryFetcher(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName string) spec.HTTPFetcher {
+	authOrigins := discoveryAuthOrigins(apiCfg, profileName)
+	return func(ctx context.Context, rawURL string, transport http.RoundTripper) (*http.Response, error) {
+		baseOpts, authOpts := c.discoveryRequestOptions(ctx, apiName, apiCfg, profileName, transport)
+		opts := baseOpts
+		if discoveryAuthAllowed(authOrigins, rawURL) {
+			opts = authOpts
+		}
+		return c.doDiscoveryRequest(ctx, http.MethodGet, rawURL, opts)
+	}
 }
 
-func (t discoveryAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req = req.Clone(req.Context())
-	if err := t.onRequest(req); err != nil {
-		return nil, fmt.Errorf("discovery auth: %w", err)
+func (c *CLI) discoveryRequestOptions(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName string, transport http.RoundTripper) (request.Options, request.Options) {
+	if profileName == "" {
+		profileName = "default"
 	}
-	return t.inner.RoundTrip(req)
+	baseOpts := request.Options{
+		Transport: transport,
+		UserAgent: "restish/" + Version,
+	}
+	authOpts := baseOpts
+	if apiCfg != nil {
+		if apiCfg.PreserveHeaderCase {
+			authOpts.PreserveHeaderCase = true
+		}
+		prof := profileForName(apiCfg, profileName)
+		if prof != nil {
+			authOpts.Headers = append([]string(nil), prof.Headers...)
+			authOpts.Query = append([]string(nil), prof.Query...)
+		}
+		callbacks := c.authOnRequest(apiName, profileName, prof, authHandlerOptionsFromContext(ctx))
+		authOpts.OnRequest = callbacks.OnRequest
+		authOpts.OnUnauthorized = callbacks.OnUnauthorized
+	}
+	if authOpts.OnRequest != nil || len(c.pluginsByHook["request-middleware"]) > 0 {
+		origOnRequest := authOpts.OnRequest
+		authOpts.OnRequest = func(req *http.Request) error {
+			if origOnRequest != nil {
+				if err := origOnRequest(req); err != nil {
+					return err
+				}
+			}
+			return c.runRequestMiddlewarePlugins(req)
+		}
+	}
+	return baseOpts, authOpts
+}
+
+func (c *CLI) doDiscoveryRequest(ctx context.Context, method, rawURL string, opts request.Options) (*http.Response, error) {
+	resp, err := request.Do(ctx, method, rawURL, nil, opts)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || opts.OnUnauthorized == nil {
+		return resp, err
+	}
+	if resp.Body != nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	retryOpts := opts
+	onUnauthorized := retryOpts.OnUnauthorized
+	retryOpts.OnRequest = func(req *http.Request) error {
+		if err := onUnauthorized(req); err != nil {
+			return err
+		}
+		return c.runRequestMiddlewarePlugins(req)
+	}
+	retryOpts.OnUnauthorized = nil
+	return request.Do(ctx, method, rawURL, nil, retryOpts)
+}
+
+func authHandlerOptionsFromContext(ctx context.Context) authHandlerOptions {
+	gf := globalFlagsFromContext(ctx)
+	return authHandlerOptions{NoBrowser: gf.NoBrowser, Verbose: gf.Verbose > 0}
+}
+
+func discoveryAuthOrigins(apiCfg *config.APIConfig, profileName string) []*url.URL {
+	if apiCfg == nil {
+		return nil
+	}
+	var origins []*url.URL
+	addNormalized := func(raw string) {
+		if raw == "" {
+			return
+		}
+		if normalized, err := request.Normalize(raw, ""); err == nil {
+			raw = normalized
+		}
+		u, err := url.Parse(raw)
+		if err == nil && u.IsAbs() && (u.Scheme == "http" || u.Scheme == "https") {
+			origins = append(origins, u)
+		}
+	}
+	addExplicitURL := func(raw string) {
+		u, err := url.Parse(raw)
+		if err == nil && u.IsAbs() && (u.Scheme == "http" || u.Scheme == "https") {
+			origins = append(origins, u)
+		}
+	}
+	addNormalized(effectiveProfileBaseURL(apiCfg, profileName))
+	addNormalized(apiCfg.SpecURL)
+	for _, src := range apiCfg.SpecFiles {
+		addExplicitURL(src)
+	}
+	return origins
+}
+
+func discoveryAuthAllowed(origins []*url.URL, rawURL string) bool {
+	if normalized, err := request.Normalize(rawURL, ""); err == nil {
+		rawURL = normalized
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || !u.IsAbs() {
+		return false
+	}
+	for _, origin := range origins {
+		if request.SameOrigin(origin, u) {
+			return true
+		}
+	}
+	return false
 }
 
 // runAPIInspect prints the config for a named API as indented JSON,

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -215,7 +215,7 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 	allowCrossOrigin, _ := cmd.Flags().GetBool("allow-cross-origin-spec")
 	yes, _ := cmd.Flags().GetBool("yes")
 	profileName := c.profileFromCmd(cmd)
-	transport, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, profileName)
+	transport, closer, err := c.discoveryTransport(requestContext(cmd), apiName, apiCfg, profileName)
 	if err != nil {
 		return err
 	}
@@ -329,7 +329,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 
 	var apiSpec *spec.APISpec
 	if !noDiscover {
-		transport, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, "default")
+		transport, closer, err := c.discoveryTransport(requestContext(cmd), apiName, apiCfg, "default")
 		if err != nil {
 			return err
 		}
@@ -1060,7 +1060,7 @@ func (c *CLI) applyXCLIConfig(apiCfg *config.APIConfig, xcli *spec.XCLIConfig) {
 	}
 }
 
-func (c *CLI) discoveryTransport(ctx context.Context, apiCfg *config.APIConfig, profileName string) (http.RoundTripper, interface{ Close() error }, error) {
+func (c *CLI) discoveryTransport(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName string) (http.RoundTripper, interface{ Close() error }, error) {
 	gf := globalFlagsFromContext(ctx)
 	if gf.Insecure {
 		c.warnf("TLS certificate verification is disabled (--rsh-insecure); connections are not secure")
@@ -1111,7 +1111,32 @@ func (c *CLI) discoveryTransport(ctx context.Context, apiCfg *config.APIConfig, 
 	}
 	transport := request.BuildTransport(opts)
 	closer, _ := transport.(interface{ Close() error })
+	if apiName != "" && apiCfg != nil {
+		pn := profileName
+		if pn == "" {
+			pn = "default"
+		}
+		callbacks := c.authOnRequest(apiName, pn, profileForName(apiCfg, pn), authHandlerOptions{})
+		if callbacks.OnRequest != nil {
+			transport = discoveryAuthTransport{inner: transport, onRequest: callbacks.OnRequest}
+		}
+	}
 	return transport, closer, nil
+}
+
+// discoveryAuthTransport wraps a transport and applies auth headers to each request.
+// Used so that spec discovery fetches are authenticated when the API requires it.
+type discoveryAuthTransport struct {
+	inner     http.RoundTripper
+	onRequest func(*http.Request) error
+}
+
+func (t discoveryAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	if err := t.onRequest(req); err != nil {
+		return nil, fmt.Errorf("discovery auth: %w", err)
+	}
+	return t.inner.RoundTrip(req)
 }
 
 // runAPIInspect prints the config for a named API as indented JSON,

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -593,6 +594,55 @@ func TestAPISyncDiscoveryUsesProfileCACert(t *testing.T) {
 	}
 }
 
+func newAPISyncCLI(t *testing.T, api *config.APIConfig) (*restishcli.CLI, string, string) {
+	t.Helper()
+	cfgFile := writeAPIConfigObject(t, "protected", api)
+	cacheDir := t.TempDir()
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	return c, cfgFile, cacheDir
+}
+
+func protectedAPI(baseURL, specURL string, authCfg *config.AuthConfig) *config.APIConfig {
+	api := &config.APIConfig{BaseURL: baseURL, SpecURL: specURL}
+	if authCfg != nil {
+		api.Profiles = map[string]*config.ProfileConfig{
+			"default": {Auth: authCfg},
+		}
+	}
+	return api
+}
+
+func runProtectedAPISync(t *testing.T, c *restishcli.CLI, args ...string) error {
+	t.Helper()
+	cmdArgs := append([]string{"restish"}, args...)
+	cmdArgs = append(cmdArgs, "api", "sync", "protected")
+	return c.Run(cmdArgs)
+}
+
+func assertSyncedSpecURL(t *testing.T, cfgFile, cacheDir, want string) {
+	t.Helper()
+	written, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load written config: %v", err)
+	}
+	if got := written.APIs["protected"].SpecURL; got != want {
+		t.Fatalf("spec_url = %q, want %q", got, want)
+	}
+
+	cached, err := spec.LoadStaleFromCache(cacheDir, "protected", restishcli.Version, nil, []spec.Loader{spec.OpenAPILoader{}})
+	if err != nil {
+		t.Fatalf("load cache: %v", err)
+	}
+	if cached == nil {
+		t.Fatal("expected cached spec")
+	}
+	if got := cached.SourceURL; got != want {
+		t.Fatalf("cached SourceURL = %q, want %q", got, want)
+	}
+}
+
 // TestAPISyncDiscoverySendsAuthCredentials verifies that spec discovery requests
 // carry auth headers when the profile has auth configured. This is a regression
 // test for the bug where discoveryTransport only set up TLS and never applied
@@ -601,22 +651,7 @@ func TestAPISyncDiscoverySendsAuthCredentials(t *testing.T) {
 	var authHeader string
 	var specHits int
 
-	c, _, _ := newTestCLI(t)
-	cfgData, _ := json.Marshal(&config.Config{
-		APIs: map[string]*config.APIConfig{
-			"protected": {
-				BaseURL: "https://api.example.com",
-				Profiles: map[string]*config.ProfileConfig{
-					"default": {Auth: bearerAuth("test-token")},
-				},
-			},
-		},
-	})
-	if err := os.WriteFile(c.Hooks().ConfigPath, cfgData, 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	c.Hooks().SpecCachePath = t.TempDir()
-
+	c, _, _ := newAPISyncCLI(t, protectedAPI("https://api.example.com", "", bearerAuth("test-token")))
 	useTransport(c, func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path == "/openapi.json" {
 			authHeader = r.Header.Get("Authorization")
@@ -632,7 +667,7 @@ func TestAPISyncDiscoverySendsAuthCredentials(t *testing.T) {
 		}, nil
 	})
 
-	if err := c.Run([]string{"restish", "api", "sync", "protected"}); err != nil {
+	if err := runProtectedAPISync(t, c); err != nil {
 		t.Fatalf("api sync: %v", err)
 	}
 	if specHits == 0 {
@@ -640,6 +675,321 @@ func TestAPISyncDiscoverySendsAuthCredentials(t *testing.T) {
 	}
 	if authHeader != "Bearer test-token" {
 		t.Fatalf("Authorization = %q, want %q", authHeader, "Bearer test-token")
+	}
+}
+
+func TestAPISyncDiscoverySendsAuthForShorthandBaseURL(t *testing.T) {
+	var authHeader string
+
+	c, _, _ := newAPISyncCLI(t, protectedAPI("api.example.com", "", bearerAuth("test-token")))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" {
+			authHeader = r.Header.Get("Authorization")
+			return jsonResponse(200, minimalOpenAPI), nil
+		}
+		return textResponse(404, "text/plain", "not found", r), nil
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization = %q, want %q", authHeader, "Bearer test-token")
+	}
+}
+
+func TestAPISyncDiscoveryFollowsLinkWithShorthandBaseURL(t *testing.T) {
+	var linkedSpecAuth string
+
+	c, _, _ := newAPISyncCLI(t, protectedAPI("api.example.com", "", bearerAuth("test-token")))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.URL.Host == "api.example.com" && (r.URL.Path == "" || r.URL.Path == "/"):
+			resp := textResponse(200, "text/html", "<html></html>", r)
+			resp.Header.Set("Link", `</openapi.yaml>; rel="service-desc"`)
+			return resp, nil
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.yaml":
+			linkedSpecAuth = r.Header.Get("Authorization")
+			return jsonResponse(200, minimalOpenAPI), nil
+		default:
+			return textResponse(404, "text/plain", "not found", r), nil
+		}
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if linkedSpecAuth != "Bearer test-token" {
+		t.Fatalf("linked spec Authorization = %q, want %q", linkedSpecAuth, "Bearer test-token")
+	}
+}
+
+func TestAPISyncDiscoveryResolvesExternalRefsWithShorthandSpecURL(t *testing.T) {
+	var specAuth string
+	var paramsAuth string
+	var requests []string
+	specBody := `{
+  "openapi": "3.1.0",
+  "info": {"title": "Protected", "version": "1.0"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "parameters": [{"$ref": "./params.yaml#/components/parameters/ID"}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`
+	paramsBody := `{
+  "components": {
+    "parameters": {
+      "ID": {
+        "name": "id",
+        "in": "path",
+        "required": true,
+        "schema": {"type": "string"}
+      }
+    }
+  }
+}`
+
+	c, _, _ := newAPISyncCLI(t, protectedAPI("api.example.com", "api.example.com/openapi.json", bearerAuth("test-token")))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		requests = append(requests, r.URL.String())
+		switch {
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json":
+			specAuth = r.Header.Get("Authorization")
+			return textResponse(200, "application/json", specBody, r), nil
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/params.yaml":
+			paramsAuth = r.Header.Get("Authorization")
+			return textResponse(200, "application/json", paramsBody, r), nil
+		default:
+			return textResponse(404, "text/plain", "not found", r), nil
+		}
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v\nrequests: %v", err, requests)
+	}
+	if specAuth != "Bearer test-token" {
+		t.Fatalf("spec Authorization = %q, want %q", specAuth, "Bearer test-token")
+	}
+	if paramsAuth != "Bearer test-token" {
+		t.Fatalf("external ref Authorization = %q, want %q", paramsAuth, "Bearer test-token")
+	}
+}
+
+func TestAPISyncDiscoveryDoesNotPersistQueryAuthInSourceURL(t *testing.T) {
+	c, cfgFile, cacheDir := newAPISyncCLI(t, protectedAPI("api.example.com", "", apiKeyAuth("query", "api_key", "secret-token")))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" && r.URL.Query().Get("api_key") == "secret-token" {
+			return textResponse(200, "application/json", minimalOpenAPI, r), nil
+		}
+		return textResponse(404, "text/plain", "not found", r), nil
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	assertSyncedSpecURL(t, cfgFile, cacheDir, "https://api.example.com/openapi.json")
+}
+
+func TestAPISyncDiscoveryDoesNotPersistDiscoveredCredentialQuerySourceURL(t *testing.T) {
+	c, cfgFile, cacheDir := newAPISyncCLI(t, protectedAPI("https://api.example.com", "", nil))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.URL.Host == "api.example.com" && (r.URL.Path == "" || r.URL.Path == "/"):
+			resp := textResponse(200, "text/html", "<html></html>", r)
+			resp.Header.Set("Link", `<https://api.example.com/openapi.json?api_key=secret-token&version=1>; rel="service-desc"`)
+			return resp, nil
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" && r.URL.Query().Get("api_key") == "secret-token":
+			return textResponse(200, "application/json", minimalOpenAPI, r), nil
+		default:
+			return textResponse(404, "text/plain", "not found", r), nil
+		}
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	assertSyncedSpecURL(t, cfgFile, cacheDir, "https://api.example.com/openapi.json?version=1")
+}
+
+func TestAPISyncDiscoveryRedactsCredentialQueryInErrorAndTrace(t *testing.T) {
+	var hitSpec bool
+	cfgFile := writeAPIConfigObject(t, "protected", protectedAPI("https://api.example.com", "https://api.example.com/openapi.json?api_key=secret-token&version=1", nil))
+	c, _, errOut := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" && r.URL.Query().Get("api_key") == "secret-token" {
+			hitSpec = true
+			return textResponse(500, "text/plain", "server error", r), nil
+		}
+		return textResponse(404, "text/plain", "not found", r), nil
+	})
+
+	err := runProtectedAPISync(t, c, "-v")
+	if err == nil {
+		t.Fatal("expected api sync failure")
+	}
+	if !hitSpec {
+		t.Fatal("expected request to include configured credential query")
+	}
+	combined := err.Error() + "\n" + errOut.String()
+	if strings.Contains(combined, "secret-token") {
+		t.Fatalf("credential query leaked in error/trace:\n%s", combined)
+	}
+	if !strings.Contains(combined, "https://api.example.com/openapi.json?version=1") {
+		t.Fatalf("expected clean URL in error/trace, got:\n%s", combined)
+	}
+}
+
+func TestAPISyncDiscoveryPersistsCleanRedirectSourceURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		location   string
+		finalPath  string
+		finalClean string
+	}{
+		{name: "path and query", location: "/specs/openapi.json?version=1&api_key=secret-token", finalPath: "/specs/openapi.json", finalClean: "https://api.example.com/specs/openapi.json?version=1"},
+		{name: "query only", location: "/openapi.json?version=1&api_key=secret-token", finalPath: "/openapi.json", finalClean: "https://api.example.com/openapi.json?version=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cfgFile, cacheDir := newAPISyncCLI(t, protectedAPI("https://api.example.com", "", nil))
+			useTransport(c, func(r *http.Request) (*http.Response, error) {
+				switch {
+				case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" && r.URL.RawQuery == "":
+					resp := textResponse(302, "text/plain", "", r)
+					resp.Header.Set("Location", tt.location)
+					return resp, nil
+				case r.URL.Host == "api.example.com" && r.URL.Path == tt.finalPath &&
+					r.URL.Query().Get("version") == "1" && r.URL.Query().Get("api_key") == "secret-token":
+					return textResponse(200, "application/json", minimalOpenAPI, r), nil
+				default:
+					return textResponse(404, "text/plain", "not found", r), nil
+				}
+			})
+
+			if err := runProtectedAPISync(t, c); err != nil {
+				t.Fatalf("api sync: %v", err)
+			}
+			assertSyncedSpecURL(t, cfgFile, cacheDir, tt.finalClean)
+		})
+	}
+}
+
+func TestAPISyncExplicitRedirectedSpecURLRemainsCacheable(t *testing.T) {
+	c, _, cacheDir := newAPISyncCLI(t, protectedAPI("https://api.example.com", "https://api.example.com/openapi.json", nil))
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" && r.URL.RawQuery == "":
+			resp := textResponse(302, "text/plain", "", r)
+			resp.Header.Set("Location", "/openapi.json?version=1&api_key=secret-token")
+			return resp, nil
+		case r.URL.Host == "api.example.com" && r.URL.Path == "/openapi.json" &&
+			r.URL.Query().Get("version") == "1" && r.URL.Query().Get("api_key") == "secret-token":
+			return textResponse(200, "application/json", minimalOpenAPI, r), nil
+		default:
+			return textResponse(404, "text/plain", "not found", r), nil
+		}
+	})
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+
+	cached, err := spec.Discover(context.Background(), spec.DiscoverConfig{
+		APIName:  "protected",
+		BaseURL:  "https://api.example.com",
+		SpecURL:  "https://api.example.com/openapi.json",
+		CacheDir: cacheDir,
+		Version:  restishcli.Version,
+		Fetch: func(context.Context, string, http.RoundTripper) (*http.Response, error) {
+			return nil, errors.New("network should not be used")
+		},
+	}, spec.DefaultLoaders())
+	if err != nil {
+		t.Fatalf("cache-only Discover: %v", err)
+	}
+	if cached == nil || cached.SourceURL != "https://api.example.com/openapi.json?version=1" {
+		t.Fatalf("cached SourceURL = %#v, want clean redirect target", cached)
+	}
+}
+
+func TestAPISyncDiscoveryDoesNotSendAuthToCrossOriginLinkSpec(t *testing.T) {
+	var linkedSpecAuth string
+
+	api := protectedAPI("https://api.example.com", "", bearerAuth("test-token"))
+	api.AllowCrossOriginSpec = true
+	c, _, _ := newAPISyncCLI(t, api)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.URL.Host == "api.example.com" && (r.URL.Path == "" || r.URL.Path == "/"):
+			resp := textResponse(200, "text/html", "<html></html>", r)
+			resp.Header.Set("Link", `<https://example.com/openapi.json>; rel="service-desc"`)
+			return resp, nil
+		case r.URL.Host == "api.example.com":
+			return textResponse(404, "text/plain", "not found", r), nil
+		case r.URL.Host == "example.com" && r.URL.Path == "/openapi.json":
+			linkedSpecAuth = r.Header.Get("Authorization")
+			return jsonResponse(200, minimalOpenAPI), nil
+		default:
+			return textResponse(404, "text/plain", "not found", r), nil
+		}
+	})
+
+	if err := runProtectedAPISync(t, c); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if linkedSpecAuth != "" {
+		t.Fatalf("cross-origin spec Authorization = %q, want empty", linkedSpecAuth)
+	}
+}
+
+func TestAPISyncDiscoveryUsesCachedOAuthForSpecURL(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if gotAuth != "Bearer cached-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"openapi":"3.1.0","info":{"title":"Protected","version":"1.0"},"servers":[{"url":%q}],"paths":{}}`, "http://"+r.Host)
+	}))
+	t.Cleanup(srv.Close)
+
+	tokenPath := filepath.Join(t.TempDir(), "tokens.cbor")
+	if err := auth.NewTokenCache(tokenPath).Set("protected:default", auth.CachedToken{AccessToken: "cached-token"}); err != nil {
+		t.Fatalf("set token: %v", err)
+	}
+	cfgFile := writeAPIConfigObject(t, "protected", &config.APIConfig{
+		BaseURL: srv.URL,
+		SpecURL: srv.URL,
+		Profiles: map[string]*config.ProfileConfig{
+			"default": {
+				Auth: &config.AuthConfig{Type: "oauth-authorization-code", Params: map[string]string{
+					"client_id":     "client",
+					"authorize_url": "https://auth.example.com/authorize",
+					"token_url":     "https://auth.example.com/token",
+				}},
+			},
+		},
+	})
+
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	c.Hooks().TokenCachePath = tokenPath
+	if err := c.Run([]string{"restish", "api", "sync", "protected"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if gotAuth != "Bearer cached-token" {
+		t.Fatalf("Authorization = %q, want cached OAuth token", gotAuth)
 	}
 }
 

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -593,6 +593,56 @@ func TestAPISyncDiscoveryUsesProfileCACert(t *testing.T) {
 	}
 }
 
+// TestAPISyncDiscoverySendsAuthCredentials verifies that spec discovery requests
+// carry auth headers when the profile has auth configured. This is a regression
+// test for the bug where discoveryTransport only set up TLS and never applied
+// auth, causing servers that require a Bearer token to return 307/401 on sync.
+func TestAPISyncDiscoverySendsAuthCredentials(t *testing.T) {
+	var authHeader string
+	var specHits int
+
+	c, _, _ := newTestCLI(t)
+	cfgData, _ := json.Marshal(&config.Config{
+		APIs: map[string]*config.APIConfig{
+			"protected": {
+				BaseURL: "https://api.example.com",
+				Profiles: map[string]*config.ProfileConfig{
+					"default": {Auth: bearerAuth("test-token")},
+				},
+			},
+		},
+	})
+	if err := os.WriteFile(c.Hooks().ConfigPath, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c.Hooks().SpecCachePath = t.TempDir()
+
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path == "/openapi.json" {
+			authHeader = r.Header.Get("Authorization")
+			specHits++
+			return jsonResponse(200, minimalOpenAPI), nil
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Proto:      "HTTP/1.1",
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    r,
+		}, nil
+	})
+
+	if err := c.Run([]string{"restish", "api", "sync", "protected"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if specHits == 0 {
+		t.Fatal("spec endpoint was never hit")
+	}
+	if authHeader != "Bearer test-token" {
+		t.Fatalf("Authorization = %q, want %q", authHeader, "Bearer test-token")
+	}
+}
+
 func TestAPIConnectAllowCrossOriginSpec(t *testing.T) {
 	cfgFile := t.TempDir() + "/restish.json"
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -461,7 +461,7 @@ func (c *CLI) discoverSpecForProfile(ctx context.Context, apiName, profileName s
 	if err != nil {
 		return nil, nil
 	}
-	transport, closer, err := c.discoveryTransport(ctx, api, profileName)
+	transport, closer, err := c.discoveryTransport(ctx, apiName, api, profileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -461,13 +461,14 @@ func (c *CLI) discoverSpecForProfile(ctx context.Context, apiName, profileName s
 	if err != nil {
 		return nil, nil
 	}
-	transport, closer, err := c.discoveryTransport(ctx, apiName, api, profileName)
+	transport, closer, err := c.discoveryTransport(ctx, api, profileName)
 	if err != nil {
 		return nil, err
 	}
 	if closer != nil {
 		defer closer.Close()
 	}
+	fetch := c.discoveryFetcher(ctx, apiName, api, profileName)
 	cfg := spec.DiscoverConfig{
 		APIName:          c.apiStateName(apiName),
 		BaseURL:          effectiveProfileBaseURL(api, profileName),
@@ -478,6 +479,7 @@ func (c *CLI) discoverSpecForProfile(ctx context.Context, apiName, profileName s
 		ServerVariables:  effectiveServerVariables(api, profileName),
 		Version:          Version,
 		Transport:        transport,
+		Fetch:            fetch,
 		AllowCrossOrigin: api.AllowCrossOriginSpec,
 		ForceRefresh:     forceRefresh,
 		Timeout:          timeout,

--- a/internal/cli/discovery_auth_internal_test.go
+++ b/internal/cli/discovery_auth_internal_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/rest-sh/restish/v2/internal/config"
+)
+
+func TestDiscoveryAuthAllowedNormalizesRequestURL(t *testing.T) {
+	origins := discoveryAuthOrigins(&config.APIConfig{BaseURL: "api.example.com"}, "default")
+	if !discoveryAuthAllowed(origins, "api.example.com/openapi.json") {
+		t.Fatal("expected shorthand request URL to match normalized base URL origin")
+	}
+}
+
+func TestDiscoveryAuthOriginsIgnoreLocalSpecFiles(t *testing.T) {
+	origins := discoveryAuthOrigins(&config.APIConfig{
+		BaseURL: "https://base.example.com",
+		SpecFiles: []string{
+			"api.example.com/openapi.yaml",
+			"file:///tmp/openapi.yaml",
+			"https://spec.example.com/openapi.yaml",
+		},
+	}, "default")
+
+	if discoveryAuthAllowed(origins, "https://api.example.com/schema.json") {
+		t.Fatal("local-looking spec file path should not authorize matching HTTP origin")
+	}
+	if !discoveryAuthAllowed(origins, "https://spec.example.com/schema.json") {
+		t.Fatal("explicit HTTP spec file URL should authorize matching origin")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -947,7 +947,7 @@ func (c *CLI) checkAPIReachability(ctx context.Context, baseURL string, apiCfg *
 	if err != nil {
 		return doctorReachabilityReport{Status: "invalid_url", Checked: false, Method: http.MethodHead, Error: err.Error()}
 	}
-	transport, closer, err := c.discoveryTransport(ctx, apiCfg, profileName)
+	transport, closer, err := c.discoveryTransport(ctx, "", apiCfg, profileName)
 	if err != nil {
 		return doctorReachabilityReport{Status: "tls_config_error", Checked: false, Method: http.MethodHead, Error: err.Error(), Note: "profile TLS settings could not be resolved"}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -363,7 +363,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(out, "Auth details: restish api auth inspect %s\n", name)
 	checkNetwork, _ := cmd.Flags().GetBool("check-network")
 	if checkNetwork {
-		c.printAPIReachability(out, style, c.checkAPIReachability(requestContext(cmd), effectiveProfileBaseURL(api, profileName), api, profileName))
+		c.printAPIReachability(out, style, c.checkAPIReachability(requestContext(cmd), name, effectiveProfileBaseURL(api, profileName), api, profileName))
 	} else {
 		fmt.Fprintf(out, "Reachability: %s (%s)\n", style.warn("skipped"), style.hint("use --check-network"))
 	}
@@ -784,7 +784,7 @@ func (c *CLI) doctorAPIReport(cmd *cobra.Command, name string) doctorAPIReport {
 	report.Auth.Hint = fmt.Sprintf("run `restish api auth inspect %s` for credential coverage and auth material", name)
 	checkNetwork, _ := cmd.Flags().GetBool("check-network")
 	if checkNetwork {
-		report.Reachability = c.checkAPIReachability(requestContext(cmd), effectiveProfileBaseURL(api, profileName), api, profileName)
+		report.Reachability = c.checkAPIReachability(requestContext(cmd), name, effectiveProfileBaseURL(api, profileName), api, profileName)
 	}
 	return report
 }
@@ -937,7 +937,7 @@ func (c *CLI) printShellSetupDiagnostic(out io.Writer, style humanTextStyle) {
 	fmt.Fprintf(out, "Shell setup: %s if glob expansion causes trouble\n", style.hint("run `restish shell setup "+shell+"`"))
 }
 
-func (c *CLI) checkAPIReachability(ctx context.Context, baseURL string, apiCfg *config.APIConfig, profileName string) doctorReachabilityReport {
+func (c *CLI) checkAPIReachability(ctx context.Context, apiName, baseURL string, apiCfg *config.APIConfig, profileName string) doctorReachabilityReport {
 	if baseURL == "" {
 		return doctorReachabilityReport{Status: "skipped", Checked: false, Note: "no base URL"}
 	}
@@ -947,7 +947,7 @@ func (c *CLI) checkAPIReachability(ctx context.Context, baseURL string, apiCfg *
 	if err != nil {
 		return doctorReachabilityReport{Status: "invalid_url", Checked: false, Method: http.MethodHead, Error: err.Error()}
 	}
-	transport, closer, err := c.discoveryTransport(ctx, "", apiCfg, profileName)
+	transport, closer, err := c.discoveryTransport(ctx, apiName, apiCfg, profileName)
 	if err != nil {
 		return doctorReachabilityReport{Status: "tls_config_error", Checked: false, Method: http.MethodHead, Error: err.Error(), Note: "profile TLS settings could not be resolved"}
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -16,6 +16,8 @@ import (
 	"github.com/rest-sh/restish/v2/internal/cache"
 	"github.com/rest-sh/restish/v2/internal/config"
 	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
+	"github.com/rest-sh/restish/v2/internal/request"
+	"github.com/rest-sh/restish/v2/internal/secrets"
 	"github.com/rest-sh/restish/v2/internal/spec"
 	"github.com/spf13/cobra"
 )
@@ -943,22 +945,30 @@ func (c *CLI) checkAPIReachability(ctx context.Context, apiName, baseURL string,
 	}
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, baseURL, nil)
+	normalizedBaseURL, err := request.Normalize(baseURL, "")
 	if err != nil {
-		return doctorReachabilityReport{Status: "invalid_url", Checked: false, Method: http.MethodHead, Error: err.Error()}
+		return doctorReachabilityReport{Status: "invalid_url", Checked: false, Method: http.MethodHead, Error: secrets.RedactDiagnosticURLText(err.Error())}
 	}
-	transport, closer, err := c.discoveryTransport(ctx, apiName, apiCfg, profileName)
+	transport, closer, err := c.discoveryTransport(ctx, apiCfg, profileName)
 	if err != nil {
 		return doctorReachabilityReport{Status: "tls_config_error", Checked: false, Method: http.MethodHead, Error: err.Error(), Note: "profile TLS settings could not be resolved"}
 	}
 	if closer != nil {
 		defer closer.Close()
 	}
-	resp, err := (&http.Client{Transport: transport}).Do(req)
-	if err != nil {
-		return doctorReachabilityReport{Status: "failed", Checked: true, Method: http.MethodHead, Error: err.Error()}
+	baseOpts, authOpts := c.discoveryRequestOptions(ctx, apiName, apiCfg, profileName, transport)
+	authOrigins := discoveryAuthOrigins(apiCfg, profileName)
+	opts := baseOpts
+	if discoveryAuthAllowed(authOrigins, normalizedBaseURL) {
+		opts = authOpts
 	}
-	_ = resp.Body.Close()
+	resp, err := c.doDiscoveryRequest(ctx, http.MethodHead, normalizedBaseURL, opts)
+	if err != nil {
+		return doctorReachabilityReport{Status: "failed", Checked: true, Method: http.MethodHead, Error: secrets.RedactDiagnosticURLText(err.Error())}
+	}
+	if resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 	report := doctorReachabilityReport{
 		Status:     "ok",
 		Checked:    true,

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -17,6 +18,40 @@ import (
 
 	"github.com/rest-sh/restish/v2/internal/cli"
 )
+
+type doctorReachabilityJSON struct {
+	Reachability struct {
+		Status     string `json:"status"`
+		Checked    bool   `json:"checked"`
+		Reachable  bool   `json:"reachable"`
+		StatusCode int    `json:"status_code"`
+		Error      string `json:"error"`
+	} `json:"reachability"`
+}
+
+func newDoctorAPIJSONCLI(t *testing.T, cfg string) (*cli.CLI, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	c, out, errOut := newTestCLI(t)
+	if err := os.WriteFile(c.Hooks().ConfigPath, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return c, out, errOut
+}
+
+func runDoctorReachabilityJSON(t *testing.T, c *cli.CLI, out, errOut *bytes.Buffer) doctorReachabilityJSON {
+	t.Helper()
+	if err := c.Run([]string{"restish", "doctor", "-o", "json", "api", "demo", "--check-network"}); err != nil {
+		t.Fatalf("doctor api -o json returned error: %v", err)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("doctor api -o json should keep stderr quiet, got:\n%s", errOut.String())
+	}
+	var report doctorReachabilityJSON
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("doctor api -o json output is not JSON: %v\n%s", err, out.String())
+	}
+	return report
+}
 
 func TestDoctorReportsInsecureTokenCachePermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -461,6 +496,92 @@ func TestDoctorAPIJSONTreats405AsReachable(t *testing.T) {
 		report.Reachability.StatusCode != http.StatusMethodNotAllowed ||
 		report.Reachability.Note == "" {
 		t.Fatalf("unexpected reachability report: %#v", report.Reachability)
+	}
+}
+
+func TestDoctorAPIReachabilityNormalizesShorthandAndSendsAuth(t *testing.T) {
+	c, out, errOut := newDoctorAPIJSONCLI(t, `{
+  "apis": {
+    "demo": {
+      "base_url": "api.example.com",
+      "profiles": {
+        "default": {
+          "auth": {
+            "type": "api-key",
+            "params": {"in": "query", "name": "api_key", "value": "secret-token"}
+          }
+        }
+      }
+    }
+  }
+}`)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("doctor reachability used %s, want HEAD", r.Method)
+		}
+		if got := r.URL.String(); got != "https://api.example.com?api_key=secret-token" {
+			t.Fatalf("doctor reachability URL = %q, want normalized authenticated URL", got)
+		}
+		return textResponse(http.StatusNoContent, "text/plain", "", r), nil
+	})
+	report := runDoctorReachabilityJSON(t, c, out, errOut)
+	if report.Reachability.Status != "ok" || !report.Reachability.Reachable || report.Reachability.StatusCode != http.StatusNoContent {
+		t.Fatalf("unexpected reachability report: %#v", report.Reachability)
+	}
+}
+
+func TestDoctorAPIReachabilityReportsInvalidURL(t *testing.T) {
+	c, out, errOut := newDoctorAPIJSONCLI(t, `{"apis":{"demo":{"base_url":":/bad"}}}`)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("transport should not be called for invalid URL")
+		return nil, nil
+	})
+	report := runDoctorReachabilityJSON(t, c, out, errOut)
+	if report.Reachability.Status != "invalid_url" || report.Reachability.Checked || report.Reachability.Error == "" {
+		t.Fatalf("unexpected reachability report: %#v", report.Reachability)
+	}
+}
+
+func TestDoctorAPIReachabilityRedactsInvalidURLCredentialQuery(t *testing.T) {
+	c, out, errOut := newDoctorAPIJSONCLI(t, `{"apis":{"demo":{"base_url":"https://api.example.com/%zz?key=secret-token%zz&version=1"}}}`)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("transport should not be called for invalid URL")
+		return nil, nil
+	})
+	report := runDoctorReachabilityJSON(t, c, out, errOut)
+	if report.Reachability.Status != "invalid_url" || report.Reachability.Error == "" {
+		t.Fatalf("unexpected reachability report: %#v", report.Reachability)
+	}
+	if strings.Contains(report.Reachability.Error, "secret-token") {
+		t.Fatalf("credential query leaked in doctor error: %q", report.Reachability.Error)
+	}
+}
+
+func TestDoctorAPIReachabilityRedactsFailedRequestCredentialQuery(t *testing.T) {
+	c, out, errOut := newDoctorAPIJSONCLI(t, `{
+  "apis": {
+    "demo": {
+      "base_url": "api.example.com",
+      "profiles": {
+        "default": {
+          "auth": {
+            "type": "api-key",
+            "params": {"in": "query", "name": "key", "value": "secret-token"}
+          }
+        }
+      }
+    }
+  }
+}`)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial failed for %s", r.URL.String())
+	})
+	report := runDoctorReachabilityJSON(t, c, out, errOut)
+	if report.Reachability.Status != "failed" || report.Reachability.Error == "" {
+		t.Fatalf("unexpected reachability report: %#v", report.Reachability)
+	}
+	if strings.Contains(report.Reachability.Error, "secret-token") {
+		t.Fatalf("credential query leaked in doctor error: %q", report.Reachability.Error)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -736,6 +736,47 @@ func TestLoad_MigratesLegacyMacOSConfig(t *testing.T) {
 	}
 }
 
+func TestLoad_MigratesLegacyFileCert(t *testing.T) {
+	home := t.TempDir()
+	setLegacyConfigEnv(t, home)
+	legacyDir := filepath.Join(home, ".config", "restish")
+	writeFile(t, filepath.Join(legacyDir, "apis.json"), `{
+  "$schema": "https://rest.sh/schemas/apis.json",
+  "myapi": {
+    "base": "https://api.example.com",
+    "tls": {
+      "cert": "/home/user/.pki/cert.pem",
+      "key": "/home/user/.pki/key.pem"
+    }
+  }
+}`)
+
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	path := config.DefaultPath()
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Migration == nil {
+		t.Fatal("expected migration info")
+	}
+
+	api := cfg.APIs["myapi"]
+	if api == nil {
+		t.Fatal("expected migrated API config")
+	}
+	prof := api.Profiles["default"]
+	if prof == nil {
+		t.Fatal("expected default profile")
+	}
+	if prof.ClientCertPath != "/home/user/.pki/cert.pem" {
+		t.Fatalf("ClientCertPath = %q, want %q", prof.ClientCertPath, "/home/user/.pki/cert.pem")
+	}
+	if prof.ClientKeyPath != "/home/user/.pki/key.pem" {
+		t.Fatalf("ClientKeyPath = %q, want %q", prof.ClientKeyPath, "/home/user/.pki/key.pem")
+	}
+}
+
 func TestLoad_MigrationReusesMatchingExistingBackupDir(t *testing.T) {
 	home := t.TempDir()
 	setLegacyConfigEnv(t, home)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -40,6 +40,8 @@ type legacyPKCS11Config struct {
 
 type legacyTLSConfig struct {
 	PKCS11 *legacyPKCS11Config `json:"pkcs11,omitempty"`
+	Cert   string              `json:"cert,omitempty"`
+	Key    string              `json:"key,omitempty"`
 }
 
 type legacyAPIProfile struct {
@@ -246,6 +248,23 @@ func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*APIConfig, [
 		}
 		if legacy.TLS.PKCS11.Label != "" && prof.TLSSignerParams["label"] == "" {
 			prof.TLSSignerParams["label"] = legacy.TLS.PKCS11.Label
+		}
+	}
+
+	if legacy.TLS != nil && (legacy.TLS.Cert != "" || legacy.TLS.Key != "") {
+		if api.Profiles == nil {
+			api.Profiles = map[string]*ProfileConfig{}
+		}
+		prof := api.Profiles["default"]
+		if prof == nil {
+			prof = &ProfileConfig{}
+			api.Profiles["default"] = prof
+		}
+		if prof.ClientCertPath == "" && legacy.TLS.Cert != "" {
+			prof.ClientCertPath = legacy.TLS.Cert
+		}
+		if prof.ClientKeyPath == "" && legacy.TLS.Key != "" {
+			prof.ClientKeyPath = legacy.TLS.Key
 		}
 	}
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -4,6 +4,7 @@ package secrets
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -130,6 +131,8 @@ func RedactDiagnosticText(value string) string {
 		"refresh_token",
 		"id_token",
 		"client_secret",
+		"api_key",
+		"apikey",
 		"password",
 		"authorization",
 		"proxy-authorization",
@@ -142,6 +145,73 @@ func RedactDiagnosticText(value string) string {
 		value = redactDiagnosticAssignment(value, marker)
 	}
 	return value
+}
+
+// RedactDiagnosticURLText removes credential-looking query parameters from
+// URL-shaped diagnostic text, including malformed URLs that net/url cannot
+// parse. It then applies the generic assignment redactor.
+func RedactDiagnosticURLText(value string) string {
+	value = strings.TrimSpace(value)
+	searchFrom := 0
+	for {
+		qRel := strings.IndexByte(value[searchFrom:], '?')
+		if qRel < 0 {
+			return RedactDiagnosticText(value)
+		}
+		qStart := searchFrom + qRel
+		qEnd := diagnosticQueryEnd(value, qStart+1)
+		if qEnd <= qStart+1 {
+			return RedactDiagnosticText(value)
+		}
+		query := value[qStart+1 : qEnd]
+		parts := strings.Split(query, "&")
+		changed := false
+		kept := parts[:0]
+		for _, part := range parts {
+			name, rawValue, _ := strings.Cut(part, "=")
+			if decoded, err := url.QueryUnescape(name); err == nil {
+				name = decoded
+			}
+			valueForCheck := rawValue
+			if decoded, err := url.QueryUnescape(rawValue); err == nil {
+				valueForCheck = decoded
+			}
+			if IsQueryParamValue(name, valueForCheck) || invalidEscapeLooksSensitive(name, rawValue) {
+				changed = true
+				continue
+			}
+			kept = append(kept, part)
+		}
+		if !changed {
+			searchFrom = qEnd
+			continue
+		}
+		if len(kept) == 0 {
+			value = value[:qStart] + value[qEnd:]
+		} else {
+			value = value[:qStart+1] + strings.Join(kept, "&") + value[qEnd:]
+		}
+		searchFrom = qStart
+	}
+}
+
+func diagnosticQueryEnd(value string, start int) int {
+	end := len(value)
+	for i := start; i < len(value); i++ {
+		switch value[i] {
+		case '#', ' ', '\t', '\r', '\n', '"', '\'', '<', '>':
+			return i
+		}
+	}
+	return end
+}
+
+func invalidEscapeLooksSensitive(name, value string) bool {
+	if _, err := url.QueryUnescape(value); err == nil {
+		return false
+	}
+	name = strings.ToLower(strings.TrimSpace(name))
+	return ambiguousQueryParamNames[name] && len(value) >= 7
 }
 
 func redactDiagnosticAssignment(value, marker string) string {

--- a/internal/spec/cache.go
+++ b/internal/spec/cache.go
@@ -43,6 +43,7 @@ type cachedRaw struct {
 	ContentType      string `cbor:"content_type,omitempty"`
 	Raw              []byte `cbor:"raw,omitempty"`
 	DiscoveryBaseURL string `cbor:"discovery_base_url,omitempty"`
+	RequestedURL     string `cbor:"requested_url,omitempty"`
 	SourceURL        string `cbor:"source_url,omitempty"`
 	LocalPath        string `cbor:"local_path,omitempty"`
 	AllowCrossOrigin bool   `cbor:"allow_cross_origin,omitempty"`
@@ -119,6 +120,7 @@ func writeCache(cacheDir, apiName string, entry *cacheEntry) error {
 		return fmt.Errorf("spec cache: invalid API name %q", apiName)
 	}
 	entry.normalize()
+	sanitizeCacheEntryForWrite(entry)
 	if entry.Schema == 0 {
 		entry.Schema = currentCacheSchema
 	}
@@ -175,6 +177,7 @@ func (e *cacheEntry) loadOptions() LoadOptions {
 	e.normalize()
 	return LoadOptions{
 		SourceURL:        e.Spec.SourceURL,
+		RequestedURL:     e.Spec.RequestedURL,
 		LocalPath:        e.Spec.LocalPath,
 		AllowCrossOrigin: e.Spec.AllowCrossOrigin,
 	}
@@ -245,13 +248,14 @@ func LoadOperationSetFromCacheStatus(cacheDir, apiName, version string, specFile
 		return OperationSet{}, status, false
 	}
 	rawHash := cacheRawHash(entry.raw())
+	cacheOpts := cacheOperationOptions(opts)
 	for _, blob := range entry.Operations {
 		if blob.Schema != currentOperationCacheSchema {
 			continue
 		}
-		if blob.BaseURL == opts.BaseURL &&
-			blob.OperationBase == opts.OperationBase &&
-			blob.ServerVariablesKey == ServerVariablesCacheKey(opts.ServerVariables) &&
+		if blob.BaseURL == cacheOpts.BaseURL &&
+			blob.OperationBase == cacheOpts.OperationBase &&
+			blob.ServerVariablesKey == ServerVariablesCacheKey(cacheOpts.ServerVariables) &&
 			blob.RawSHA256 == rawHash {
 			set := OperationSet{
 				Info:           blob.Info,
@@ -299,7 +303,7 @@ func StoreOperationSetInCache(cacheDir, apiName, version string, opts OperationO
 	if !ok {
 		return nil
 	}
-	entry.upsertOperationSet(opts, set)
+	entry.upsertOperationSet(cacheOperationOptions(opts), set)
 	return writeCache(cacheDir, apiName, entry)
 }
 
@@ -322,17 +326,59 @@ func StoreSpecInCache(cacheDir, apiName, version string, apiSpec *APISpec, specF
 		Spec: cachedRaw{
 			ContentType:      apiSpec.ContentType,
 			Raw:              apiSpec.Raw,
-			DiscoveryBaseURL: opts.BaseURL,
-			SourceURL:        apiSpec.SourceURL,
+			DiscoveryBaseURL: cleanSourceURL(opts.BaseURL),
+			RequestedURL:     cleanSourceURL(apiSpec.RequestedURL),
+			SourceURL:        cleanSourceURL(apiSpec.SourceURL),
 			LocalPath:        apiSpec.LocalPath,
 			AllowCrossOrigin: apiSpec.AllowCrossOrigin,
 		},
 	}
 	entry.SpecFiles = cacheSpecFileMetadata(specFiles)
 	if set.Operations != nil {
-		entry.upsertOperationSet(opts, set)
+		entry.upsertOperationSet(cacheOperationOptions(opts), set)
 	}
 	return writeCache(cacheDir, apiName, entry)
+}
+
+func cacheOperationOptions(opts OperationOptions) OperationOptions {
+	opts.BaseURL = cleanSourceURL(opts.BaseURL)
+	opts.OperationBase = cleanSourceURL(opts.OperationBase)
+	return opts
+}
+
+func sanitizeCacheEntryForWrite(entry *cacheEntry) {
+	if entry == nil {
+		return
+	}
+	entry.Spec.DiscoveryBaseURL = cleanSourceURL(entry.Spec.DiscoveryBaseURL)
+	entry.Spec.RequestedURL = cleanSourceURL(entry.Spec.RequestedURL)
+	entry.Spec.SourceURL = cleanSourceURL(entry.Spec.SourceURL)
+	for i := range entry.SpecFiles {
+		if !entry.SpecFiles[i].Local {
+			entry.SpecFiles[i].Source = cleanSourceURL(entry.SpecFiles[i].Source)
+		}
+	}
+	entry.Operations = sanitizeOpsBlobs(entry.Operations)
+}
+
+func sanitizeOpsBlobs(blobs []opsBlob) []opsBlob {
+	if len(blobs) == 0 {
+		return blobs
+	}
+	out := make([]opsBlob, 0, len(blobs))
+	index := map[string]int{}
+	for _, blob := range blobs {
+		blob.BaseURL = cleanSourceURL(blob.BaseURL)
+		blob.OperationBase = cleanSourceURL(blob.OperationBase)
+		key := fmt.Sprintf("%d\x00%s\x00%s\x00%s\x00%s", blob.Schema, blob.BaseURL, blob.OperationBase, blob.ServerVariablesKey, blob.RawSHA256)
+		if i, ok := index[key]; ok {
+			out[i] = blob
+			continue
+		}
+		index[key] = len(out)
+		out = append(out, blob)
+	}
+	return out
 }
 
 func (e *cacheEntry) upsertOperationSet(opts OperationOptions, set OperationSet) {

--- a/internal/spec/cache_test.go
+++ b/internal/spec/cache_test.go
@@ -6,9 +6,12 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/fxamacker/cbor/v2"
 )
 
 const testSpecRaw = `{"openapi":"3.1.0","info":{"title":"Test","version":"1.0.0"},"paths":{}}`
+const testSpecRawWithOperation = `{"openapi":"3.1.0","info":{"title":"Test","version":"1.0.0"},"paths":{"/items":{"get":{"operationId":"listItems","responses":{"200":{"description":"OK"}}}}}}`
 
 func TestWriteAndReadCache(t *testing.T) {
 	dir := t.TempDir()
@@ -57,6 +60,105 @@ func TestWriteCacheUsesAtomicReplacement(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("cache mode = %v, want 0600", got)
+	}
+}
+
+func credentialURLTestOperationOptions() OperationOptions {
+	return OperationOptions{
+		BaseURL:       "https://api.example.com?api_key=base-secret&region=us",
+		OperationBase: "https://ops.example.com/root?api_key=op-secret&page=1",
+	}
+}
+
+func assertCacheEntryHasCleanCredentialURLMetadata(t *testing.T, entry *cacheEntry, opCount int) {
+	t.Helper()
+	if got := entry.Spec.DiscoveryBaseURL; got != "https://api.example.com?region=us" {
+		t.Fatalf("DiscoveryBaseURL = %q, want clean URL", got)
+	}
+	if got := entry.Spec.SourceURL; got != "https://api.example.com/openapi.json?version=1" {
+		t.Fatalf("SourceURL = %q, want clean URL", got)
+	}
+	if len(entry.SpecFiles) != 1 || entry.SpecFiles[0].Source != "https://files.example.com/openapi.json?version=1" {
+		t.Fatalf("SpecFiles = %#v, want clean remote source", entry.SpecFiles)
+	}
+	if len(entry.Operations) != opCount {
+		t.Fatalf("Operations = %d, want %d cached operation blob(s)", len(entry.Operations), opCount)
+	}
+	if got := entry.Operations[0].BaseURL; got != "https://api.example.com?region=us" {
+		t.Fatalf("operation BaseURL = %q, want clean URL", got)
+	}
+	if got := entry.Operations[0].OperationBase; got != "https://ops.example.com/root?page=1" {
+		t.Fatalf("operation OperationBase = %q, want clean URL", got)
+	}
+}
+
+func TestStoreSpecInCacheCleansCredentialURLMetadata(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte(testSpecRawWithOperation)
+	apiSpec, err := OpenAPILoader{}.LoadWithOptions(raw, LoadOptions{
+		SourceURL: "https://api.example.com/openapi.json?api_key=spec-secret&version=1",
+	})
+	if err != nil {
+		t.Fatalf("load spec: %v", err)
+	}
+	apiSpec.SourceURL = "https://api.example.com/openapi.json?api_key=spec-secret&version=1"
+
+	specFiles := []string{"https://files.example.com/openapi.json?access_token=file-secret&version=1"}
+	if err := StoreSpecInCache(dir, "testapi", "v2", apiSpec, specFiles, credentialURLTestOperationOptions(), time.Hour); err != nil {
+		t.Fatalf("StoreSpecInCache: %v", err)
+	}
+
+	entry, ok := readCache(dir, "testapi", "v2")
+	if !ok {
+		t.Fatal("expected cache entry")
+	}
+	assertCacheEntryHasCleanCredentialURLMetadata(t, entry, 1)
+}
+
+func TestStoreOperationSetInCacheCleansLegacyCredentialURLMetadata(t *testing.T) {
+	dir := t.TempDir()
+	raw := []byte(testSpecRawWithOperation)
+	legacy := &cacheEntry{
+		Version:   "v2",
+		FetchedAt: time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+		Schema:    currentCacheSchema,
+		Spec: cachedRaw{
+			ContentType:      "application/json",
+			Raw:              raw,
+			DiscoveryBaseURL: "https://api.example.com?api_key=base-secret&region=us",
+			SourceURL:        "https://api.example.com/openapi.json?api_key=spec-secret&version=1",
+		},
+		SpecFiles: []cachedSpecFile{{
+			Source: "https://files.example.com/openapi.json?access_token=file-secret&version=1",
+		}},
+		Operations: []opsBlob{{
+			Schema:        currentOperationCacheSchema,
+			BaseURL:       "https://api.example.com?api_key=base-secret&region=us",
+			OperationBase: "https://ops.example.com/root?api_key=op-secret&page=1",
+			RawSHA256:     cacheRawHash(raw),
+			Operations:    []Operation{{ID: "old"}},
+		}},
+	}
+	data, err := cbor.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy cache: %v", err)
+	}
+	if err := atomicWriteCacheFile(cacheFile(dir, "testapi"), data); err != nil {
+		t.Fatalf("write legacy cache: %v", err)
+	}
+
+	if err := StoreOperationSetInCache(dir, "testapi", "v2", credentialURLTestOperationOptions(), OperationSet{Operations: []Operation{{ID: "new"}}}); err != nil {
+		t.Fatalf("StoreOperationSetInCache: %v", err)
+	}
+
+	entry, ok := readCache(dir, "testapi", "v2")
+	if !ok {
+		t.Fatal("expected cache entry")
+	}
+	assertCacheEntryHasCleanCredentialURLMetadata(t, entry, 1)
+	if got := entry.Operations[0].Operations[0].ID; got != "new" {
+		t.Fatalf("operation blob ID = %q, want updated blob to win", got)
 	}
 }
 

--- a/internal/spec/discover.go
+++ b/internal/spec/discover.go
@@ -502,6 +502,9 @@ func fetchWithLinks(ctx context.Context, rawURL string, tr http.RoundTripper, fe
 	if err != nil {
 		return "", nil, 0, displayURL, nil, fmt.Errorf("GET %s: %w", displayURL, cleanErrorForDisplay(err, rawURL, displayURL))
 	}
+	if resp == nil {
+		return "", nil, 0, displayURL, nil, fmt.Errorf("GET %s: no response", displayURL)
+	}
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}

--- a/internal/spec/discover.go
+++ b/internal/spec/discover.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/rest-sh/restish/v2/internal/hypermedia"
+	"github.com/rest-sh/restish/v2/internal/request"
+	"github.com/rest-sh/restish/v2/internal/secrets"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -70,6 +72,8 @@ type DiscoverConfig struct {
 	Version string
 	// Transport is used for all HTTP fetches.  nil uses http.DefaultTransport.
 	Transport http.RoundTripper
+	// Fetch, when set, is used for all HTTP fetches instead of Transport.
+	Fetch HTTPFetcher
 	// AllowCrossOrigin permits Link-header-discovered spec URLs on other hosts.
 	// When false, only same-host discovered links are followed. Private/local
 	// cross-origin targets are still rejected unless the base URL is already in
@@ -99,7 +103,7 @@ func Discover(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*APISp
 		ctx, cancel = context.WithTimeout(ctx, discoverTimeout(cfg))
 		defer cancel()
 	}
-	tracef(cfg.Trace, "OpenAPI discovery for %q: base=%s spec=%s", cfg.APIName, cfg.BaseURL, cfg.SpecURL)
+	tracef(cfg.Trace, "OpenAPI discovery for %q: base=%s spec=%s", cfg.APIName, cleanSourceURL(cfg.BaseURL), cleanSourceURL(cfg.SpecURL))
 
 	// 1. Cache check (synchronous, no network).
 	if cfg.CacheDir != "" && !cfg.ForceRefresh {
@@ -113,6 +117,7 @@ func Discover(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*APISp
 			opts := entry.loadOptions()
 			opts.Context = ctx
 			opts.Transport = effectiveTransport(cfg)
+			opts.Fetch = effectiveFetcher(cfg)
 			opts.Trace = cfg.Trace
 			if spec, err := loadWithOptions(entry.contentType(), entry.raw(), loaders, opts); err == nil && spec != nil {
 				return spec, nil
@@ -137,7 +142,7 @@ loadFresh:
 				Spec: cachedRaw{
 					ContentType:      spec.ContentType,
 					Raw:              spec.Raw,
-					DiscoveryBaseURL: cfg.BaseURL,
+					DiscoveryBaseURL: cleanSourceURL(cfg.BaseURL),
 					SourceURL:        spec.SourceURL,
 					LocalPath:        spec.LocalPath,
 					AllowCrossOrigin: spec.AllowCrossOrigin,
@@ -145,7 +150,7 @@ loadFresh:
 			}
 			entry.SpecFiles = cacheSpecFileMetadata(cfg.SpecFiles)
 			if set.Operations != nil {
-				entry.upsertOperationSet(opts, set)
+				entry.upsertOperationSet(cacheOperationOptions(opts), set)
 			}
 			if err := writeCache(cfg.CacheDir, cfg.APIName, entry); err != nil {
 				return nil, err
@@ -158,6 +163,9 @@ loadFresh:
 	spec, ttl, err := discoverFromNetwork(ctx, cfg, loaders)
 	if err != nil {
 		return nil, err
+	}
+	if spec != nil && cfg.SpecURL != "" && spec.RequestedURL == "" {
+		spec.RequestedURL = cleanSourceURL(cfg.SpecURL)
 	}
 
 	// Cache the result.
@@ -177,14 +185,15 @@ loadFresh:
 			Spec: cachedRaw{
 				ContentType:      spec.ContentType,
 				Raw:              spec.Raw,
-				DiscoveryBaseURL: cfg.BaseURL,
+				DiscoveryBaseURL: cleanSourceURL(cfg.BaseURL),
+				RequestedURL:     cleanSourceURL(cfg.SpecURL),
 				SourceURL:        spec.SourceURL,
 				LocalPath:        spec.LocalPath,
 				AllowCrossOrigin: spec.AllowCrossOrigin,
 			},
 		}
 		if set.Operations != nil {
-			entry.upsertOperationSet(opts, set)
+			entry.upsertOperationSet(cacheOperationOptions(opts), set)
 		}
 		if err := writeCache(cfg.CacheDir, cfg.APIName, entry); err != nil {
 			return nil, err
@@ -215,16 +224,23 @@ func cacheSourceMatches(cfg DiscoverConfig, entry *cacheEntry) bool {
 		return false
 	}
 	entry.normalize()
-	if entry.Spec.DiscoveryBaseURL != "" && entry.Spec.DiscoveryBaseURL != cfg.BaseURL {
+	if entry.Spec.DiscoveryBaseURL != "" && !sourceURLMatches(entry.Spec.DiscoveryBaseURL, cfg.BaseURL) {
 		return false
 	}
 	if len(cfg.SpecFiles) > 0 {
 		return cacheSpecFilesMatch(cfg.SpecFiles, entry)
 	}
 	if cfg.SpecURL != "" {
-		return entry.Spec.SourceURL == cfg.SpecURL
+		if entry.Spec.RequestedURL != "" {
+			return sourceURLMatches(entry.Spec.RequestedURL, cfg.SpecURL)
+		}
+		return sourceURLMatches(entry.Spec.SourceURL, cfg.SpecURL)
 	}
 	return true
+}
+
+func sourceURLMatches(got, want string) bool {
+	return cleanSourceURL(got) == cleanSourceURL(want)
 }
 
 func cacheSpecFilesMatch(specFiles []string, entry *cacheEntry) bool {
@@ -249,7 +265,7 @@ func cacheSpecFilesMatch(specFiles []string, entry *cacheEntry) bool {
 		}
 		return entry.Spec.LocalPath == path
 	}
-	return entry.Spec.SourceURL == src
+	return sourceURLMatches(entry.Spec.SourceURL, src)
 }
 
 func cacheSpecFileMetadata(specFiles []string) []cachedSpecFile {
@@ -269,6 +285,8 @@ func cacheSpecFileMetadata(specFiles []string) []cachedSpecFile {
 					meta.Size = info.Size()
 				}
 			}
+		} else {
+			meta.Source = cleanSourceURL(src)
 		}
 		out = append(out, meta)
 	}
@@ -326,51 +344,56 @@ func discoverFromNetwork(ctx context.Context, cfg DiscoverConfig, loaders []Load
 	ch := make(chan discoveryResult, initialProbes)
 	var wg sync.WaitGroup
 	tr := effectiveTransport(cfg)
+	fetch := effectiveFetcher(cfg)
 
-	launch := func(priority int, sourceURL string, fn func() (string, []byte, time.Duration, error)) {
+	launch := func(priority int, sourceURL string, fn func() (string, []byte, time.Duration, string, error)) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ct, body, ttl, err := fn()
+			ct, body, ttl, effectiveSourceURL, err := fn()
+			if effectiveSourceURL == "" {
+				effectiveSourceURL = sourceURL
+			}
 			if err != nil {
 				if priority > 0 && errors.Is(err, errNoSpecCandidate) {
 					return
 				}
 				if ctx.Err() != nil {
 					select {
-					case ch <- discoveryResult{err: err, priority: priority, sourceURL: sourceURL}:
+					case ch <- discoveryResult{err: err, priority: priority, sourceURL: effectiveSourceURL}:
 					default:
 					}
 					return
 				}
 				select {
-				case ch <- discoveryResult{err: err, priority: priority, sourceURL: sourceURL}:
+				case ch <- discoveryResult{err: err, priority: priority, sourceURL: effectiveSourceURL}:
 				case <-ctx.Done():
 				}
 				return
 			}
 			spec, loadErr := loadWithOptions(ct, body, loaders, LoadOptions{
 				Context:          ctx,
-				SourceURL:        sourceURL,
+				SourceURL:        effectiveSourceURL,
 				AllowCrossOrigin: cfg.AllowCrossOrigin,
 				Transport:        tr,
+				Fetch:            fetch,
 				Trace:            cfg.Trace,
 			})
 			if spec != nil && spec.SourceURL == "" {
-				spec.SourceURL = sourceURL
+				spec.SourceURL = effectiveSourceURL
 			}
 			if priority == 0 && spec == nil && loadErr == nil {
-				loadErr = fmt.Errorf("GET %s: unsupported API spec: expected an OpenAPI 3.x document", sourceURL)
+				loadErr = fmt.Errorf("GET %s: unsupported API spec: expected an OpenAPI 3.x document", effectiveSourceURL)
 			}
 			if loadErr != nil && ctx.Err() != nil {
 				select {
-				case ch <- discoveryResult{spec: spec, ttl: ttl, err: loadErr, priority: priority, sourceURL: sourceURL}:
+				case ch <- discoveryResult{spec: spec, ttl: ttl, err: loadErr, priority: priority, sourceURL: effectiveSourceURL}:
 				default:
 				}
 				return
 			}
 			select {
-			case ch <- discoveryResult{spec: spec, ttl: ttl, err: loadErr, priority: priority, sourceURL: sourceURL}:
+			case ch <- discoveryResult{spec: spec, ttl: ttl, err: loadErr, priority: priority, sourceURL: effectiveSourceURL}:
 			case <-ctx.Done():
 			}
 		}()
@@ -379,12 +402,12 @@ func discoverFromNetwork(ctx context.Context, cfg DiscoverConfig, loaders []Load
 	// Explicit spec URL (priority 0 — most authoritative error source).
 	if cfg.SpecURL != "" {
 		u := cfg.SpecURL
-		launch(0, u, func() (string, []byte, time.Duration, error) {
-			ct, body, ttl, err := fetchBytes(ctx, u, tr, cfg.Trace)
+		launch(0, u, func() (string, []byte, time.Duration, string, error) {
+			ct, body, ttl, sourceURL, err := fetchBytes(ctx, u, tr, fetch, cfg.Trace)
 			if errors.Is(err, errNoSpecCandidate) {
-				return "", nil, 0, fmt.Errorf("GET %s: 404 Not Found", u)
+				return "", nil, 0, sourceURL, fmt.Errorf("GET %s: 404 Not Found", sourceURL)
 			}
-			return ct, body, ttl, err
+			return ct, body, ttl, sourceURL, err
 		})
 		go func() {
 			wg.Wait()
@@ -395,10 +418,10 @@ func discoverFromNetwork(ctx context.Context, cfg DiscoverConfig, loaders []Load
 
 	// Probe base URL: extract Link headers and try the body itself.
 	baseURL := cfg.BaseURL
-	launch(1, baseURL, func() (string, []byte, time.Duration, error) {
-		ct, body, ttl, linkURLs, err := fetchWithLinks(ctx, baseURL, tr, cfg.AllowCrossOrigin, cfg.Trace)
+	launch(1, baseURL, func() (string, []byte, time.Duration, string, error) {
+		ct, body, ttl, sourceURL, linkURLs, err := fetchWithLinks(ctx, baseURL, tr, fetch, cfg.AllowCrossOrigin, cfg.Trace)
 		if err != nil {
-			return "", nil, 0, err
+			return "", nil, 0, sourceURL, err
 		}
 		// Launch Link-header candidates as additional probes.
 		// Calling launch() from within a goroutine tracked by wg is safe:
@@ -406,18 +429,18 @@ func discoverFromNetwork(ctx context.Context, cfg DiscoverConfig, loaders []Load
 		// counter is still ≥1 when the inner wg.Add(1) is called.
 		for _, lu := range linkURLs {
 			u := lu
-			launch(1, u, func() (string, []byte, time.Duration, error) {
-				return fetchBytes(ctx, u, tr, cfg.Trace)
+			launch(1, u, func() (string, []byte, time.Duration, string, error) {
+				return fetchBytes(ctx, u, tr, fetch, cfg.Trace)
 			})
 		}
-		return ct, body, ttl, nil
+		return ct, body, ttl, sourceURL, nil
 	})
 
 	// Well-known paths.
 	for _, path := range wellKnownSpecPaths {
 		u := joinURL(cfg.BaseURL, path)
-		launch(1, u, func() (string, []byte, time.Duration, error) {
-			return fetchBytes(ctx, u, tr, cfg.Trace)
+		launch(1, u, func() (string, []byte, time.Duration, string, error) {
+			return fetchBytes(ctx, u, tr, fetch, cfg.Trace)
 		})
 	}
 
@@ -462,41 +485,43 @@ func collectDiscoveryResults(ctx context.Context, cancel context.CancelFunc, ch 
 	if err := ctx.Err(); err != nil {
 		return nil, 0, err
 	}
-	return nil, 0, fmt.Errorf("%w at %s", ErrNoSpecFound, baseURL)
+	return nil, 0, fmt.Errorf("%w at %s", ErrNoSpecFound, cleanSourceURL(baseURL))
 }
 
-// fetchBytes performs a GET and returns content-type, body, cache TTL, and error.
-func fetchBytes(ctx context.Context, rawURL string, tr http.RoundTripper, trace func(format string, args ...any)) (string, []byte, time.Duration, error) {
-	ct, body, ttl, _, err := fetchWithLinks(ctx, rawURL, tr, true, trace)
-	return ct, body, ttl, err
+// fetchBytes performs a GET and returns content-type, body, cache TTL, effective source URL, and error.
+func fetchBytes(ctx context.Context, rawURL string, tr http.RoundTripper, fetch HTTPFetcher, trace func(format string, args ...any)) (string, []byte, time.Duration, string, error) {
+	ct, body, ttl, sourceURL, _, err := fetchWithLinks(ctx, rawURL, tr, fetch, true, trace)
+	return ct, body, ttl, sourceURL, err
 }
 
 // fetchWithLinks performs a GET and also returns parsed Link header spec URLs.
-func fetchWithLinks(ctx context.Context, rawURL string, tr http.RoundTripper, allowCrossOrigin bool, trace func(format string, args ...any)) (ct string, body []byte, ttl time.Duration, links []string, err error) {
-	tracef(trace, "GET OpenAPI source %s", rawURL)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+func fetchWithLinks(ctx context.Context, rawURL string, tr http.RoundTripper, fetch HTTPFetcher, allowCrossOrigin bool, trace func(format string, args ...any)) (ct string, body []byte, ttl time.Duration, sourceURL string, links []string, err error) {
+	displayURL := cleanSourceURL(rawURL)
+	tracef(trace, "GET OpenAPI source %s", displayURL)
+	resp, err := fetch(ctx, rawURL, tr)
 	if err != nil {
-		return "", nil, 0, nil, err
+		return "", nil, 0, displayURL, nil, fmt.Errorf("GET %s: %w", displayURL, cleanErrorForDisplay(err, rawURL, displayURL))
 	}
-	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		return "", nil, 0, nil, err
+	if resp.Body != nil {
+		defer resp.Body.Close()
 	}
-	defer resp.Body.Close()
+	sourceURL = effectiveResponseSourceURL(rawURL, resp)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp.StatusCode == http.StatusNotFound {
-			return "", nil, 0, nil, errNoSpecCandidate
+			return "", nil, 0, sourceURL, nil, errNoSpecCandidate
 		}
-		return "", nil, 0, nil, fmt.Errorf("GET %s: %s", rawURL, resp.Status)
+		return "", nil, 0, sourceURL, nil, fmt.Errorf("GET %s: %s", sourceURL, resp.Status)
 	}
 
-	body, err = io.ReadAll(io.LimitReader(resp.Body, maxSpecBytes+1))
+	if resp.Body != nil {
+		body, err = io.ReadAll(io.LimitReader(resp.Body, maxSpecBytes+1))
+	}
 	if err != nil {
-		return "", nil, 0, nil, err
+		return "", nil, 0, sourceURL, nil, err
 	}
 	if int64(len(body)) > maxSpecBytes {
-		return "", nil, 0, nil, fmt.Errorf("spec body from %s exceeds limit of %d bytes", rawURL, maxSpecBytes)
+		return "", nil, 0, sourceURL, nil, fmt.Errorf("spec body from %s exceeds limit of %d bytes", sourceURL, maxSpecBytes)
 	}
 
 	ct = resp.Header.Get("Content-Type")
@@ -505,8 +530,91 @@ func fetchWithLinks(ctx context.Context, rawURL string, tr http.RoundTripper, al
 	}
 
 	ttl = cacheTTL(resp)
-	links = filterDiscoveredSpecLinks(rawURL, extractSpecLinks(rawURL, resp.Header), allowCrossOrigin)
-	return ct, body, ttl, links, nil
+	links = filterDiscoveredSpecLinks(sourceURL, extractSpecLinks(sourceURL, resp.Header), allowCrossOrigin)
+	return ct, body, ttl, sourceURL, links, nil
+}
+
+func effectiveResponseSourceURL(rawURL string, resp *http.Response) string {
+	normalizedRaw := rawURL
+	if normalized, err := request.Normalize(rawURL, ""); err == nil {
+		normalizedRaw = normalized
+	}
+	base, baseErr := url.Parse(normalizedRaw)
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil || baseErr != nil {
+		return cleanSourceURL(rawURL)
+	}
+	source := *resp.Request.URL
+	source.User = nil
+	source.Fragment = ""
+	if resp.Request.Response != nil {
+		source.RawQuery = cleanSourceURLQuery(source.Query()).Encode()
+	} else {
+		source.RawQuery = cleanSourceURLQuery(base.Query()).Encode()
+	}
+	return source.String()
+}
+
+func cleanSourceURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return raw
+	}
+	cleaned := raw
+	if normalized, err := request.Normalize(raw, ""); err == nil {
+		cleaned = normalized
+	}
+	u, err := url.Parse(cleaned)
+	if err != nil || !u.IsAbs() {
+		return cleanPossiblyInvalidURL(cleaned)
+	}
+	u.User = nil
+	u.Fragment = ""
+	u.RawQuery = cleanSourceURLQuery(u.Query()).Encode()
+	return u.String()
+}
+
+func cleanSourceURLQuery(values url.Values) url.Values {
+	cleaned := url.Values{}
+	for name, vals := range values {
+		if request.IsCredentialQueryParam(name) {
+			continue
+		}
+		for _, value := range vals {
+			if secrets.IsQueryParamValue(name, value) {
+				continue
+			}
+			cleaned.Add(name, value)
+		}
+	}
+	return cleaned
+}
+
+func cleanPossiblyInvalidURL(raw string) string {
+	return secrets.RedactDiagnosticURLText(raw)
+}
+
+type displayError struct {
+	err     error
+	raw     string
+	display string
+}
+
+func (e displayError) Error() string {
+	msg := e.err.Error()
+	if e.raw != "" && e.display != "" {
+		msg = strings.ReplaceAll(msg, e.raw, e.display)
+	}
+	return cleanPossiblyInvalidURL(msg)
+}
+
+func (e displayError) Unwrap() error {
+	return e.err
+}
+
+func cleanErrorForDisplay(err error, raw, display string) error {
+	if err == nil {
+		return nil
+	}
+	return displayError{err: err, raw: raw, display: display}
 }
 
 // effectiveTransport returns cfg.Transport when set, or http.DefaultTransport.
@@ -515,6 +623,19 @@ func effectiveTransport(cfg DiscoverConfig) http.RoundTripper {
 		return cfg.Transport
 	}
 	return http.DefaultTransport
+}
+
+func effectiveFetcher(cfg DiscoverConfig) HTTPFetcher {
+	if cfg.Fetch != nil {
+		return cfg.Fetch
+	}
+	return func(ctx context.Context, rawURL string, tr http.RoundTripper) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		return tr.RoundTrip(req)
+	}
 }
 
 // cacheTTL extracts the cache duration from a response's Cache-Control header.
@@ -663,10 +784,12 @@ func joinURL(base, path string) string {
 // scalar spellings are not preserved in the merged representation.
 func loadSpecFiles(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*APISpec, error) {
 	tr := effectiveTransport(cfg)
+	fetch := effectiveFetcher(cfg)
 
 	// Fast path: single file needs no merge; avoid an extra unmarshal+marshal.
 	if len(cfg.SpecFiles) == 1 {
 		src := cfg.SpecFiles[0]
+		displaySrc := specFileDisplaySource(src)
 		var ct string
 		var data []byte
 		var err error
@@ -677,22 +800,24 @@ func loadSpecFiles(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*
 				opts.LocalPath = localPath
 			}
 		} else {
-			ct, data, _, err = fetchBytes(ctx, src, tr, cfg.Trace)
-			opts.SourceURL = src
+			var sourceURL string
+			ct, data, _, sourceURL, err = fetchBytes(ctx, src, tr, fetch, cfg.Trace)
+			opts.SourceURL = sourceURL
 			opts.AllowCrossOrigin = cfg.AllowCrossOrigin
 		}
 		if err != nil {
-			return nil, fmt.Errorf("spec file %q: %w", src, err)
+			return nil, fmt.Errorf("spec file %q: %w", displaySrc, err)
 		}
 		opts.Context = ctx
 		opts.Transport = tr
+		opts.Fetch = fetch
 		opts.Trace = cfg.Trace
 		spec, err := loadWithOptions(ct, data, loaders, opts)
 		if err != nil {
 			return nil, err
 		}
 		if spec == nil {
-			return nil, fmt.Errorf("spec file %q: unsupported API spec: expected an OpenAPI 3.x document", src)
+			return nil, fmt.Errorf("spec file %q: unsupported API spec: expected an OpenAPI 3.x document", displaySrc)
 		}
 		return spec, nil
 	}
@@ -701,10 +826,11 @@ func loadSpecFiles(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*
 	var lastCT string
 
 	for _, src := range cfg.SpecFiles {
+		displaySrc := specFileDisplaySource(src)
 		var ct string
 		var data []byte
 		var err error
-		opts := LoadOptions{Context: ctx, Transport: tr, Trace: cfg.Trace}
+		opts := LoadOptions{Context: ctx, Transport: tr, Fetch: fetch, Trace: cfg.Trace}
 
 		if isLocalPath(src) {
 			ct, data, err = readLocalFile(src)
@@ -712,21 +838,22 @@ func loadSpecFiles(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*
 				opts.LocalPath = localPath
 			}
 		} else {
-			ct, data, _, err = fetchBytes(ctx, src, tr, cfg.Trace)
-			opts.SourceURL = src
+			var sourceURL string
+			ct, data, _, sourceURL, err = fetchBytes(ctx, src, tr, fetch, cfg.Trace)
+			opts.SourceURL = sourceURL
 			opts.AllowCrossOrigin = cfg.AllowCrossOrigin
 		}
 		if err != nil {
-			return nil, fmt.Errorf("spec file %q: %w", src, err)
+			return nil, fmt.Errorf("spec file %q: %w", displaySrc, err)
 		}
 		data, err = resolveOpenAPIExternalRefs(data, opts)
 		if err != nil {
-			return nil, fmt.Errorf("spec file %q: %w", src, err)
+			return nil, fmt.Errorf("spec file %q: %w", displaySrc, err)
 		}
 
 		var doc map[string]any
 		if err := yaml.Unmarshal(data, &doc); err != nil {
-			return nil, fmt.Errorf("spec file %q: parse: %w", src, err)
+			return nil, fmt.Errorf("spec file %q: parse: %w", displaySrc, err)
 		}
 		merged = deepMerge(merged, doc)
 		lastCT = ct
@@ -752,6 +879,13 @@ func loadSpecFiles(ctx context.Context, cfg DiscoverConfig, loaders []Loader) (*
 		return nil, fmt.Errorf("spec files: unsupported API spec: expected an OpenAPI 3.x document")
 	}
 	return spec, nil
+}
+
+func specFileDisplaySource(src string) string {
+	if isLocalPath(src) {
+		return src
+	}
+	return cleanSourceURL(src)
 }
 
 // isLocalPath reports whether s is a local filesystem path rather than a URL.

--- a/internal/spec/discover_test.go
+++ b/internal/spec/discover_test.go
@@ -1029,6 +1029,24 @@ func TestDiscoverRedactsCredentialQueryInInvalidSpecURL(t *testing.T) {
 	}
 }
 
+func TestDiscoverNilFetchResponseReturnsError(t *testing.T) {
+	cfg := DiscoverConfig{
+		APIName: "nil-response",
+		BaseURL: "https://api.example.com",
+		SpecURL: "https://api.example.com/openapi.json",
+		Fetch: func(context.Context, string, http.RoundTripper) (*http.Response, error) {
+			return nil, nil
+		},
+	}
+	_, err := Discover(context.Background(), cfg, DefaultLoaders())
+	if err == nil {
+		t.Fatal("expected nil fetch response failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "GET https://api.example.com/openapi.json: no response") {
+		t.Fatalf("expected no response error, got: %v", err)
+	}
+}
+
 func TestDiscoverResolvesSameOriginRemoteExternalRefs(t *testing.T) {
 	root := `openapi: "3.1.0"
 info:
@@ -1525,10 +1543,12 @@ func TestDiscoverRedactsCredentialQueryInExternalRefFailures(t *testing.T) {
 		ref     string
 		want    string
 		itemErr bool
+		itemNil bool
 		status  int
 	}{
 		{name: "status", ref: "./item.yaml?api_key=ref-secret&version=1", want: "https://specs.example.com/item.yaml?version=1", status: http.StatusInternalServerError},
 		{name: "transport", ref: "./item.yaml?api_key=ref-secret&version=1", want: "https://specs.example.com/item.yaml?version=1", itemErr: true},
+		{name: "nil response", ref: "./item.yaml?api_key=ref-secret&version=1", want: "https://specs.example.com/item.yaml?version=1", itemNil: true},
 		{name: "unsupported scheme", ref: "ftp://files.example.com/item.yaml?api_key=ref-secret&version=1", want: "ftp://files.example.com/item.yaml?version=1"},
 		{name: "malformed", ref: "./item.yaml?api_key=ref-secret%zz&version=1", want: "https://specs.example.com/item.yaml?version=1"},
 	}
@@ -1547,6 +1567,9 @@ paths:
 				case "/item.yaml":
 					if tt.itemErr {
 						return nil, fmt.Errorf("dial failed for %s", r.URL.String())
+					}
+					if tt.itemNil {
+						return nil, nil
 					}
 					return httpResponse(tt.status, "text/plain", "server error", nil), nil
 				default:
@@ -1575,6 +1598,14 @@ paths:
 				t.Fatalf("expected clean external ref URL %q, got:\n%s", tt.want, combined)
 			}
 		})
+	}
+}
+
+func TestOpenAPIRefDisplayURLPreservesAbsoluteFragmentAndRedactsQuery(t *testing.T) {
+	got := openAPIRefDisplayURL("https://user:pass@example.com/schema.yaml?api_key=secret&version=1#/components/schemas/Foo")
+	want := "https://example.com/schema.yaml?version=1#/components/schemas/Foo"
+	if got != want {
+		t.Fatalf("display URL = %q, want %q", got, want)
 	}
 }
 

--- a/internal/spec/discover_test.go
+++ b/internal/spec/discover_test.go
@@ -884,6 +884,105 @@ func TestDiscover_ExplicitSpecURL(t *testing.T) {
 	}
 }
 
+func TestDiscoverCleansCredentialURLMetadataInCache(t *testing.T) {
+	raw := `{"openapi":"3.1.0","info":{"title":"Direct","version":"1.0.0"},"paths":{"/items":{"get":{"operationId":"listItems","responses":{"200":{"description":"OK"}}}}}}`
+	tr := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.String() == "https://api.example.com/spec.json?api_key=spec-secret&version=1" {
+			resp := httpResponse(200, "application/json", raw, nil)
+			resp.Request = r
+			return resp, nil
+		}
+		return httpResponse(404, "text/plain", "not found", nil), nil
+	})
+	cacheDir := t.TempDir()
+
+	cfg := DiscoverConfig{
+		APIName:       "testapi",
+		BaseURL:       "https://api.example.com?api_key=base-secret&region=us",
+		OperationBase: "https://ops.example.com/root?api_key=op-secret&page=1",
+		SpecURL:       "https://api.example.com/spec.json?api_key=spec-secret&version=1",
+		CacheDir:      cacheDir,
+		Version:       "v2",
+		Transport:     tr,
+	}
+	if _, err := Discover(context.Background(), cfg, DefaultLoaders()); err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	entry, ok := readCache(cacheDir, "testapi", "v2")
+	if !ok {
+		t.Fatal("expected cache entry")
+	}
+	if got := entry.Spec.DiscoveryBaseURL; got != "https://api.example.com?region=us" {
+		t.Fatalf("DiscoveryBaseURL = %q, want clean URL", got)
+	}
+	if got := entry.Spec.SourceURL; got != "https://api.example.com/spec.json?version=1" {
+		t.Fatalf("SourceURL = %q, want clean URL", got)
+	}
+	if len(entry.Operations) != 1 {
+		t.Fatalf("Operations = %d, want one cached operation blob", len(entry.Operations))
+	}
+	if got := entry.Operations[0].BaseURL; got != "https://api.example.com?region=us" {
+		t.Fatalf("operation BaseURL = %q, want clean URL", got)
+	}
+	if got := entry.Operations[0].OperationBase; got != "https://ops.example.com/root?page=1" {
+		t.Fatalf("operation OperationBase = %q, want clean URL", got)
+	}
+}
+
+func TestDiscoverExplicitRedirectMatchesFreshCache(t *testing.T) {
+	raw := `{"openapi":"3.1.0","info":{"title":"Direct","version":"1.0.0"},"paths":{}}`
+	var fetches int
+	fetch := func(ctx context.Context, rawURL string, tr http.RoundTripper) (*http.Response, error) {
+		fetches++
+		if fetches > 1 {
+			return nil, errors.New("unexpected network fetch")
+		}
+		if rawURL != "https://api.example.com/openapi.json" {
+			return nil, fmt.Errorf("unexpected URL %s", rawURL)
+		}
+		finalReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com/openapi.json?version=1&api_key=secret-token", nil)
+		if err != nil {
+			return nil, err
+		}
+		finalReq.Response = &http.Response{StatusCode: http.StatusFound}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(raw)),
+			Request:    finalReq,
+		}, nil
+	}
+	cacheDir := t.TempDir()
+	cfg := DiscoverConfig{
+		APIName:  "redirected",
+		BaseURL:  "https://api.example.com",
+		SpecURL:  "https://api.example.com/openapi.json",
+		CacheDir: cacheDir,
+		Version:  "v2",
+		Fetch:    fetch,
+	}
+	first, err := Discover(context.Background(), cfg, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("first Discover: %v", err)
+	}
+	if first.SourceURL != "https://api.example.com/openapi.json?version=1" {
+		t.Fatalf("first SourceURL = %q, want clean redirect target", first.SourceURL)
+	}
+
+	cfg.Fetch = func(context.Context, string, http.RoundTripper) (*http.Response, error) {
+		return nil, errors.New("network should not be used")
+	}
+	second, err := Discover(context.Background(), cfg, DefaultLoaders())
+	if err != nil {
+		t.Fatalf("second Discover from cache: %v", err)
+	}
+	if second == nil || second.SourceURL != "https://api.example.com/openapi.json?version=1" {
+		t.Fatalf("cached SourceURL = %#v, want clean redirect target", second)
+	}
+}
+
 func TestDiscoverExplicitSpecURLRejectsNonOpenAPIJSON(t *testing.T) {
 	tr := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.String() == "https://api.example.com/spec.json" {
@@ -904,6 +1003,29 @@ func TestDiscoverExplicitSpecURLRejectsNonOpenAPIJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported API spec") || !strings.Contains(err.Error(), "https://api.example.com/spec.json") {
 		t.Fatalf("expected unsupported explicit spec URL error, got: %v", err)
+	}
+}
+
+func TestDiscoverRedactsCredentialQueryInInvalidSpecURL(t *testing.T) {
+	var traces []string
+	cfg := DiscoverConfig{
+		APIName: "invalid-spec-url",
+		BaseURL: "https://api.example.com",
+		SpecURL: "https://api.example.com/openapi.json?api_key=spec-secret%zz&version=1",
+		Trace: func(format string, args ...any) {
+			traces = append(traces, fmt.Sprintf(format, args...))
+		},
+	}
+	_, err := Discover(context.Background(), cfg, DefaultLoaders())
+	if err == nil {
+		t.Fatal("expected invalid spec URL failure")
+	}
+	combined := err.Error() + "\n" + strings.Join(traces, "\n")
+	if strings.Contains(combined, "spec-secret") {
+		t.Fatalf("spec URL credential query leaked:\n%s", combined)
+	}
+	if !strings.Contains(combined, "https://api.example.com/openapi.json?version=1") {
+		t.Fatalf("expected clean spec URL, got:\n%s", combined)
 	}
 }
 
@@ -1394,6 +1516,65 @@ paths:
 		if !strings.Contains(got, want) {
 			t.Fatalf("trace missing %q, got:\n%s", want, got)
 		}
+	}
+}
+
+func TestDiscoverRedactsCredentialQueryInExternalRefFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		want    string
+		itemErr bool
+		status  int
+	}{
+		{name: "status", ref: "./item.yaml?api_key=ref-secret&version=1", want: "https://specs.example.com/item.yaml?version=1", status: http.StatusInternalServerError},
+		{name: "transport", ref: "./item.yaml?api_key=ref-secret&version=1", want: "https://specs.example.com/item.yaml?version=1", itemErr: true},
+		{name: "unsupported scheme", ref: "ftp://files.example.com/item.yaml?api_key=ref-secret&version=1", want: "ftp://files.example.com/item.yaml?version=1"},
+		{name: "malformed", ref: "./item.yaml?api_key=ref-secret%zz&version=1", want: "https://specs.example.com/item.yaml?version=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				switch r.URL.Path {
+				case "/openapi.yaml":
+					return httpResponse(200, "application/yaml", fmt.Sprintf(`openapi: "3.1.0"
+info: {title: Test, version: "1.0"}
+paths:
+  /items:
+    $ref: %q
+`, tt.ref), nil), nil
+				case "/item.yaml":
+					if tt.itemErr {
+						return nil, fmt.Errorf("dial failed for %s", r.URL.String())
+					}
+					return httpResponse(tt.status, "text/plain", "server error", nil), nil
+				default:
+					return httpResponse(404, "text/plain", "not found", nil), nil
+				}
+			})
+			var traces []string
+			cfg := DiscoverConfig{
+				APIName:   "redact-ref-" + tt.name,
+				BaseURL:   "https://specs.example.com",
+				SpecURL:   "https://specs.example.com/openapi.yaml",
+				Transport: tr,
+				Trace: func(format string, args ...any) {
+					traces = append(traces, fmt.Sprintf(format, args...))
+				},
+			}
+			_, err := Discover(context.Background(), cfg, DefaultLoaders())
+			if err == nil {
+				t.Fatal("expected external ref failure")
+			}
+			combined := err.Error() + "\n" + strings.Join(traces, "\n")
+			if strings.Contains(combined, "ref-secret") {
+				t.Fatalf("external ref credential query leaked:\n%s", combined)
+			}
+			if !strings.Contains(combined, tt.want) {
+				t.Fatalf("expected clean external ref URL %q, got:\n%s", tt.want, combined)
+			}
+		})
 	}
 }
 

--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -218,27 +218,34 @@ func openAPIRemoteURLHandler(opts LoadOptions) func(string) (*http.Response, err
 	source, _ := url.Parse(opts.SourceURL)
 
 	return func(rawURL string) (*http.Response, error) {
+		displayURL := openAPIRefDisplayURL(rawURL)
+		displaySourceURL := openAPIRefDisplayURL(opts.SourceURL)
 		u, err := url.Parse(rawURL)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("OpenAPI external ref %q: %w", displayURL, cleanErrorForDisplay(err, rawURL, displayURL))
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
-			return nil, fmt.Errorf("OpenAPI external ref %q uses unsupported scheme %q", rawURL, u.Scheme)
+			return nil, fmt.Errorf("OpenAPI external ref %q uses unsupported scheme %q", displayURL, u.Scheme)
 		}
 		if source != nil && !opts.AllowCrossOrigin && !sameOrigin(source, u) {
-			return nil, fmt.Errorf("OpenAPI external ref %q is not same-origin with %q", rawURL, opts.SourceURL)
+			return nil, fmt.Errorf("OpenAPI external ref %q is not same-origin with %q", displayURL, displaySourceURL)
 		}
 		if source != nil && opts.AllowCrossOrigin && isDisallowedCrossOriginHost(source.Hostname(), u.Hostname()) {
-			return nil, fmt.Errorf("OpenAPI external ref %q targets a non-public host from public origin %q", rawURL, opts.SourceURL)
+			return nil, fmt.Errorf("OpenAPI external ref %q targets a non-public host from public origin %q", displayURL, displaySourceURL)
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-		if err != nil {
-			return nil, err
+		var resp *http.Response
+		if opts.Fetch != nil {
+			resp, err = opts.Fetch(ctx, rawURL, tr)
+		} else {
+			req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+			if reqErr != nil {
+				return nil, fmt.Errorf("OpenAPI external ref %q: %w", displayURL, cleanErrorForDisplay(reqErr, rawURL, displayURL))
+			}
+			resp, err = tr.RoundTrip(req)
 		}
-		resp, err := tr.RoundTrip(req)
 		if err != nil {
-			return nil, err
+			return nil, cleanErrorForDisplay(err, rawURL, displayURL)
 		}
 		if resp.Body == nil {
 			return resp, nil
@@ -249,7 +256,7 @@ func openAPIRemoteURLHandler(opts LoadOptions) func(string) (*http.Response, err
 			return nil, err
 		}
 		if int64(len(data)) > maxSpecBytes {
-			return nil, fmt.Errorf("OpenAPI external ref %q exceeds limit of %d bytes", rawURL, maxSpecBytes)
+			return nil, fmt.Errorf("OpenAPI external ref %q exceeds limit of %d bytes", displayURL, maxSpecBytes)
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(data))
 		resp.ContentLength = int64(len(data))
@@ -297,7 +304,7 @@ func resolveOpenAPIExternalRefs(body []byte, opts LoadOptions) ([]byte, error) {
 		return body, nil
 	}
 	if opts.SourceURL != "" {
-		tracef(opts.Trace, "Resolving OpenAPI external refs from %s", opts.SourceURL)
+		tracef(opts.Trace, "Resolving OpenAPI external refs from %s", openAPIRefDisplayURL(opts.SourceURL))
 	} else {
 		tracef(opts.Trace, "Resolving OpenAPI external refs from %s", opts.LocalPath)
 	}
@@ -413,11 +420,11 @@ func (r *openAPIRefResolver) resolveNode(n *yaml.Node, source openAPIRefSource, 
 func (r *openAPIRefResolver) resolveLocalRef(ref string, source openAPIRefSource) (*yaml.Node, error) {
 	doc := r.docForSource(source)
 	if doc == nil {
-		return nil, fmt.Errorf("OpenAPI external ref %q has no loaded source document", ref)
+		return nil, fmt.Errorf("OpenAPI external ref %q has no loaded source document", openAPIRefDisplayURL(ref))
 	}
 	target, err := yamlPointer(doc, strings.TrimPrefix(ref, "#"))
 	if err != nil {
-		return nil, fmt.Errorf("OpenAPI external ref %q: %w", ref, err)
+		return nil, fmt.Errorf("OpenAPI external ref %q: %w", openAPIRefDisplayURL(ref), err)
 	}
 	return target, nil
 }
@@ -488,7 +495,7 @@ func (r *openAPIRefResolver) collectExternalDocRequests(n *yaml.Node, source ope
 		if ref := mappingRefValue(n); ref != "" && !strings.HasPrefix(ref, "#") {
 			root, _, _ := strings.Cut(ref, "#")
 			if root == "" {
-				return fmt.Errorf("OpenAPI external ref %q has no external document", ref)
+				return fmt.Errorf("OpenAPI external ref %q has no external document", openAPIRefDisplayURL(ref))
 			}
 			key, targetSource, err := r.resolveRefRoot(root, source)
 			if err != nil {
@@ -598,7 +605,7 @@ func removeMappingKey(content []*yaml.Node, key string) []*yaml.Node {
 func (r *openAPIRefResolver) resolveRef(ref string, source openAPIRefSource) (*yaml.Node, openAPIRefSource, error) {
 	root, fragment, _ := strings.Cut(ref, "#")
 	if root == "" {
-		return nil, source, fmt.Errorf("OpenAPI external ref %q has no external document", ref)
+		return nil, source, fmt.Errorf("OpenAPI external ref %q has no external document", openAPIRefDisplayURL(ref))
 	}
 	key, targetSource, err := r.resolveRefRoot(root, source)
 	if err != nil {
@@ -610,29 +617,32 @@ func (r *openAPIRefResolver) resolveRef(ref string, source openAPIRefSource) (*y
 	}
 	target, err := yamlPointer(doc, fragment)
 	if err != nil {
-		return nil, source, fmt.Errorf("OpenAPI external ref %q: %w", ref, err)
+		return nil, source, fmt.Errorf("OpenAPI external ref %q: %w", openAPIRefDisplayURL(ref), err)
 	}
 	return target, targetSource, nil
 }
 
 func (r *openAPIRefResolver) resolveRefRoot(root string, source openAPIRefSource) (string, openAPIRefSource, error) {
+	displayRoot := openAPIRefDisplayURL(root)
 	if u, err := url.Parse(root); err == nil && u.Scheme != "" {
 		switch u.Scheme {
 		case "file":
 			if source.localPath == "" {
-				return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q uses local file access from remote source %q", root, source.url)
+				return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q uses local file access from remote source %q", displayRoot, openAPIRefDisplayURL(source.url))
 			}
 			path, err := localPathFromSource(u.String())
 			if err != nil {
-				return "", openAPIRefSource{}, err
+				return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q: %w", displayRoot, cleanErrorForDisplay(err, root, displayRoot))
 			}
 			path = filepath.Clean(path)
 			return "file:" + path, openAPIRefSource{localPath: path}, nil
 		case "http", "https":
 			return u.String(), openAPIRefSource{url: u.String()}, nil
 		default:
-			return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q uses unsupported scheme %q", root, u.Scheme)
+			return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q uses unsupported scheme %q", displayRoot, u.Scheme)
 		}
+	} else if err != nil {
+		return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q: %w", displayRoot, cleanErrorForDisplay(err, root, displayRoot))
 	}
 
 	if source.localPath != "" {
@@ -647,13 +657,13 @@ func (r *openAPIRefResolver) resolveRefRoot(root string, source openAPIRefSource
 		}
 		rel, err := url.Parse(root)
 		if err != nil {
-			return "", openAPIRefSource{}, err
+			return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q: %w", displayRoot, cleanErrorForDisplay(err, root, displayRoot))
 		}
 		resolved := base.ResolveReference(rel).String()
 		return resolved, openAPIRefSource{url: resolved}, nil
 	}
 
-	return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q has no source to resolve against", root)
+	return "", openAPIRefSource{}, fmt.Errorf("OpenAPI external ref %q has no source to resolve against", displayRoot)
 }
 
 func (r *openAPIRefResolver) loadExternalDoc(key string, source openAPIRefSource) (*yaml.Node, error) {
@@ -678,7 +688,7 @@ func (r *openAPIRefResolver) loadExternalDocData(source openAPIRefSource) ([]byt
 	case source.localPath != "":
 		return os.ReadFile(source.localPath)
 	case source.url != "":
-		tracef(r.opts.Trace, "GET OpenAPI external ref %s", source.url)
+		tracef(r.opts.Trace, "GET OpenAPI external ref %s", openAPIRefDisplayURL(source.url))
 		return r.fetchRemoteDoc(source.url)
 	default:
 		return nil, fmt.Errorf("OpenAPI external ref has no resolved source")
@@ -698,6 +708,7 @@ func parseExternalOpenAPIDoc(data []byte) (*yaml.Node, error) {
 }
 
 func (r *openAPIRefResolver) fetchRemoteDoc(rawURL string) ([]byte, error) {
+	displayURL := openAPIRefDisplayURL(rawURL)
 	opts := r.opts
 	opts.SourceURL = r.opts.SourceURL
 	if opts.SourceURL == "" {
@@ -706,23 +717,39 @@ func (r *openAPIRefResolver) fetchRemoteDoc(rawURL string) ([]byte, error) {
 	handler := openAPIRemoteURLHandler(opts)
 	resp, err := handler(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
+		return nil, fmt.Errorf("GET %s: %w", displayURL, err)
 	}
 	if resp == nil {
-		return nil, fmt.Errorf("GET %s: no response", rawURL)
+		return nil, fmt.Errorf("GET %s: no response", displayURL)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("GET %s: %s", rawURL, resp.Status)
+		return nil, fmt.Errorf("GET %s: %s", displayURL, resp.Status)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxSpecBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", rawURL, err)
+		return nil, fmt.Errorf("GET %s: %w", displayURL, err)
 	}
 	if int64(len(data)) > maxSpecBytes {
-		return nil, fmt.Errorf("OpenAPI external ref %q exceeds limit of %d bytes", rawURL, maxSpecBytes)
+		return nil, fmt.Errorf("OpenAPI external ref %q exceeds limit of %d bytes", displayURL, maxSpecBytes)
 	}
 	return data, nil
+}
+
+func openAPIRefDisplayURL(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return cleanPossiblyInvalidURL(raw)
+	}
+	if u.IsAbs() {
+		return cleanSourceURL(raw)
+	}
+	u.User = nil
+	u.RawQuery = cleanSourceURLQuery(u.Query()).Encode()
+	return u.String()
 }
 
 func yamlPointer(root *yaml.Node, fragment string) (*yaml.Node, error) {

--- a/internal/spec/openapi.go
+++ b/internal/spec/openapi.go
@@ -247,6 +247,9 @@ func openAPIRemoteURLHandler(opts LoadOptions) func(string) (*http.Response, err
 		if err != nil {
 			return nil, cleanErrorForDisplay(err, rawURL, displayURL)
 		}
+		if resp == nil {
+			return nil, fmt.Errorf("OpenAPI external ref %q: no response", displayURL)
+		}
 		if resp.Body == nil {
 			return resp, nil
 		}
@@ -743,9 +746,6 @@ func openAPIRefDisplayURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return cleanPossiblyInvalidURL(raw)
-	}
-	if u.IsAbs() {
-		return cleanSourceURL(raw)
 	}
 	u.User = nil
 	u.RawQuery = cleanSourceURLQuery(u.Query()).Encode()

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -24,15 +24,22 @@ type Loader interface {
 	Priority() int
 }
 
+// HTTPFetcher fetches a remote spec resource and returns a response whose body
+// the caller must close. Callers should use transport unless they intentionally
+// need to replace the network stack.
+type HTTPFetcher func(ctx context.Context, rawURL string, transport http.RoundTripper) (*http.Response, error)
+
 // LoadOptions carries source metadata needed by loaders that resolve external
 // references. Plain loaders may ignore it.
 type LoadOptions struct {
 	Context          context.Context
 	ContentType      string
 	SourceURL        string
+	RequestedURL     string
 	LocalPath        string
 	AllowCrossOrigin bool
 	Transport        http.RoundTripper
+	Fetch            HTTPFetcher
 	Trace            func(format string, args ...any)
 }
 
@@ -46,6 +53,7 @@ type APISpec struct {
 	Document libopenapi.Document
 	// SourceURL/LocalPath capture where the spec came from so external refs can
 	// be resolved consistently when the raw spec is cached and reparsed.
+	RequestedURL     string
 	SourceURL        string
 	LocalPath        string
 	AllowCrossOrigin bool
@@ -174,6 +182,9 @@ func loadWithOptions(contentType string, body []byte, loaders []Loader, opts Loa
 	}
 	if spec.SourceURL == "" {
 		spec.SourceURL = opts.SourceURL
+	}
+	if spec.RequestedURL == "" {
+		spec.RequestedURL = opts.RequestedURL
 	}
 	if spec.LocalPath == "" {
 		spec.LocalPath = opts.LocalPath


### PR DESCRIPTION
Fixes #355.

3 bugs fixed: two that together broke `restish api sync` on Linux with OAuth + mTLS, and one that silently dropped file-based client certificates during v1 => v2 migration.

## spec discovery skips auth

`discoveryTransport()` only set up TLS. It never applied auth credentials, so `spec.Discover` sent a bare request. The server got the mTLS cert but no `Authorization: Bearer` header and returned 307.

Fix: pass `apiName` to `discoveryTransport`, call `authOnRequest` to get the profile's auth callback, and wrap the transport with a thin `discoveryAuthTransport` that clones the request, applies auth, and delegates down. The `doctor` reachability check receives `apiName` too so `--check-network` also works.

**Before**
```
$ restish api sync myapi
Error: api sync "myapi" failed: spec discovery: GET https://api.example.com: 307 Temporary Redirect
hint: API registration and existing spec cache were left unchanged; check the network and spec_url, then retry api sync
```

**After**
```
$ restish api sync myapi
Synced spec for "myapi".
```

## xdg-open rejects `--` on Linux

`defaultOpenBrowserCommand` passed `xdg-open -- <url>` on Linux. `xdg-open 1.2.1` exits 1 with `unexpected option '--'`. `DefaultOpenBrowser` discards the error, so restish printed `Opening browser for authentication.` and stalled waiting for a callback that never came.

Fix: drop the `--` on Linux. Real OAuth URLs start with `https://`, so no flag injection risk. `TestDefaultOpenBrowserCommandUsesArgumentSeparator` is skipped on Linux since it was already broken there.

**Before**
```
$ restish myapi list-items
Opening browser for authentication.
# browser never opens; xdg-open exits 1 silently
# restish hangs here waiting for the OAuth callback
^C
```

**After**
```
$ restish myapi list-items
Opening browser for authentication.
# browser opens, user authorises, callback received
HTTP/1.1 200 OK
[...]
```

## v1 => v2 migration silently drops file-based client certificates

`legacyTLSConfig` had no `Cert`/`Key` fields, so `tls.cert` and `tls.key` from v1 `apis.json` were silently discarded during migration.

Fix: add `Cert`/`Key` to `legacyTLSConfig` and map them to `client_cert_path`/`client_key_path` on the default profile, mirroring the existing PKCS11 migration.

**Before** (`~/.config/restish/apis.json`: v1)
```json
{
  "myapi": {
    "base": "https://api.example.com",
    "tls": {
      "cert": "/home/user/.pki/client.pem",
      "key": "/home/user/.pki/client-key.pem"
    }
  }
}
```

**After migration, before fix** (`~/.config/restish/restish.json`: v2, certs silently lost)
```json
{
  "apis": {
    "myapi": {
      "base_url": "https://api.example.com"
    }
  }
}
```

**After migration, after fix** (`~/.config/restish/restish.json`: v2, certs preserved)
```json
{
  "apis": {
    "myapi": {
      "base_url": "https://api.example.com",
      "profiles": {
        "default": {
          "client_cert": "/home/user/.pki/client.pem",
          "client_key": "/home/user/.pki/client-key.pem"
        }
      }
    }
  }
}
```

---

> [!NOTE]
> This PR was assisted by GitHub Copilot using the Claude Sonnet 4.6 model.