### PR TITLE
fix(auth+cli): fix OAuth browser flows on Linux; reduce prompts during api sync

### DIFF
--- a/cmd/restish-docgen/main.go
+++ b/cmd/restish-docgen/main.go
@@ -831,6 +831,7 @@ var envDocs = []envDoc{
 	{Name: "RSH_PRINT", Group: "Editor And Terminal", Description: "Default `--rsh-print` output parts, such as `b` for compact rendered output in scripts.", Source: "global flags"},
 	{Name: "VISUAL", Group: "Editor And Terminal", Description: "Preferred editor for `config edit` and `edit`.", Source: "editor"},
 	{Name: "EDITOR", Group: "Editor And Terminal", Description: "Fallback editor for `config edit` and `edit`.", Source: "editor"},
+	{Name: "BROWSER", Group: "Editor And Terminal", Description: "Browser binary used for OAuth authorization-code flows. When set, Restish invokes it directly instead of `xdg-open` (Linux), `open` (macOS), or `start` (Windows).", Source: "oauth browser"},
 	{Name: "GLAMOUR_STYLE", Group: "Editor And Terminal", Description: "Markdown rendering style for markdown-formatted terminal output.", Source: "output"},
 	{Name: "RSH_IMAGE_PROTOCOL", Group: "Editor And Terminal", Description: "Force terminal image rendering protocol: `kitty`, `iterm2`, or `halfblock`.", Source: "output"},
 	{Name: "KITTY_WINDOW_ID", Group: "Editor And Terminal", Description: "Used to auto-detect Kitty image support.", Source: "output"},

--- a/internal/auth/oauth_authcode.go
+++ b/internal/auth/oauth_authcode.go
@@ -12,16 +12,25 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
 
 const defaultRedirectPort = "8484"
 const authTimeout = 5 * time.Minute
+
+// browserFlowMu ensures only one browser-based OAuth flow runs at a time.
+// Parallel spec-discovery probes can all miss the token cache simultaneously;
+// waiters re-check the cache after acquiring the lock and skip the flow if a
+// token was already stored.
+var browserFlowMu sync.Mutex
+
 const callbackPageResultWait = 200 * time.Millisecond
 const defaultCallbackSuccessColor = "#5fafd7"
 const defaultCallbackFailureColor = "#E94F37"
@@ -128,7 +137,15 @@ func (h *AuthorizationCode) resolveToken(ctx context.Context, params map[string]
 		// Refresh token rejected — fall through to interactive auth.
 	}
 
-	// Full browser flow.
+	// Serialize browser flows; re-check the cache in case a concurrent flow
+	// already completed while we were waiting.
+	browserFlowMu.Lock()
+	defer browserFlowMu.Unlock()
+
+	if token2, ok2, _ := cachedOAuthAccessToken(h.Cache, cacheKey, false, nil); ok2 {
+		return token2, nil
+	}
+
 	authorizeURL, tokenURL, err := h.resolveEndpoints(ctx, params)
 	if err != nil {
 		return "", err
@@ -360,6 +377,8 @@ func (h *AuthorizationCode) doBrowserFlow(ctx context.Context, params map[string
 				fmt.Fprint(w, callbackPages.errorPage("Authentication timed out", "Return to the terminal to try again.", "timed_out"))
 			}
 		})}
+		// No keep-alives: lets the socket close promptly after Shutdown.
+		srv.SetKeepAlivesEnabled(false)
 		go func() {
 			if e := serveOAuthCallback(srv, ln, redirect); e != nil && e != http.ErrServerClosed {
 				trySendErr(errCh, e)
@@ -779,18 +798,43 @@ func defaultOpenBrowserCommand(rawURL string) *exec.Cmd {
 	return defaultOpenBrowserCommandForGOOS(runtime.GOOS, rawURL)
 }
 
-func defaultOpenBrowserCommandForGOOS(goos, rawURL string) *exec.Cmd {
-	switch goos {
-	case "darwin":
-		return exec.Command("open", "--", rawURL)
-	case "windows":
-		// Pass an explicit empty title ("") before the URL so that special
-		// characters in the URL are not misinterpreted as window title or
-		// cmd /c start flags.
-		return exec.Command("cmd", "/c", "start", "", "--", rawURL)
-	default:
-		return exec.Command("xdg-open", rawURL)
+// browserEnv returns os.Environ() with XDG_CONFIG_HOME, XDG_CACHE_HOME, and
+// XDG_DATA_HOME stripped so the browser always uses the user's real profile.
+func browserEnv() []string {
+	strip := map[string]bool{
+		"XDG_CONFIG_HOME": true,
+		"XDG_CACHE_HOME":  true,
+		"XDG_DATA_HOME":   true,
 	}
+	var env []string
+	for _, e := range os.Environ() {
+		key := strings.SplitN(e, "=", 2)[0]
+		if !strip[key] {
+			env = append(env, e)
+		}
+	}
+	return env
+}
+
+func defaultOpenBrowserCommandForGOOS(goos, rawURL string) *exec.Cmd {
+	var cmd *exec.Cmd
+	if b := os.Getenv("BROWSER"); b != "" {
+		cmd = exec.Command(b, rawURL)
+	} else {
+		switch goos {
+		case "darwin":
+			cmd = exec.Command("open", "--", rawURL)
+		case "windows":
+			// Pass an explicit empty title ("") before the URL so that special
+			// characters in the URL are not misinterpreted as window title or
+			// cmd /c start flags.
+			cmd = exec.Command("cmd", "/c", "start", "", "--", rawURL)
+		default:
+			cmd = exec.Command("xdg-open", rawURL)
+		}
+	}
+	cmd.Env = browserEnv()
+	return cmd
 }
 
 // FreePort returns an available local TCP port as a string.

--- a/internal/auth/oauth_authcode_test.go
+++ b/internal/auth/oauth_authcode_test.go
@@ -313,6 +313,98 @@ func TestAuthCodeResolvesRelativeEndpoints(t *testing.T) {
 	}
 }
 
+// TestAuthCodeResolvesEndpointsViaOIDCDiscovery verifies that when only
+// issuer_url is set (typical Keycloak/Dex configuration), resolveEndpoints
+// fetches /.well-known/openid-configuration and populates the authorization and
+// token endpoints from the discovery document.
+func TestAuthCodeResolvesEndpointsViaOIDCDiscovery(t *testing.T) {
+	const issuerURL = "https://keycloak.example.com/realms/myrealm"
+	const wantDiscoveryPath = "/realms/myrealm/.well-known/openid-configuration"
+	const wantAuthURL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/auth"
+	const wantTokenURL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
+
+	h := &AuthorizationCode{
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			if r.URL.Path != wantDiscoveryPath {
+				t.Fatalf("discovery path = %q, want %q", r.URL.Path, wantDiscoveryPath)
+			}
+			body := `{
+				"issuer": "` + issuerURL + `",
+				"authorization_endpoint": "` + wantAuthURL + `",
+				"token_endpoint": "` + wantTokenURL + `"
+			}`
+			return testResponse(http.StatusOK, "application/json", body), nil
+		}),
+	}
+	authorizeURL, tokenURL, err := h.resolveEndpoints(context.Background(), map[string]string{
+		"issuer_url": issuerURL,
+	})
+	if err != nil {
+		t.Fatalf("resolveEndpoints: %v", err)
+	}
+	if authorizeURL != wantAuthURL {
+		t.Fatalf("authorizeURL = %q, want %q", authorizeURL, wantAuthURL)
+	}
+	if tokenURL != wantTokenURL {
+		t.Fatalf("tokenURL = %q, want %q", tokenURL, wantTokenURL)
+	}
+}
+
+// TestAuthCode_BrowserFlow_KeycloakIssuerURL verifies that a complete browser
+// flow succeeds when the API is configured with only issuer_url (no explicit
+// authorize_url / token_url), as is typical for Keycloak realms.
+func TestAuthCode_BrowserFlow_KeycloakIssuerURL(t *testing.T) {
+	const issuerURL = "https://keycloak.example.com/realms/myrealm"
+	const wantAuthURL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/auth"
+	const wantTokenURL = "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token"
+
+	cacheFile := filepath.Join(t.TempDir(), "tokens.cbor")
+	h := &AuthorizationCode{
+		Cache: NewTokenCache(cacheFile),
+		HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+			if strings.HasSuffix(r.URL.Path, "/.well-known/openid-configuration") {
+				body := `{
+					"issuer": "` + issuerURL + `",
+					"authorization_endpoint": "` + wantAuthURL + `",
+					"token_endpoint": "` + wantTokenURL + `"
+				}`
+				return testResponse(http.StatusOK, "application/json", body), nil
+			}
+			// Token exchange.
+			if err := r.ParseForm(); err != nil {
+				return testResponse(http.StatusBadRequest, "text/plain", "bad form"), nil
+			}
+			if got := r.FormValue("code"); got != "kc-code" {
+				t.Fatalf("token exchange code = %q, want kc-code", got)
+			}
+			return testResponse(http.StatusOK, "application/json", `{"access_token":"kc-token","token_type":"bearer","expires_in":3600}`), nil
+		}),
+		OpenBrowser: func(raw string) error {
+			callbackURL, state := mustCallbackURL(t, raw)
+			resp, err := http.Get(fmt.Sprintf("%s/?state=%s&code=kc-code", callbackURL, url.QueryEscape(state)))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			return nil
+		},
+	}
+
+	req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+	err := h.OnRequest(req, map[string]string{
+		"issuer_url":    issuerURL,
+		"client_id":     "restish",
+		"redirect_port": availablePort(t),
+		"_cache_key":    "myapi:default",
+	})
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer kc-token" {
+		t.Fatalf("Authorization = %q, want Bearer kc-token", got)
+	}
+}
+
 func TestAuthCode_BrowserFlow_FaviconRequestDoesNotAbort(t *testing.T) {
 	var stderr bytes.Buffer
 	h := &AuthorizationCode{
@@ -1217,6 +1309,131 @@ func TestDefaultOpenBrowserCommandLinuxUsesXDGOpenWithoutSeparator(t *testing.T)
 	want := []string{"xdg-open", "https://example.com/callback?code=abc"}
 	if !reflect.DeepEqual(cmd.Args, want) {
 		t.Fatalf("linux browser command args = %#v, want %#v", cmd.Args, want)
+	}
+}
+
+func TestDefaultOpenBrowserCommandRespectsBROWSEREnvVar(t *testing.T) {
+	t.Setenv("BROWSER", "my-browser")
+	cmd := defaultOpenBrowserCommandForGOOS("linux", "https://example.com")
+	if cmd.Args[0] != "my-browser" {
+		t.Fatalf("browser command = %q, want %q", cmd.Args[0], "my-browser")
+	}
+	if cmd.Args[1] != "https://example.com" {
+		t.Fatalf("browser command URL = %q, want %q", cmd.Args[1], "https://example.com")
+	}
+}
+
+func TestDefaultOpenBrowserCommandRespectsBROWSEREnvVarOnNonLinux(t *testing.T) {
+	t.Setenv("BROWSER", "my-browser")
+	cmd := defaultOpenBrowserCommandForGOOS("darwin", "https://example.com")
+	if cmd.Args[0] != "my-browser" {
+		t.Fatalf("browser command = %q, want %q", cmd.Args[0], "my-browser")
+	}
+}
+
+func TestBrowserEnvStripsXDGVars(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/sandboxed/.config")
+	t.Setenv("XDG_CACHE_HOME", "/tmp/sandboxed/.cache")
+	t.Setenv("XDG_DATA_HOME", "/tmp/sandboxed/.local/share")
+	t.Setenv("HOME", "/home/user")
+
+	env := browserEnv()
+
+	for _, e := range env {
+		key := strings.SplitN(e, "=", 2)[0]
+		switch key {
+		case "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME":
+			t.Errorf("browserEnv should not include %s", key)
+		}
+	}
+	found := false
+	for _, e := range env {
+		if e == "HOME=/home/user" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("browserEnv should preserve HOME")
+	}
+}
+
+func TestDefaultOpenBrowserCommandEnvStripsXDGVars(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/sandboxed/.config")
+	cmd := defaultOpenBrowserCommandForGOOS("linux", "https://example.com")
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "XDG_CONFIG_HOME=") {
+			t.Fatalf("browser command env should not include XDG_CONFIG_HOME, got %q", e)
+		}
+	}
+}
+
+func TestAuthCode_BrowserFlow_ConcurrentProbesOpenOneBrowserWindow(t *testing.T) {
+	// Three goroutines miss the token cache simultaneously; only one browser
+	// window should open and the token endpoint should be called once.
+	cacheFile := filepath.Join(t.TempDir(), "tokens.cbor")
+	cache := NewTokenCache(cacheFile)
+	cacheKey := "myapi:default"
+
+	var browserOpens atomic.Int32
+	var tokenRequests atomic.Int32
+
+	port := availablePort(t)
+
+	newHandler := func() *AuthorizationCode {
+		return &AuthorizationCode{
+			Cache: NewTokenCache(cacheFile),
+			HTTPClient: testHTTPClient(func(r *http.Request) (*http.Response, error) {
+				tokenRequests.Add(1)
+				return testResponse(200, "application/json", `{"access_token":"shared-token","token_type":"bearer","expires_in":3600}`), nil
+			}),
+			OpenBrowser: func(raw string) error {
+				if browserOpens.Add(1) == 1 {
+					callbackURL, state := mustCallbackURL(t, raw)
+					resp, err := http.Get(fmt.Sprintf("%s/?state=%s&code=code1", callbackURL, url.QueryEscape(state)))
+					if err != nil {
+						return err
+					}
+					defer resp.Body.Close()
+				}
+				return nil
+			},
+		}
+	}
+
+	params := map[string]string{
+		"client_id":     "id1",
+		"authorize_url": "https://auth.example.com/authorize",
+		"token_url":     "https://auth.example.com/token",
+		"redirect_port": port,
+		"_cache_key":    cacheKey,
+	}
+
+	_ = cache
+	const concurrency = 3
+	errs := make(chan error, concurrency)
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "https://api.example.com", nil)
+			errs <- newHandler().OnRequest(req, params)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("OnRequest: %v", err)
+		}
+	}
+	if got := browserOpens.Load(); got != 1 {
+		t.Errorf("browser opened %d time(s), want 1", got)
+	}
+	if got := tokenRequests.Load(); got != 1 {
+		t.Errorf("token endpoint called %d time(s), want 1", got)
 	}
 }
 

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -59,13 +59,14 @@ func (c *CLI) addAPICommand(root *cobra.Command) {
 		RunE:    c.runAPIRemove,
 	})
 	syncCmd := &cobra.Command{
-		Use:   "sync <name>",
+		Use:   "sync <name> [name...]",
 		Short: "Force re-fetch of the cached OpenAPI spec for a named API",
 		Long:  apiSyncLong,
 		Example: fmt.Sprintf(`  %s api sync demo
   %s api sync demo --yes
-  %s api sync demo --allow-cross-origin-spec`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
-		Args: usageExactArgs(1),
+  %s api sync demo --allow-cross-origin-spec
+  %s api sync api-one api-two api-three`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
+		Args: usageMinimumNArgs(1),
 		RunE: c.runAPISync,
 	}
 	syncCmd.Flags().Bool("allow-cross-origin-spec", false, "Allow safe Link-header spec discovery from another host for this sync run")
@@ -205,10 +206,97 @@ func (c *CLI) runAPIAuthLogout(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// runAPISync force-invalidates the cached spec for an API, fetches a fresh one,
-// and persists non-profile metadata that can be discovered safely from it.
+// runAPISync force-invalidates the cached spec for one or more APIs, fetches a
+// fresh one for each, and persists non-profile metadata that can be discovered
+// safely from it. Accepting multiple names in a single invocation allows the
+// process (and any shared PKCS#11 session) to be reused across all of them,
+// which means a hardware-token PIN is only requested once.
 func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
-	apiName := args[0]
+	// When all APIs share the same TLS signer (e.g. all yubikey APIs), build
+	// one transport up front so the plugin subprocess — and the PKCS#11 session
+	// it holds — is shared across every sync. This means the user is prompted
+	// for the hardware-token PIN exactly once instead of once per API.
+	var shared http.RoundTripper
+	if len(args) > 1 {
+		tr, closer, err := c.sharedDiscoveryTransport(cmd, args)
+		if err != nil {
+			return err
+		}
+		if tr != nil {
+			shared = tr
+			if closer != nil {
+				defer closer.Close()
+			}
+		}
+	}
+
+	var errs []error
+	for _, apiName := range args {
+		if err := c.syncOneAPI(cmd, apiName, shared); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// sharedDiscoveryTransport returns a single transport to reuse across all
+// named APIs if every API in the list resolves to the same TLS signer name.
+// Returns (nil, nil, nil) when the APIs have heterogeneous signer configs;
+// in that case each syncOneAPI call will build its own transport.
+func (c *CLI) sharedDiscoveryTransport(cmd *cobra.Command, apiNames []string) (http.RoundTripper, interface{ Close() error }, error) {
+	ctx := requestContext(cmd)
+	gf := globalFlagsFromContext(ctx)
+	globalSignerParams, err := parseKVStrings(gf.TLSSignerParams)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid tls signer param: %w", err)
+	}
+	profileName := c.profileFromCmd(cmd)
+	if profileName == "" {
+		profileName = "default"
+	}
+
+	var commonSignerPath string
+	var representativeCfg *config.APIConfig
+	for _, apiName := range apiNames {
+		apiCfg, err := c.requireAPI(apiName)
+		if err != nil {
+			return nil, nil, err
+		}
+		signerName := gf.TLSSigner
+		if prof := profileForName(apiCfg, profileName); prof != nil {
+			if signerName == "" {
+				signerName = prof.TLSSigner
+			}
+		}
+		if signerName == "" {
+			return nil, nil, nil // this API uses no signer; can't share
+		}
+		opts := request.Options{TLSSignerName: signerName, TLSSignerParams: globalSignerParams}
+		if prof := profileForName(apiCfg, profileName); prof != nil {
+			opts.TLSSignerParams = mergeTLSSignerParams(opts.TLSSignerParams, prof.TLSSignerParams)
+		}
+		opts, err = c.resolveTLSSigner(opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		if representativeCfg == nil {
+			commonSignerPath = opts.TLSSignerPath
+			representativeCfg = apiCfg
+		} else if opts.TLSSignerPath != commonSignerPath {
+			return nil, nil, nil // different signer executables; can't share
+		}
+	}
+	if representativeCfg == nil {
+		return nil, nil, nil
+	}
+	tr, closer, err := c.discoveryTransport(ctx, representativeCfg, profileName)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tr, closer, nil
+}
+
+func (c *CLI) syncOneAPI(cmd *cobra.Command, apiName string, sharedTransport http.RoundTripper) error {
 	apiCfg, err := c.requireAPI(apiName)
 	if err != nil {
 		return err
@@ -217,12 +305,18 @@ func (c *CLI) runAPISync(cmd *cobra.Command, args []string) error {
 	allowCrossOrigin, _ := cmd.Flags().GetBool("allow-cross-origin-spec")
 	yes, _ := cmd.Flags().GetBool("yes")
 	profileName := c.profileFromCmd(cmd)
-	transport, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, profileName)
-	if err != nil {
-		return err
-	}
-	if closer != nil {
-		defer closer.Close()
+	var transport http.RoundTripper
+	if sharedTransport != nil {
+		transport = sharedTransport
+	} else {
+		tr, closer, err := c.discoveryTransport(requestContext(cmd), apiCfg, profileName)
+		if err != nil {
+			return err
+		}
+		if closer != nil {
+			defer closer.Close()
+		}
+		transport = tr
 	}
 	fetch := c.discoveryFetcher(requestContext(cmd), apiName, apiCfg, profileName)
 	discCfg := spec.DiscoverConfig{

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -456,7 +458,11 @@ func TestAPIAuthInspectOAuthAuthorizationCodeRequiresCachedTokenAndExactScopes(t
 		"OAuth: configured (OAuth access token not cached), needs read:profile read:recovery, satisfies read:profile",
 	)
 
-	if err := auth.NewTokenCache(tokenPath).Set("tapi:default:credential:OAuth", auth.CachedToken{
+	// The cache key for oauth-authorization-code is derived from token_url+client_id
+	// so APIs sharing the same identity provider reuse one token cache entry.
+	sum := sha256.Sum256([]byte("https://auth.example.com/token" + "\x00" + "client"))
+	oauthCacheKey := "oauth:" + hex.EncodeToString(sum[:8])
+	if err := auth.NewTokenCache(tokenPath).Set(oauthCacheKey, auth.CachedToken{
 		AccessToken: "cached-token",
 		Expiry:      time.Now().Add(time.Hour),
 	}); err != nil {

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -964,7 +966,10 @@ func TestAPISyncDiscoveryUsesCachedOAuthForSpecURL(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	tokenPath := filepath.Join(t.TempDir(), "tokens.cbor")
-	if err := auth.NewTokenCache(tokenPath).Set("protected:default", auth.CachedToken{AccessToken: "cached-token"}); err != nil {
+	// inlineAuthCacheKey maps absolute token_url+client_id to a shared key.
+	cacheKeySum := sha256.Sum256([]byte("https://auth.example.com/token\x00client"))
+	cacheKey := "oauth:" + hex.EncodeToString(cacheKeySum[:8])
+	if err := auth.NewTokenCache(tokenPath).Set(cacheKey, auth.CachedToken{AccessToken: "cached-token"}); err != nil {
 		t.Fatalf("set token: %v", err)
 	}
 	cfgFile := writeAPIConfigObject(t, "protected", &config.APIConfig{

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -518,11 +518,30 @@ func sharedAuthCacheKey(ref string, ac *config.AuthConfig, baseURL string) strin
 }
 
 func inlineAuthCacheKey(baseKey string, ac *config.AuthConfig, baseURL string) string {
-	if !authConfigUsesRelativeOAuthEndpoint(ac) || baseURL == "" {
+	if ac == nil {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(baseURL))
-	return baseKey + ":base_url:" + hex.EncodeToString(sum[:8])
+	// Relative endpoints: key on the resolved base URL so all APIs served by
+	// the same host share one token cache entry.
+	if authConfigUsesRelativeOAuthEndpoint(ac) && baseURL != "" {
+		sum := sha256.Sum256([]byte(baseURL))
+		return baseKey + ":base_url:" + hex.EncodeToString(sum[:8])
+	}
+	// Absolute endpoints: for oauth-authorization-code, key on token_url +
+	// client_id so APIs pointing at the same identity provider share one token
+	// cache entry and avoid redundant browser flows.
+	if ac.Type == "oauth-authorization-code" {
+		tokenURL := ac.Params["token_url"]
+		clientID := ac.Params["client_id"]
+		if tokenURL != "" && clientID != "" {
+			u, err := url.Parse(tokenURL)
+			if err == nil && u.IsAbs() {
+				sum := sha256.Sum256([]byte(tokenURL + "\x00" + clientID))
+				return "oauth:" + hex.EncodeToString(sum[:8])
+			}
+		}
+	}
+	return ""
 }
 
 func authConfigUsesRelativeOAuthEndpoint(ac *config.AuthConfig) bool {

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -159,6 +159,40 @@ func TestInlineAuthCacheKeyFallsBackForAbsoluteEndpoints(t *testing.T) {
 	}
 }
 
+func TestInlineAuthCacheKeyDeduplicatesAbsoluteAuthCodeEndpoints(t *testing.T) {
+	// Two APIs pointing at the same dex instance should produce the same cache
+	// key so only one browser login is needed.
+	ac := &config.AuthConfig{
+		Type: "oauth-authorization-code",
+		Params: map[string]string{
+			"client_id":     "restish",
+			"authorize_url": "https://dex.example.com/auth",
+			"token_url":     "https://dex.example.com/token",
+		},
+	}
+	k1 := inlineAuthCacheKey("api-one:default", ac, "https://api-one.example.com")
+	k2 := inlineAuthCacheKey("api-two:default", ac, "https://api-two.example.com")
+	if k1 == "" || k2 == "" {
+		t.Fatalf("expected non-empty cache keys, got %q and %q", k1, k2)
+	}
+	if k1 != k2 {
+		t.Fatalf("expected same cache key for same dex, got %q and %q", k1, k2)
+	}
+
+	// Different token_url should give a different key.
+	ac2 := &config.AuthConfig{
+		Type: "oauth-authorization-code",
+		Params: map[string]string{
+			"client_id": "restish",
+			"token_url": "https://other-dex.example.com/token",
+		},
+	}
+	k3 := inlineAuthCacheKey("api-one:default", ac2, "https://api-one.example.com")
+	if k3 == k1 {
+		t.Fatalf("different token_url should produce different cache key, got %q", k3)
+	}
+}
+
 func TestAuthHandlerForOAuthUsesThemeCallbackColors(t *testing.T) {
 	if err := output.SetTheme(output.ThemeEntries{
 		"status_2xx":   "bold #00ff00",

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1475,7 +1477,10 @@ func TestGeneratedCommandOAuthAuthorizationCodeRequiresCachedTokenBeforeSending(
 		t.Fatalf("request hits = %d, want 0 before OAuth token is available", got)
 	}
 
-	if err := auth.NewTokenCache(tokenPath).Set("tapi:default:credential:OAuth", auth.CachedToken{
+	// inlineAuthCacheKey maps absolute token_url+client_id to a shared key.
+	cacheKeySum := sha256.Sum256([]byte("https://auth.example.com/token\x00client"))
+	cacheKey := "oauth:" + hex.EncodeToString(cacheKeySum[:8])
+	if err := auth.NewTokenCache(tokenPath).Set(cacheKey, auth.CachedToken{
 		AccessToken: "cached-token",
 		Expiry:      time.Now().Add(time.Hour),
 	}); err != nil {

--- a/site/content/en/docs/reference/api-management.md
+++ b/site/content/en/docs/reference/api-management.md
@@ -128,7 +128,7 @@ By default, sync follows the same-origin spec source already recorded for the AP
 Usage:
 
 ```text
-restish api sync <name> [flags]
+restish api sync <name> [name...] [flags]
 ```
 
 Examples:
@@ -137,6 +137,7 @@ Examples:
   restish api sync demo
   restish api sync demo --yes
   restish api sync demo --allow-cross-origin-spec
+  restish api sync api-one api-two api-three
 ```
 
 Flags:

--- a/site/content/en/docs/reference/environment-variables.md
+++ b/site/content/en/docs/reference/environment-variables.md
@@ -45,6 +45,7 @@ Generated from production source environment-variable usage plus Go's standard p
 | `RSH_PRINT` | Default `--rsh-print` output parts, such as `b` for compact rendered output in scripts. | global flags |
 | `VISUAL` | Preferred editor for `config edit` and `edit`. | editor |
 | `EDITOR` | Fallback editor for `config edit` and `edit`. | editor |
+| `BROWSER` | Browser binary used for OAuth authorization-code flows. When set, Restish invokes it directly instead of `xdg-open` (Linux), `open` (macOS), or `start` (Windows). | oauth browser |
 | `GLAMOUR_STYLE` | Markdown rendering style for markdown-formatted terminal output. | output |
 | `RSH_IMAGE_PROTOCOL` | Force terminal image rendering protocol: `kitty`, `iterm2`, or `halfblock`. | output |
 | `KITTY_WINDOW_ID` | Used to auto-detect Kitty image support. | output |


### PR DESCRIPTION
Found these during end-to-end testing of a v1 → v2 migration with yubikey + multi-API setups.

## Browser flow fixes (Linux)

- **`$BROWSER` support**: `xdg-open` ignores `$BROWSER`. Now checked first, so you can point OAuth flows at a browser that already has an SSO session.
- **XDG env stripping**: browsers like Zen/Firefox read `$XDG_CONFIG_HOME` for their profile path. When that's overridden by a tool, the browser opens a blank profile and SSO fails silently. Now stripped from the subprocess env.
- **Concurrent flow serialization**: `api sync` probes 3 spec URLs in parallel; if all three miss the token cache simultaneously, they each try to bind port 8484 and open a browser — causing port collisions. A mutex now serializes this; waiters reuse the token from the first completed flow.

## One browser login per dex instance

`oauth-authorization-code` APIs with the same `token_url` + `client_id` now share a token cache entry. Syncing 8 APIs behind one dex = 1 login, not 8.

## `api sync` batching

`api sync` now takes multiple names at once:
```
restish api sync api1 api2 api3
```
When they share the same PKCS#11 signer, one subprocess handles all of them — PIN prompted once for the batch.