### PR TITLE
feat(pkcs11): auto-select token when only one is present

### DIFF
--- a/cmd/restish-pkcs11/config.go
+++ b/cmd/restish-pkcs11/config.go
@@ -29,11 +29,27 @@ var defaultPKCS11Paths = func() []string {
 	}
 }
 
+type pkcs11TokenEnumerator interface {
+	Initialize() error
+	Finalize() error
+	Destroy()
+	GetSlotList(tokenPresent bool) ([]uint, error)
+	GetTokenInfo(slotID uint) (pkcs11.TokenInfo, error)
+}
+
+var newPKCS11Ctx = func(modulePath string) pkcs11TokenEnumerator {
+	p := pkcs11.New(modulePath)
+	if p == nil {
+		return nil
+	}
+	return p
+}
+
 // detectSingleTokenSlot enumerates the tokens present in modulePath.
 // If exactly one is found, it returns its slot number.
 // If zero or more than one are found, it returns a descriptive error.
 func detectSingleTokenSlot(modulePath string) (int, error) {
-	p := pkcs11.New(modulePath)
+	p := newPKCS11Ctx(modulePath)
 	if p == nil {
 		return 0, fmt.Errorf("could not load pkcs11 module %q", modulePath)
 	}
@@ -64,7 +80,7 @@ func detectSingleTokenSlot(modulePath string) (int, error) {
 		}
 		labels = append(labels, fmt.Sprintf("%q (slot %d)", strings.TrimSpace(info.Label), s))
 	}
-	return 0, fmt.Errorf("found %d pkcs11 tokens (%s); set token_label/token_serial/slot to pick one (label, serial, and slot aliases are supported)", len(slots), strings.Join(labels, ", "))
+	return 0, fmt.Errorf("found %d pkcs11 tokens (%s); set token_label/label, token_serial/serial, or slot to pick one", len(slots), strings.Join(labels, ", "))
 }
 
 type pkcs11Config struct {

--- a/cmd/restish-pkcs11/config.go
+++ b/cmd/restish-pkcs11/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/miekg/pkcs11"
 )
 
 var defaultPKCS11Paths = func() []string {
@@ -26,6 +27,43 @@ var defaultPKCS11Paths = func() []string {
 			"/usr/lib64/pkcs11/opensc-pkcs11.so",
 		}
 	}
+}
+
+// detectSingleTokenSlot enumerates the tokens present in modulePath.
+// If exactly one is found, it returns its slot number.
+// If zero or more than one are found, it returns a descriptive error.
+func detectSingleTokenSlot(modulePath string) (int, error) {
+	p := pkcs11.New(modulePath)
+	if p == nil {
+		return 0, fmt.Errorf("could not load pkcs11 module %q", modulePath)
+	}
+	if err := p.Initialize(); err != nil {
+		return 0, fmt.Errorf("pkcs11 initialize: %w", err)
+	}
+	defer func() {
+		_ = p.Finalize()
+		p.Destroy()
+	}()
+	slots, err := p.GetSlotList(true)
+	if err != nil {
+		return 0, fmt.Errorf("pkcs11 get slot list: %w", err)
+	}
+	if len(slots) == 0 {
+		return 0, fmt.Errorf("no pkcs11 tokens found; plug in your device or set token_label/serial/slot")
+	}
+	if len(slots) == 1 {
+		return int(slots[0]), nil
+	}
+	var labels []string
+	for _, s := range slots {
+		info, err := p.GetTokenInfo(s)
+		if err != nil {
+			labels = append(labels, fmt.Sprintf("slot %d", s))
+			continue
+		}
+		labels = append(labels, fmt.Sprintf("%q", info.Label))
+	}
+	return 0, fmt.Errorf("found %d pkcs11 tokens (%s); set token_label, token_serial, or slot to pick one", len(slots), strings.Join(labels, ", "))
 }
 
 type pkcs11Config struct {
@@ -56,8 +94,16 @@ func parsePKCS11Config(params map[string]string, env map[string]string, promptPI
 	if err != nil {
 		return nil, fmt.Errorf("invalid slot %q: %w", slotValue, err)
 	}
-	if countNonEmpty(label, serial)+boolCount(slot != nil) != 1 {
-		return nil, fmt.Errorf("exactly one of token_label/label, token_serial/serial, or slot must be set")
+	selectors := countNonEmpty(label, serial) + boolCount(slot != nil)
+	if selectors > 1 {
+		return nil, fmt.Errorf("at most one of token_label/label, token_serial/serial, or slot may be set")
+	}
+	if selectors == 0 {
+		slotNum, err := detectSingleTokenSlot(modulePath)
+		if err != nil {
+			return nil, err
+		}
+		slot = &slotNum
 	}
 
 	pin := firstString(params, "pin")

--- a/cmd/restish-pkcs11/config.go
+++ b/cmd/restish-pkcs11/config.go
@@ -38,6 +38,7 @@ func detectSingleTokenSlot(modulePath string) (int, error) {
 		return 0, fmt.Errorf("could not load pkcs11 module %q", modulePath)
 	}
 	if err := p.Initialize(); err != nil {
+		p.Destroy()
 		return 0, fmt.Errorf("pkcs11 initialize: %w", err)
 	}
 	defer func() {
@@ -49,7 +50,7 @@ func detectSingleTokenSlot(modulePath string) (int, error) {
 		return 0, fmt.Errorf("pkcs11 get slot list: %w", err)
 	}
 	if len(slots) == 0 {
-		return 0, fmt.Errorf("no pkcs11 tokens found; plug in your device or set token_label/serial/slot")
+		return 0, fmt.Errorf("no pkcs11 tokens found; plug in your device")
 	}
 	if len(slots) == 1 {
 		return int(slots[0]), nil
@@ -61,9 +62,9 @@ func detectSingleTokenSlot(modulePath string) (int, error) {
 			labels = append(labels, fmt.Sprintf("slot %d", s))
 			continue
 		}
-		labels = append(labels, fmt.Sprintf("%q", info.Label))
+		labels = append(labels, fmt.Sprintf("%q (slot %d)", strings.TrimSpace(info.Label), s))
 	}
-	return 0, fmt.Errorf("found %d pkcs11 tokens (%s); set token_label, token_serial, or slot to pick one", len(slots), strings.Join(labels, ", "))
+	return 0, fmt.Errorf("found %d pkcs11 tokens (%s); set token_label/token_serial/slot to pick one (label, serial, and slot aliases are supported)", len(slots), strings.Join(labels, ", "))
 }
 
 type pkcs11Config struct {

--- a/cmd/restish-pkcs11/config_test.go
+++ b/cmd/restish-pkcs11/config_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"crypto"
 	"crypto/rsa"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/miekg/pkcs11"
 )
 
 func TestParsePKCS11ConfigAliases(t *testing.T) {
@@ -56,6 +60,100 @@ func TestParsePKCS11ConfigUsesPinEnvAndSlot(t *testing.T) {
 	}
 }
 
+func TestParsePKCS11ConfigAutoDetectsSingleToken(t *testing.T) {
+	fake := &fakePKCS11Ctx{slots: []uint{42}}
+	restore := stubPKCS11Ctx(t, fake)
+	defer restore()
+
+	cfg, err := parsePKCS11Config(map[string]string{
+		"module": "/tmp/opensc.so",
+		"pin":    "123456",
+	}, map[string]string{}, nil)
+	if err != nil {
+		t.Fatalf("parsePKCS11Config: %v", err)
+	}
+	if cfg.SlotNumber == nil || *cfg.SlotNumber != 42 {
+		t.Fatalf("unexpected slot: %#v", cfg.SlotNumber)
+	}
+	if !fake.finalized || !fake.destroyed {
+		t.Fatalf("expected pkcs11 context cleanup, finalized=%v destroyed=%v", fake.finalized, fake.destroyed)
+	}
+}
+
+func TestParsePKCS11ConfigAutoDetectRequiresToken(t *testing.T) {
+	fake := &fakePKCS11Ctx{}
+	restore := stubPKCS11Ctx(t, fake)
+	defer restore()
+
+	_, err := parsePKCS11Config(map[string]string{
+		"module": "/tmp/opensc.so",
+		"pin":    "123456",
+	}, map[string]string{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "no pkcs11 tokens found; plug in your device") {
+		t.Fatalf("expected no-token error, got %v", err)
+	}
+	if !fake.finalized || !fake.destroyed {
+		t.Fatalf("expected pkcs11 context cleanup, finalized=%v destroyed=%v", fake.finalized, fake.destroyed)
+	}
+}
+
+func TestParsePKCS11ConfigAutoDetectListsMultipleTokens(t *testing.T) {
+	fake := &fakePKCS11Ctx{
+		slots: []uint{3, 9},
+		tokenInfo: map[uint]pkcs11.TokenInfo{
+			3: {Label: "YubiKey PIV   "},
+			9: {Label: "Backup"},
+		},
+	}
+	restore := stubPKCS11Ctx(t, fake)
+	defer restore()
+
+	_, err := parsePKCS11Config(map[string]string{
+		"module": "/tmp/opensc.so",
+		"pin":    "123456",
+	}, map[string]string{}, nil)
+	want := `found 2 pkcs11 tokens ("YubiKey PIV" (slot 3), "Backup" (slot 9)); set token_label/label, token_serial/serial, or slot to pick one`
+	if err == nil || err.Error() != want {
+		t.Fatalf("unexpected error:\nwant %q\ngot  %v", want, err)
+	}
+	if !fake.finalized || !fake.destroyed {
+		t.Fatalf("expected pkcs11 context cleanup, finalized=%v destroyed=%v", fake.finalized, fake.destroyed)
+	}
+}
+
+func TestParsePKCS11ConfigAutoDetectHandlesLoadError(t *testing.T) {
+	restore := stubPKCS11Ctx(t, nil)
+	defer restore()
+
+	_, err := parsePKCS11Config(map[string]string{
+		"module": "/tmp/missing-pkcs11.so",
+		"pin":    "123456",
+	}, map[string]string{}, nil)
+	if err == nil || !strings.Contains(err.Error(), `could not load pkcs11 module "/tmp/missing-pkcs11.so"`) {
+		t.Fatalf("expected load error, got %v", err)
+	}
+}
+
+func TestParsePKCS11ConfigAutoDetectCleansUpInitializeError(t *testing.T) {
+	fake := &fakePKCS11Ctx{initializeErr: errors.New("module unavailable")}
+	restore := stubPKCS11Ctx(t, fake)
+	defer restore()
+
+	_, err := parsePKCS11Config(map[string]string{
+		"module": "/tmp/opensc.so",
+		"pin":    "123456",
+	}, map[string]string{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "pkcs11 initialize: module unavailable") {
+		t.Fatalf("expected initialize error, got %v", err)
+	}
+	if fake.finalized {
+		t.Fatal("did not expect finalize after initialize failure")
+	}
+	if !fake.destroyed {
+		t.Fatal("expected destroy after initialize failure")
+	}
+}
+
 func TestParsePKCS11ConfigPromptsForPIN(t *testing.T) {
 	prompted := false
 	cfg, err := parsePKCS11Config(map[string]string{
@@ -102,5 +200,51 @@ func TestEnvMap(t *testing.T) {
 	t.Setenv("RESTISH_PKCS11_TEST", "value")
 	if got := envMap()["RESTISH_PKCS11_TEST"]; got != "value" {
 		t.Fatalf("unexpected env value: %q", got)
+	}
+}
+
+type fakePKCS11Ctx struct {
+	initializeErr error
+	finalized     bool
+	destroyed     bool
+	slots         []uint
+	slotErr       error
+	tokenInfo     map[uint]pkcs11.TokenInfo
+	tokenInfoErr  map[uint]error
+}
+
+func (f *fakePKCS11Ctx) Initialize() error {
+	return f.initializeErr
+}
+
+func (f *fakePKCS11Ctx) Finalize() error {
+	f.finalized = true
+	return nil
+}
+
+func (f *fakePKCS11Ctx) Destroy() {
+	f.destroyed = true
+}
+
+func (f *fakePKCS11Ctx) GetSlotList(tokenPresent bool) ([]uint, error) {
+	return f.slots, f.slotErr
+}
+
+func (f *fakePKCS11Ctx) GetTokenInfo(slotID uint) (pkcs11.TokenInfo, error) {
+	if err := f.tokenInfoErr[slotID]; err != nil {
+		return pkcs11.TokenInfo{}, err
+	}
+	if info, ok := f.tokenInfo[slotID]; ok {
+		return info, nil
+	}
+	return pkcs11.TokenInfo{}, nil
+}
+
+func stubPKCS11Ctx(t *testing.T, fake pkcs11TokenEnumerator) func() {
+	t.Helper()
+	orig := newPKCS11Ctx
+	newPKCS11Ctx = func(modulePath string) pkcs11TokenEnumerator { return fake }
+	return func() {
+		newPKCS11Ctx = orig
 	}
 }

--- a/docs/design/022-restish-pkcs11-plugin.md
+++ b/docs/design/022-restish-pkcs11-plugin.md
@@ -85,17 +85,18 @@ goal is a stable signer plugin, not a complete PKCS#11 management tool.
 
 ## Token Selection
 
-Exactly one token selector must be provided:
+At most one token selector may be provided:
 
 - token label
 - token serial
 - slot number
 
-That constraint is intentional. The plugin refuses ambiguous selection so it
-does not accidentally choose the wrong certificate when multiple tokens or
-slots are available.
+If no selector is provided, the plugin enumerates present tokens and
+auto-selects the slot only when exactly one token is available. Otherwise, the
+plugin refuses ambiguous selection so it does not accidentally choose the wrong
+certificate when multiple tokens or slots are available.
 
-If more than one selector is supplied and they disagree, startup should fail.
+If more than one selector is supplied, startup should fail.
 
 ## Module Path Resolution
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/itchyny/gojq v0.12.19
 	github.com/mattn/go-isatty v0.0.20
+	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pb33f/libopenapi v0.35.0
 	github.com/sandrolain/httpcache v1.4.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
@@ -51,7 +52,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
-	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pb33f/jsonpath v0.8.2 // indirect

--- a/site/content/en/docs/plugins/tls-signer-plugins.md
+++ b/site/content/en/docs/plugins/tls-signer-plugins.md
@@ -51,9 +51,11 @@ rejects configs that combine both client-certificate files and a TLS signer.
 CLI flags such as `--rsh-client-cert`, `--rsh-client-key`, `--rsh-ca-cert`, and
 `--rsh-tls-signer` override both config layers for the current command.
 
-For the bundled PKCS#11 signer, set `module` or `path`, exactly one of
-`token_label`/`label`, `token_serial`/`serial`, or `slot`, and either `pin`,
-`pin_env`, `PKCS11_PIN`, or `login_not_supported: true`.
+For the bundled PKCS#11 signer, set `module` or `path`, at most one token
+selector (`token_label`/`label`, `token_serial`/`serial`, or `slot`), and
+either `pin`, `pin_env`, `PKCS11_PIN`, or `login_not_supported: true`. If you
+omit the token selector, the plugin auto-selects the token only when exactly one
+token is present.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Addresses #362.

Right now the pkcs11 plugin requires you to set token_label, token_serial, or slot. That means a shared restish config has to include a per-user label, which is annoying to distribute.

If no selector is set and there is only one token on the device, just use it. If there are multiple, error and list their labels so the user knows what to put in token_label.

Backwards compatible: configs with an explicit label/serial/slot are unchanged.