### PR TITLE
docs: add Restish blog

### DIFF
--- a/.agents/skills/rsh-docs/SKILL.md
+++ b/.agents/skills/rsh-docs/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: rsh-docs
-description: Documentation writer and maintainer
+description: Write and maintain Restish documentation, blog posts, release announcements, tutorials, recipes, and user-facing product explanations.
 ---
 
 # Restish Documentation
 
-You write and maintain Restish documentation. Help users succeed with the CLI, and help maintainers preserve design intent. Docs are part of the product, not release-note filler or a wrapper around implementation details.
+You write and maintain Restish documentation and product writing. Help users succeed with the CLI, and help maintainers preserve design intent. Docs and posts are part of the product, not release-note filler or a wrapper around implementation details.
 
 ## Scope
 
-Maintain user docs in `site/`, design docs in `docs/design/`, user-facing Markdown elsewhere, examples, tutorials, recipes, plugin docs, and Go doc comments for exported APIs.
+Maintain user docs in `site/`, blog posts in `site/content/en/blog/`, design docs in `docs/design/`, user-facing Markdown elsewhere, examples, tutorials, recipes, plugin docs, and Go doc comments for exported APIs.
 
 When user-visible behavior changes, update user docs. When architecture or subsystem behavior changes significantly, update or add a design doc.
 
@@ -23,6 +23,7 @@ Choose one primary mode before writing:
 - Reference: complete factual lookup; terse, predictable, example-backed.
 - Troubleshooting: symptom, cause, confirm, fix, prevention.
 - Design doc: why the system is shaped this way; alternatives and consequences.
+- Blog post or announcement: product story, release context, technical idea, or design rationale; narrative entry point backed by concrete Restish behavior.
 
 Do not blur modes casually. If reference needs context, link to a guide. If a design doc changes user behavior, write the user-facing explanation too.
 
@@ -125,6 +126,48 @@ Config reference: include scope, precedence, file location, fields, types, defau
 
 Troubleshooting: repeat the shape `Symptom`, `Likely cause`, `How to confirm`, `Fix`, `Prevention`, `Related docs`. Good topics include auth failures, OpenAPI loading/cache, content negotiation, pagination, shorthand parsing, plugin discovery, and output formatting.
 
+Blog post or announcement: lead with the user problem, product change, or technical bet. Keep the narrative grounded in examples users can try. Use the post to create interest and explain why the work matters, then route exact syntax and long-lived procedures to docs pages.
+
+## Blog Posts And Announcements
+
+Use blog posts for release stories, API tooling ideas, OpenAPI/CLI design notes,
+automation patterns, plugin/MCP stories, and deeper product decisions. Blog
+posts can be warmer and more narrative than reference docs, but they must stay
+technically specific and useful.
+
+General notes for blog posts:
+
+- Reintroduce the project without assuming readers know older posts.
+- State what stayed familiar before explaining what changed.
+- Frame comparisons generously: `curl`, Postman, SDKs, and Swagger UI all have
+  valid jobs; Restish owns the shell-native, API-aware workflow between them.
+- Keep product vocabulary explicit. Command naming, stdout/stderr behavior,
+  auth placement, pagination, and plugin boundaries are user-facing design.
+- Put runnable `restish-example` shortcodes near the claims they support.
+- Use plain fenced commands when setup is local-only or not suitable for the
+  browser preview.
+- Prefer public `api.rest.sh` examples and call out when the browser preview
+  has built-in API mappings that differ from local setup.
+- Include a concise "try it locally" section with install, first request, API
+  connect, and 3-5 durable next links.
+- Use front matter consistently: `title`, `linkTitle`, `date`, `author`,
+  `description`, `canonical_url`, `categories`, and `tags`.
+
+Good blog shape:
+
+1. Hook: name the user pain, product change, or timely technical idea.
+2. Thesis: say where Restish fits and what the reader will learn.
+3. Concrete path: show direct request, generated API command, output/filtering,
+   auth, pagination, plugin, or MCP behavior as relevant.
+4. Why it matters: explain tradeoffs, compatibility, security, or design
+   reasoning without turning the post into a design doc.
+5. Try it: include local install or upgrade steps and link to maintained docs.
+
+Avoid turning posts into vague marketing copy. Avoid dunking on adjacent tools.
+Avoid making blog posts the only source for exact commands, migration steps, or
+security-sensitive behavior; link to durable docs and update those docs when the
+post reveals a gap.
+
 ## Plugin Docs
 
 Always separate operator docs from author docs. Operators need install/configure/run/verify/debug. Authors need contract, inputs/outputs, lifecycle, testing, compatibility, packaging, and distribution. Do not make operators read authoring internals to use a plugin.
@@ -166,5 +209,8 @@ After meaningful site changes, run:
 ```bash
 hugo --source site --quiet
 ```
+
+For blog changes that affect social cards, run `npm run social-images` from
+`site/` or `npm run build` if dependencies are available.
 
 Also verify new links, check examples against current CLI behavior, grep touched docs for stale `api.example.com` placeholders and leftover `Source material:` sections, and prefer examples that can later be validated against `api.rest.sh` or promoted into tests.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.DS_Store
+.DS_Store
 
 # Local build outputs from `go build ./cmd/...`.
 /restish
@@ -15,6 +15,7 @@
 /refactor.md
 /testing.md
 /test-findings.md
+/blog.md
 
 # Local Codex skill installs.
 /skills-lock.json

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Andy Warhol mural in Miami gif     /images/gif
 Use Homebrew for the easiest managed install on macOS:
 
 ```bash
-brew install rest-sh/tap/restish
+brew install restish
 restish --version
 ```
 

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -35,9 +35,15 @@ older version such as `0.21.2`.
 GoReleaser injects the tag version into
 `github.com/rest-sh/restish/v2/internal/cli.Version`.
 
-## Homebrew Tap
+## Homebrew
 
-The public tap is:
+The primary Homebrew install path for the current v2 CLI is Homebrew core:
+
+```bash
+brew install restish
+```
+
+The public tap still exists for legacy and plugin formulae:
 
 ```text
 rest-sh/tap
@@ -49,15 +55,18 @@ The GitHub repository backing that tap must be named:
 rest-sh/homebrew-tap
 ```
 
-Stable v2 releases update the main formula:
+Stable v2 releases should update the Homebrew core `restish` formula. After
+publishing, verify the core formula installs the current v2 binary:
 
 ```bash
-brew install rest-sh/tap/restish
+brew install restish
+restish --version
+restish api.rest.sh/
 ```
 
-The tap also keeps a separate `restish@1` formula for the last v1 release. That
-formula is intentionally keg-only so it can coexist with the current `restish`
-formula without fighting for the same linked executable.
+The tap keeps a separate `restish@1` formula for the last v1 release. That
+formula is intentionally keg-only so it can coexist with the current core
+`restish` formula without fighting for the same linked executable.
 
 ```bash
 brew install rest-sh/tap/restish@1
@@ -65,12 +74,10 @@ brew install rest-sh/tap/restish@1
 
 The release workflow uses the existing Restish Releaser GitHub App secrets
 (`RELEASER_APP_ID` and `RELEASER_APP_PRIVATE_KEY`) to mint a short-lived token
-with access to `rest-sh/homebrew-tap`. GoReleaser uses it to update v2 formulae,
-and the workflow seeds the v1 formula from `packaging/homebrew/restish@1.rb`.
-
-Do not use unqualified `brew install restish` for v2 verification until the
-tap/core state is checked. The documented user path is the official tap:
-`brew install rest-sh/tap/restish`.
+with access to `rest-sh/homebrew-tap`. The workflow seeds the v1 formula from
+`packaging/homebrew/restish@1.rb` and updates first-party plugin formulae in the
+tap. Do not advertise `rest-sh/tap/restish` as the normal v2 install path while
+Homebrew core is current.
 
 ## mise
 

--- a/site/README.md
+++ b/site/README.md
@@ -25,7 +25,8 @@ npm run build
 
 ## Notes
 
-- Content lives under `content/en/docs/`.
+- Documentation content lives under `content/en/docs/`.
+- Blog content lives under `content/en/blog/`.
 - The theme is provided through Hugo Modules.
 - Social preview images are generated into `static/images/social/` before
   Hugo runs. That directory is ignored because CI regenerates it for deploys.

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -248,6 +248,63 @@ body.td-home .td-navbar__search .td-search-input {
   letter-spacing: 0;
 }
 
+.td-content h1[id],
+.td-content h2[id],
+.td-content h3[id],
+.td-content h4[id],
+.td-content h5[id],
+.td-content h6[id] {
+  scroll-margin-top: 5.5rem;
+}
+
+.td-content .restish-heading-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.45rem;
+  height: 1.45rem;
+  margin-left: 0.35rem;
+  border-radius: 6px;
+  color: var(--restish-link-color);
+  font-size: 0.78em;
+  line-height: 1;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(-0.05em);
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.td-content .restish-heading-anchor:hover,
+.td-content .restish-heading-anchor:focus {
+  background: rgba(45, 212, 191, 0.1);
+  color: var(--restish-nav-hover);
+  text-decoration: none;
+}
+
+.td-content h1[id]:hover .restish-heading-anchor,
+.td-content h2[id]:hover .restish-heading-anchor,
+.td-content h3[id]:hover .restish-heading-anchor,
+.td-content h4[id]:hover .restish-heading-anchor,
+.td-content h5[id]:hover .restish-heading-anchor,
+.td-content h6[id]:hover .restish-heading-anchor,
+.td-content .restish-heading-anchor:focus {
+  opacity: 1;
+}
+
+.td-content .restish-heading-anchor:focus-visible {
+  outline: 2px solid var(--restish-heading-accent);
+  outline-offset: 2px;
+}
+
+@media (hover: none) {
+  .td-content .restish-heading-anchor {
+    opacity: 0.72;
+  }
+}
+
 .td-content h2 {
   position: relative;
   margin-top: 2.4rem;
@@ -705,6 +762,13 @@ body.td-home .td-navbar__search .td-search-input {
   white-space: pre;
 }
 
+.td-content pre.restish-playground__output--table code,
+.restish-playground__output.restish-playground__output--table code {
+  font-family: Menlo, "DejaVu Sans Mono", "Cascadia Mono", "SFMono-Regular", Consolas, monospace;
+  font-variant-ligatures: none;
+  line-height: 1;
+}
+
 .restish-playground__terminal-image {
   display: block;
   width: 100%;
@@ -934,6 +998,431 @@ body.td-home .td-navbar__search .td-search-input {
   border-color: rgba(94, 234, 212, 0.24);
   background: rgba(45, 212, 191, 0.1);
   color: #f8fafc;
+}
+
+.restish-blog {
+  background: var(--restish-paper);
+}
+
+.restish-blog .td-main {
+  background:
+    linear-gradient(180deg, rgba(45, 212, 191, 0.08), transparent 18rem),
+    var(--restish-paper);
+}
+
+.restish-blog .td-main main {
+  --td-main-padding-top: 0rem;
+}
+
+.restish-blog-hero {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--restish-navbar-border);
+  background:
+    linear-gradient(135deg, #07111f 0%, #102033 56%, #14343a 100%);
+  color: #f8fafc;
+}
+
+.restish-blog-hero::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 0.35rem;
+  background: linear-gradient(90deg, var(--restish-teal), var(--restish-amber), var(--restish-pink));
+}
+
+.restish-blog-hero__inner {
+  width: calc(100% - 2rem);
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: clamp(3.5rem, 8vw, 6.5rem) 0 clamp(2.8rem, 6vw, 5rem);
+}
+
+.restish-blog-hero__eyebrow {
+  margin: 0 0 0.85rem;
+  color: #5eead4;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.restish-blog-hero h1 {
+  max-width: 13ch;
+  margin: 0;
+  color: #f8fafc;
+  font-family: "Space Grotesk", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(2.65rem, 7vw, 5.8rem);
+  font-weight: 700;
+  line-height: 0.96;
+  letter-spacing: 0;
+}
+
+.restish-blog-hero--index h1 {
+  max-width: 9ch;
+}
+
+.restish-blog-hero--article h1 {
+  max-width: 14em;
+}
+
+.restish-blog-hero__dek {
+  max-width: 44rem;
+  margin: 1.4rem 0 0;
+  color: #d9e5ea;
+  font-size: clamp(1.13rem, 2vw, 1.45rem);
+  line-height: 1.5;
+}
+
+.restish-blog-hero__intro {
+  max-width: 46rem;
+  margin-top: 1.4rem;
+  color: #bfd0d8;
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.restish-blog-hero__intro p {
+  margin-bottom: 0.65rem;
+}
+
+.restish-blog-hero__intro a {
+  color: #fbbf24;
+  text-decoration-color: rgba(251, 191, 36, 0.42);
+}
+
+.restish-blog-hero__meta,
+.restish-blog-hero__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  margin-top: 1.35rem;
+}
+
+.restish-blog-hero__meta {
+  color: #bfd0d8;
+  font-size: 0.94rem;
+}
+
+.restish-blog-hero__meta span,
+.restish-blog-hero__meta time {
+  display: inline-flex;
+  align-items: center;
+}
+
+.restish-blog-hero__meta span + time::before,
+.restish-blog-hero__meta time + span::before {
+  content: "";
+  width: 0.35rem;
+  height: 0.35rem;
+  margin-right: 0.6rem;
+  border-radius: 999px;
+  background: var(--restish-amber);
+}
+
+.restish-blog-hero__tags span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.8rem;
+  padding: 0 0.68rem;
+  border: 1px solid rgba(94, 234, 212, 0.24);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #e6fffb;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.restish-blog-index {
+  padding: clamp(2.5rem, 6vw, 4.5rem) 0;
+}
+
+.restish-blog-index__inner {
+  width: calc(100% - 2rem);
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.restish-blog-index__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1.1rem;
+}
+
+.restish-blog-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 20rem;
+  padding: 1.3rem;
+  border: 1px solid var(--restish-card-border);
+  border-radius: 8px;
+  background: linear-gradient(180deg, var(--restish-card-bg-top), var(--restish-card-bg-bottom));
+  box-shadow: var(--restish-card-shadow);
+}
+
+.restish-blog-card__meta,
+.restish-blog-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  color: var(--restish-card-text);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.restish-blog-card__meta span::before {
+  content: "/";
+  margin-right: 0.5rem;
+  color: var(--restish-amber);
+}
+
+.restish-blog-card h2 {
+  margin: 1rem 0 0;
+  padding: 0;
+  border: 0;
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  line-height: 1.08;
+}
+
+.restish-blog-card h2::after {
+  display: none;
+}
+
+.restish-blog-card h2 a {
+  color: var(--restish-card-title);
+  text-decoration: none;
+}
+
+.restish-blog-card p {
+  margin: 0.95rem 0 0;
+  color: var(--restish-card-text);
+  line-height: 1.6;
+}
+
+.restish-blog-card__footer {
+  justify-content: space-between;
+  margin-top: auto;
+  padding-top: 1.2rem;
+}
+
+.restish-blog-card__footer a {
+  color: var(--restish-link-color);
+}
+
+.restish-blog-card__footer span {
+  color: var(--restish-muted);
+}
+
+.restish-blog-article__shell {
+  display: grid;
+  grid-template-columns: minmax(0, 48rem) minmax(12rem, 17rem);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: start;
+  width: calc(100% - 2rem);
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: clamp(2.2rem, 5vw, 4.5rem) 0;
+}
+
+.restish-blog-article__content {
+  grid-column: 1;
+  order: 0;
+  max-width: none;
+  font-size: 1.05rem;
+  line-height: 1.78;
+}
+
+.restish-blog .td-main > main .restish-blog-article__content.td-content {
+  max-width: none;
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.restish-blog-article__content.td-content > blockquote,
+.restish-blog-article__content.td-content > dl dd,
+.restish-blog-article__content.td-content > h1,
+.restish-blog-article__content.td-content > h2,
+.restish-blog-article__content.td-content > h3,
+.restish-blog-article__content.td-content > h4,
+.restish-blog-article__content.td-content > h5,
+.restish-blog-article__content.td-content > h6,
+.restish-blog-article__content.td-content > ol,
+.restish-blog-article__content.td-content > p,
+.restish-blog-article__content.td-content > pre,
+.restish-blog-article__content.td-content > ul {
+  max-width: none;
+}
+
+.restish-blog-article__content > p:first-child {
+  color: var(--restish-card-title);
+  font-size: 1.24rem;
+  line-height: 1.65;
+}
+
+.restish-blog-article__content h2 {
+  margin-top: 3.2rem;
+  font-size: clamp(1.75rem, 3vw, 2.35rem);
+}
+
+.restish-blog-article__content .restish-playground {
+  margin: 1.55rem 0 2rem;
+}
+
+.restish-blog-callout {
+  margin: 2rem 0;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(45, 212, 191, 0.22);
+  border-left: 4px solid var(--restish-teal);
+  border-radius: 8px;
+  background: rgba(45, 212, 191, 0.08);
+}
+
+.restish-blog-callout strong {
+  color: var(--restish-card-title);
+}
+
+.restish-blog-cta {
+  display: grid;
+  gap: 1.2rem;
+  margin: 3.2rem 0 0;
+  padding: clamp(1.25rem, 3vw, 1.7rem);
+  border: 1px solid var(--restish-card-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, rgba(45, 212, 191, 0.12), rgba(255, 77, 189, 0.08)),
+    var(--restish-card-bg-top);
+  box-shadow: var(--restish-card-shadow);
+}
+
+.restish-blog-cta__eyebrow {
+  margin: 0 0 0.45rem;
+  color: var(--restish-nav-hover);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.td-content .restish-blog-cta h2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: var(--restish-card-title);
+  font-size: clamp(1.55rem, 3vw, 2rem);
+  line-height: 1.12;
+}
+
+.td-content .restish-blog-cta h2::after {
+  display: none;
+}
+
+.restish-blog-cta p {
+  max-width: 42rem;
+  margin: 0.75rem 0 0;
+  color: var(--restish-card-text);
+  line-height: 1.6;
+}
+
+.restish-blog-cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.restish-blog-article__rail {
+  grid-column: 2;
+  order: 0;
+  position: sticky;
+  top: 6rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.restish-blog-rail-card {
+  display: block;
+  padding: 0.95rem;
+  border: 1px solid var(--restish-card-border);
+  border-radius: 8px;
+  background: var(--restish-card-bg-top);
+  color: var(--restish-card-text);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+}
+
+a.restish-blog-rail-card {
+  color: var(--restish-link-color);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.restish-blog-rail-card i {
+  margin-right: 0.35rem;
+}
+
+.restish-blog-rail-card strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--restish-card-title);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.restish-blog-rail-card #TableOfContents ul {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.restish-blog-rail-card #TableOfContents ul ul {
+  display: none;
+}
+
+.restish-blog-rail-card #TableOfContents li {
+  margin: 0.45rem 0;
+}
+
+.restish-blog-rail-card #TableOfContents a {
+  color: var(--restish-toc-link);
+  text-decoration: none;
+}
+
+.restish-blog-rail-card #TableOfContents a:hover,
+.restish-blog-rail-card #TableOfContents a:focus {
+  color: var(--restish-link-color);
+}
+
+[data-bs-theme="dark"] .restish-blog,
+[data-bs-theme="dark"] .restish-blog .td-main {
+  background: var(--bs-body-bg);
+}
+
+[data-bs-theme="dark"] .restish-blog-hero {
+  border-bottom-color: rgba(148, 163, 184, 0.18);
+}
+
+[data-bs-theme="dark"] .restish-blog-callout {
+  background: rgba(45, 212, 191, 0.1);
+}
+
+[data-bs-theme="dark"] .restish-blog-rail-card {
+  background: var(--restish-card-bg-top);
+}
+
+@media (max-width: 991.98px) {
+  .restish-blog-article__shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .restish-blog-article__rail {
+    display: none;
+  }
 }
 
 @media (max-width: 575.98px) {
@@ -1197,11 +1686,24 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
   box-shadow: 0 10px 24px rgba(255, 77, 189, 0.24);
 }
 
+.restish-button--secondary {
+  border: 1px solid rgba(45, 212, 191, 0.26);
+  background: rgba(45, 212, 191, 0.08);
+  color: var(--restish-card-title);
+}
+
 .td-content a.restish-button--primary,
 .restish-button--primary:hover,
 .restish-button--primary:focus {
   background: #e83da9;
   color: #fff;
+  text-decoration: none;
+}
+
+.td-content a.restish-button--secondary,
+.restish-button--secondary:hover,
+.restish-button--secondary:focus {
+  color: var(--restish-nav-hover);
   text-decoration: none;
 }
 
@@ -1239,6 +1741,18 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
   box-shadow: none;
 }
 
+.td-content .restish-install-copy code {
+  padding: 0 0.8rem 0 1.25rem;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.restish-install-copy .token-symbol {
+  margin-right: 0.35rem;
+  color: var(--restish-teal);
+}
+
 .restish-install-copy__button {
   display: inline-flex;
   align-items: center;
@@ -1264,13 +1778,8 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
   color: #0f766e;
 }
 
-.restish-hero__actions .token-symbol,
 .restish-window .token-symbol {
   color: var(--restish-teal);
-}
-
-.restish-hero__actions .token-symbol {
-  margin-right: 0.35rem;
 }
 
 .restish-window-wrap {
@@ -1690,6 +2199,12 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
 }
 
 [data-bs-theme="dark"] .restish-install-copy code {
+  background: transparent;
+  color: #fafafa;
+}
+
+[data-bs-theme="dark"] .td-content .restish-install-copy code {
+  background: transparent;
   color: #fafafa;
 }
 

--- a/site/content/en/blog/_index.md
+++ b/site/content/en/blog/_index.md
@@ -1,0 +1,10 @@
+---
+title: Blog
+linkTitle: Blog
+description: Notes on Restish releases, API tooling, OpenAPI, CLI design, automation, plugins, and the decisions behind the project.
+---
+
+The Restish blog is for release stories, API tooling ideas, and deeper notes on
+the design choices behind the CLI. For task-focused help, start with the
+[documentation](/docs/). For the shortest hands-on path, use the
+[browser tour](/docs/getting-started/tour/).

--- a/site/content/en/blog/restish-v2-a-cli-for-rest-apis-rebuilt.md
+++ b/site/content/en/blog/restish-v2-a-cli-for-rest-apis-rebuilt.md
@@ -1,0 +1,331 @@
+---
+title: "Restish v2: A CLI for REST APIs, Rebuilt"
+linkTitle: "Restish v2: A CLI for REST APIs, Rebuilt"
+date: 2026-05-30
+author: "Daniel Taylor"
+description: Restish v2 keeps the fast one-off HTTP workflow, then turns OpenAPI-described APIs into shell-native commands with profiles, auth, output filtering, pagination, plugins, and MCP.
+canonical_url: "https://rest.sh/blog/restish-v2-a-cli-for-rest-apis-rebuilt/"
+categories:
+  - Releases
+tags:
+  - cli
+  - openapi
+  - rest
+  - devtools
+---
+
+Most APIs already know more about themselves than the command line does. They
+have schemas, auth rules, pagination links, content types, examples, and often a
+full OpenAPI description. Then we copy a `curl` command into a terminal and
+teach all of that context back to the shell one flag at a time.
+
+`curl` is still the universal primitive. Restish is for the moment after that:
+when a URL becomes a workflow, and the API should start feeling like a small
+native CLI instead of a string you keep rebuilding.
+
+Restish v1 proved the shape of the product: start with direct HTTP requests,
+then let OpenAPI turn repeated work into an API-specific CLI. V2 keeps that
+idea, but rebuilds the foundation around it: one config model, clearer command
+families, stricter output contracts, safer auth behavior, and a real plugin
+boundary.
+
+<div class="restish-blog-callout">
+  <strong>Try it as you read.</strong> The runnable examples below use the same
+  browser preview as the docs. They make live requests to the public
+  <code>api.rest.sh</code> API, and the same commands work locally after you
+  install Restish.
+</div>
+
+## Why a V2?
+
+V2 exists because the original design worked well enough to outgrow itself.
+Restish had picked up direct requests, generated OpenAPI commands, shorthand
+input, auth helpers, pagination, output formatting, config editing, and plugin
+workflows over time. The result was useful, but some of the product vocabulary
+and internal boundaries were carrying too much history.
+
+Streaming was one pressure point. Server-Sent Events, NDJSON, paginated
+collections, filters, and ordinary response bodies all want different output
+shapes, but they still have to compose with the same `stdout`, `stderr`,
+redirect, timeout, and formatting rules. V2 gave Restish a stricter output
+model so live streams can emit records incrementally while scripts still get
+predictable output.
+
+Configuration was another. V1 split API registrations and global settings
+across multiple files, and the old interactive API setup tried to discover too
+much through a prompt flow that was hard to maintain and easy to get stuck in.
+V2 centers persistent state in one JSONC `restish.json`, makes config editing
+explicit with `config edit`, and makes API setup a repeatable command:
+`restish api connect <name> <url>`.
+
+OpenAPI auth also needed a more honest model. Many APIs do not have one global
+credential. One operation may be public, another may require an API key, and a
+third may accept either OAuth or a partner key. V2 lets a profile hold multiple
+credential bindings, then selects credentials per operation from the OpenAPI
+security policy instead of pasting one profile-level auth value onto every
+generated request.
+
+Finally, v2 needed a real extension boundary. V1 had an external auth command
+hook, but not a general plugin system. V2 adds plugin discovery, manifests,
+hook protocols, command plugins, formatter plugins, TLS signer plugins, and
+host-delegated request execution around one shared request pipeline. A plugin
+can extend Restish without reimplementing auth, TLS, retries, pagination,
+streaming, filtering, or output rules on its own.
+
+Those changes are why v2 has a few intentional breaks. Config moved from
+`apis.json` and `config.json` into `restish.json`; `api edit` became
+`config edit`; `api clear-auth-cache` became `api auth logout`; auth inspection
+became API/profile-aware; and some output defaults became stricter so redirects,
+streaming, and scripts behave predictably. The
+[upgrade guide](/docs/getting-started/upgrade-from-v1/) covers the command
+mapping, but the theme is simple: preserve the daily request workflow, and
+clean up the foundation underneath it.
+
+So v2 is not a pivot away from v1. It is the same bet with sharper edges:
+direct requests stay fast, connected APIs feel native, and the Restish-owned
+control plane becomes easier to explain, test, and extend.
+
+## Start With a URL
+
+Restish does not require setup for the first request. Give it a URL and it sends
+a request, decodes the response, and renders something useful for the terminal.
+
+{{< restish-example >}}
+restish api.rest.sh/types
+{{< /restish-example >}}
+
+That fast path matters. A tool that only works after setup is not the tool you
+reach for while debugging a response, checking a new endpoint, or pasting one
+command into a chat thread.
+
+Restish keeps the obvious HTTP verbs too:
+
+{{< restish-example >}}
+restish post api.rest.sh/body 'name: Ada, tags: [cli, openapi], active: true'
+{{< /restish-example >}}
+
+The body there is Restish shorthand: a shell-friendly way to send structured
+data without stopping to quote and escape JSON by hand. Raw JSON, forms,
+multipart uploads, files, and stdin are still there when you need them.
+
+## Then Let the API Become a CLI
+
+The bigger idea is that a useful API already describes itself. If an API
+publishes OpenAPI, Restish can turn that description into commands at runtime.
+
+Locally, that starts like this:
+
+```bash
+restish api connect example api.rest.sh
+restish example --help
+```
+
+After that, operations from the API become commands under the API name. The
+browser preview uses a built-in `example` API mapping so you can try the same
+shape without writing local config:
+
+{{< restish-example >}}
+restish example list-images -o table
+{{< /restish-example >}}
+
+That command shape is intentional. Direct HTTP requests stay direct. Connected
+APIs become native command groups. A generated API call does not live under
+`restish api call ...` because calling the API is the daily workflow. The `api`
+command is for managing registrations, not for hiding the API behind one more
+noun.
+
+## Output Is a Product Feature
+
+API tools tend to fail in two different ways. Some are friendly in a terminal
+but awkward in scripts. Others are scriptable, but make humans stare at raw
+payloads until the coffee wears off.
+
+Restish treats output as part of the contract:
+
+- stdout carries the selected response data.
+- stderr carries diagnostics, warnings, progress, and verbose traces.
+- interactive terminals get readable output by default.
+- redirected unfiltered responses preserve body bytes.
+- filters and explicit formats produce structured output for the next command.
+
+For example, if you want one field from every item, ask for one field from every
+item:
+
+{{< restish-example >}}
+restish api.rest.sh/books -f body.url -o lines
+{{< /restish-example >}}
+
+The v2 rule for files is intentionally boring: if stdout is redirected and you
+did not ask Restish to filter or format the response, Restish writes the body
+bytes. That keeps image downloads, archives, CBOR, YAML, and other payloads from
+being "helpfully" rewritten when what you needed was the file. When you do ask
+for `-o json`, `-o table`, `-o ndjson`, `-o lines`, or another format, Restish
+renders the selected value for the next program.
+
+## Pagination Shouldn't Be Copy-Pasted
+
+A lot of API scripts grow the same little loop: fetch a page, extract `next`,
+fetch another page, stop eventually, and hope the next link does not wander
+somewhere surprising.
+
+Restish follows recognized `next` links for collection responses by default,
+with limits. It also keeps same-origin pagination conservative unless an API has
+explicitly opted into a broader discovery path.
+
+{{< restish-example >}}
+restish example list-images --per-page=1 --rsh-max-items 3 -f body.self -o lines
+{{< /restish-example >}}
+
+The goal is not to hide HTTP. The goal is to remove the repeated glue code while
+still making limits, warnings, and failure cases visible.
+
+## Auth Belongs in Profiles, Not Shell History
+
+Real APIs need credentials, environments, and sometimes several auth schemes for
+different operations. Repeating those details in every command is both tedious
+and risky.
+
+Restish v2 keeps auth in profiles. A profile can hold headers, query params,
+base URLs, API keys, bearer tokens, OAuth settings, mTLS settings, external tool
+auth, and OpenAPI-derived credential bindings.
+
+For quick debugging, you can still send a header directly:
+
+{{< restish-example >}}
+restish -H 'Authorization: Bearer docs-token' api.rest.sh/auth/bearer
+{{< /restish-example >}}
+
+For real work, put the value behind an environment reference or an OAuth flow.
+Restish can inspect computed auth material, redact sensitive values for support
+logs, and clear cached OAuth tokens with `restish api auth logout`.
+
+OpenAPI operation security also matters. Public operations should not inherit
+credentials by accident. Operations with several allowed auth alternatives need
+a way to choose which credential to use. V2 makes that part of the generated
+command behavior instead of treating auth as one global header pasted onto every
+request.
+
+## V2 Cleaned Up the Restish Side
+
+Restish v1 grew organically, which meant several local management tasks ended
+up under `api`. V2 keeps the request path familiar and gives the control plane
+clearer nouns:
+
+```text
+restish api      # connect, inspect, sync, remove, and configure APIs
+restish config   # show, edit, and update local Restish config
+restish cache    # inspect and clear response cache state
+restish plugin   # install, list, remove, and debug plugins
+restish shell    # setup and completion
+restish doctor   # local diagnostics
+```
+
+That sounds small, but command vocabulary is product design. If `config edit`
+opens the whole Restish config, the command should say `config`. If an OAuth
+token cache needs to be cleared, that belongs with `api auth`. If MCP starts a
+long-running server, the command should say `serve`.
+
+## Plugins Keep the Core Focused
+
+Restish v2 has a plugin system because not every useful API workflow belongs in
+the main binary.
+
+Hooks can add output formats, auth behavior, loaders, and request or response
+middleware. Command plugins can provide larger workflows while delegating HTTP
+execution back to Restish, so they still get the normal profiles, auth, TLS,
+retries, output formatting, and diagnostics. TLS signer plugins can handle
+client-certificate signing when private keys must stay in hardware or another
+local system.
+
+The first-party plugins are examples of that split:
+
+- `restish-csv` adds CSV output.
+- `restish-bulk` keeps a multi-step resource checkout workflow out of core.
+- `restish-pkcs11` signs mTLS handshakes with PKCS#11-backed keys.
+- `restish-mcp` exposes registered APIs as MCP tools.
+
+The `plugin debug` command is there because plugin protocols should not require
+guessing what happened on stdio.
+
+## OpenAPI to MCP Is Now One Command
+
+MCP is a natural extension of the same idea behind Restish: an API description
+can become an interface for another kind of user.
+
+For humans, Restish turns OpenAPI operations into CLI commands. For agents,
+`restish-mcp` can expose those operations as MCP tools:
+
+```bash
+restish mcp serve example
+```
+
+The important part is not only "OpenAPI becomes tools." The important part is
+that those tools run through the same Restish request pipeline: profiles, auth,
+TLS, retries, timeouts, and output normalization.
+
+V2 also keeps the default conservative. MCP exposes read-oriented tools by
+default. Write operations require an explicit opt-in, and you can allowlist
+operations when a client should only see a subset of the API.
+
+## Where Restish Fits
+
+Restish is not trying to replace every API tool.
+
+Use `curl` when you need the universal primitive. Use Postman when you want a
+collaborative GUI workspace. Use generated SDKs inside applications. Use
+Swagger UI when a browser is the right place to explore a spec.
+
+Restish is for the space between those:
+
+- you live in the terminal
+- you work with REST-ish APIs repeatedly
+- your API publishes OpenAPI, or at least behaves consistently
+- you want commands that compose with shell tools
+- you want auth, profiles, output, pagination, retries, and plugins to be
+  remembered by the tool instead of pasted into every command
+
+That space is bigger than it looks. It includes local development, API support,
+CI jobs, internal platform tools, incident debugging, docs examples, and now
+agent tool servers.
+
+## Try It Locally
+
+Install the v2 release line with Homebrew:
+
+```bash
+brew install restish
+restish --version
+```
+
+Or with Go:
+
+```bash
+go install github.com/rest-sh/restish/v2/cmd/restish@latest
+restish --help
+```
+
+Then make one request:
+
+```bash
+restish api.rest.sh/types
+```
+
+If the first request works, connect the example API and look at the generated
+commands:
+
+```bash
+restish api connect example api.rest.sh
+restish example --help
+restish example list-images -o table --rsh-columns name,format,self
+```
+
+Useful next stops:
+
+- [Tour of Restish](/docs/getting-started/tour/) runs more examples in the browser.
+- [Install](/docs/getting-started/install/) covers package managers and setup.
+- [Connect to an API](/docs/getting-started/connect-to-an-api/) turns an OpenAPI API into commands.
+- [Scripting and Automation](/docs/guides/automation/) covers stdout, stderr, exit codes, retries, and pagination.
+- [Serve APIs Over MCP](/docs/plugins/mcp/) explains the MCP plugin.
+
+Restish v2 is a redesign, but not a reinvention. The core promise is the same:
+start with a URL, then let the API teach your terminal how to work with it.

--- a/site/content/en/docs/contributing/release-packaging.md
+++ b/site/content/en/docs/contributing/release-packaging.md
@@ -50,20 +50,27 @@ restish-X.Y.Z-windows-amd64.zip
 
 ## Homebrew
 
-The Homebrew tap should install the current v2 `restish` binary as `restish`.
-The legacy v1 formula stays keg-only as `restish@1` for users who need the old
-binary while migrating.
+The primary Homebrew install path for the current v2 CLI is Homebrew core. The
+`rest-sh/tap` tap stays available for the legacy v1 formula and first-party
+plugin formulae.
 
-After updating the formula, verify:
+After publishing, verify the core formula installs the current v2 binary:
 
 ```bash
-brew install rest-sh/tap/restish
+brew install restish
 restish --version
 restish api.rest.sh/
 ```
 
-Check the tap formula directly and do not rely on an unqualified
-`brew install restish` for the v2 release verification.
+The legacy v1 formula remains keg-only as `restish@1` for users who need the
+old binary while migrating:
+
+```bash
+brew install rest-sh/tap/restish@1
+```
+
+Do not advertise `rest-sh/tap/restish` as the normal v2 install path while
+Homebrew core is current.
 
 ## mise
 

--- a/site/content/en/docs/getting-started/install.md
+++ b/site/content/en/docs/getting-started/install.md
@@ -20,12 +20,13 @@ restish --version
 Use Homebrew for the easiest managed install on macOS:
 
 ```bash
-brew install rest-sh/tap/restish
+brew install restish
 restish --version
 ```
 
-The tap also keeps a legacy `restish@1` formula available for users who
-intentionally stay on v1 during migration.
+The `rest-sh/tap` tap keeps a legacy `restish@1` formula available for users
+who intentionally stay on v1 during migration. It also carries first-party
+plugin formulae.
 
 ## Build From Source
 

--- a/site/content/en/docs/getting-started/upgrade-from-v1.md
+++ b/site/content/en/docs/getting-started/upgrade-from-v1.md
@@ -25,7 +25,7 @@ The main upgrade differences are:
 - the first v2 run auto-migrates legacy v1 config files when no v2 config
   exists yet
 - generated commands are stricter and more explicit in a few places
-- the plugin protocol changed, so v1 plugins do not load in v2
+- v2 adds a general plugin system; v1 only had the external auth command hook
 
 If Restish migrates your config, it prints a one-time notice like:
 
@@ -107,7 +107,6 @@ These changes are intentional in v2 and are not treated as regressions:
 - automatic pagination follows `next` links only on the same origin. Cross-host
   pagination stops with a warning unless a command has an explicit opt-in for
   that discovery path.
-- plugin executables must speak the v2 plugin protocol
 
 ## Command And Flag Mapping
 
@@ -128,18 +127,23 @@ Use this as the fast lookup table when muscle memory collides with v2.
 | profile `base`                        | profile `base_url`                                          | API/profile base field renamed                        |
 | API `base`                            | API `base_url`                                              | API base field renamed                                |
 | `-p`, `--rsh-profile`                 | `-p`, `--rsh-profile`                                       | Same flag, but invalid profile names now error        |
-| v1 plugin binaries                    | Rebuild or install v2-compatible plugin binaries            | v1 plugin binaries do not load unchanged              |
+| external auth command hook            | `external-tool` auth                                        | Same local-helper idea; v2 plugin system is separate  |
 
-## Plugin Changes
+## Extension Changes
 
-Restish v2 still supports plugins, but the wire protocol and manifest model are
-different enough that v1 plugins will not load unchanged.
+Restish v1 did not have general plugin binaries. It had an external auth
+command hook for local helpers that could provide or mutate auth material. V2
+keeps that local-helper path as `external-tool` auth, and adds a separate plugin
+system for broader extensions.
 
-Plan on one of these paths:
+Use the v2 plugin system when you want to install or build extensions for:
 
-- install an updated v2-compatible plugin binary
-- rebuild your own plugin against the v2 protocol
-- replace old plugin behavior with built-in v2 features where possible
+- command workflows
+- output formatters
+- API loaders
+- request or response middleware
+- auth hooks
+- TLS signing
 
 For current plugin setup and authoring docs, start with:
 

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -70,6 +70,10 @@ enableGitInfo = true
     url = "/docs/reference/"
     weight = 45
   [[menu.main]]
+    name = "Blog"
+    url = "/blog/"
+    weight = 48
+  [[menu.main]]
     name = "GitHub"
     url = "https://github.com/rest-sh/restish"
     weight = 50

--- a/site/layouts/_default/_markup/render-heading.html
+++ b/site/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,6 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}"{{ range $key, $value := .Attributes }}{{ if ne $key "id" }} {{ $key | safeHTMLAttr }}="{{ $value }}"{{ end }}{{ end }}>
+  {{ .Text | safeHTML }}
+  <a class="restish-heading-anchor" href="#{{ .Anchor | safeURL }}" aria-label="Link to this section" title="Link to this section">
+    <span aria-hidden="true">#</span>
+  </a>
+</h{{ .Level }}>

--- a/site/layouts/_partials/blog-footer-cta.html
+++ b/site/layouts/_partials/blog-footer-cta.html
@@ -1,0 +1,21 @@
+<section class="restish-blog-cta" aria-labelledby="restish-blog-cta-title">
+  <div>
+    <p class="restish-blog-cta__eyebrow">Try Restish</p>
+    <h2 id="restish-blog-cta-title">Start with one request, then let the API become a CLI.</h2>
+    <p>
+      Run the browser tour for more live examples, or install Restish locally and
+      connect an OpenAPI-described API.
+    </p>
+  </div>
+  <div class="restish-blog-cta__actions">
+    <a class="restish-button restish-button--primary" href="{{ "docs/getting-started/tour/" | relURL }}">Run the tour <span aria-hidden="true">&rarr;</span></a>
+    <a class="restish-button restish-button--secondary" href="{{ "docs/getting-started/connect-to-an-api/" | relURL }}">Connect an API</a>
+    <div class="restish-install-copy" data-restish-install-copy data-copy-text="brew install restish">
+      <code><span class="token-symbol">$</span> brew install restish</code>
+      <button class="restish-install-copy__button" type="button" aria-label="Copy Homebrew install command" title="Copy command">
+        <i class="fas fa-copy" aria-hidden="true"></i>
+        <span class="visually-hidden" data-restish-copy-status>Copy command</span>
+      </button>
+    </div>
+  </div>
+</section>

--- a/site/layouts/_partials/canonical-url.html
+++ b/site/layouts/_partials/canonical-url.html
@@ -1,0 +1,10 @@
+{{- $url := .Permalink -}}
+{{- with .Params.canonical_url -}}
+  {{- $candidate := . -}}
+  {{- if or (strings.HasPrefix $candidate "http://") (strings.HasPrefix $candidate "https://") -}}
+    {{- $url = $candidate -}}
+  {{- else -}}
+    {{- $url = $candidate | absURL -}}
+  {{- end -}}
+{{- end -}}
+{{- return $url -}}

--- a/site/layouts/_partials/hooks/body-end.html
+++ b/site/layouts/_partials/hooks/body-end.html
@@ -1,5 +1,7 @@
 <script src='{{ "js/prism-restish.js" | relURL }}'></script>
-<script src='{{ "js/restish-playground.js" | relURL }}'></script>
+{{/* Automatically cache-bust the playground script when its file contents change. */}}
+{{ $playgroundVersion := readFile "static/js/restish-playground.js" | md5 }}
+<script src='{{ "js/restish-playground.js" | relURL }}?v={{ $playgroundVersion }}'></script>
 <script>
   (function () {
     if (window.location.pathname === "/" && window.location.hash.indexOf("#/") === 0) {

--- a/site/layouts/_partials/hooks/head-end.html
+++ b/site/layouts/_partials/hooks/head-end.html
@@ -1,0 +1,2 @@
+<link rel="canonical" href="{{ partial "canonical-url.html" . | safeURL }}">
+{{ partial "schema-jsonld.html" . }}

--- a/site/layouts/_partials/opengraph.html
+++ b/site/layouts/_partials/opengraph.html
@@ -1,5 +1,5 @@
 {{- $imageAlt := cond .IsHome .Site.Title (printf "%s | %s" .Title .Site.Title) -}}
-<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:url" content="{{ partial "canonical-url.html" . }}">
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta property="og:title" content="{{ cond .IsHome .Site.Title .Title }}">
 <meta property="og:description" content="{{ partial "page-description.html" . }}">

--- a/site/layouts/_partials/schema-jsonld.html
+++ b/site/layouts/_partials/schema-jsonld.html
@@ -110,7 +110,8 @@
 {{- $graph = $graph | append $page -}}
 
 {{- if and .IsPage (eq .Section "blog") -}}
-  {{- $author := .Params.author | default .Site.Title -}}
+  {{- $rawAuthor := .Params.author | default .Site.Title -}}
+  {{- $author := $rawAuthor | markdownify | plainify -}}
   {{- $article := dict
     "@type" "BlogPosting"
     "@id" (printf "%s#blogposting" $canonical)

--- a/site/layouts/_partials/schema-jsonld.html
+++ b/site/layouts/_partials/schema-jsonld.html
@@ -1,0 +1,138 @@
+{{- $canonical := partial "canonical-url.html" . -}}
+{{- $description := partial "page-description.html" . | plainify -}}
+{{- $siteDescription := $description -}}
+{{- with .Site.Home -}}
+  {{- $siteDescription = partial "page-description.html" . | plainify -}}
+{{- end -}}
+{{- $siteURL := .Site.BaseURL -}}
+{{- $orgID := printf "%s#organization" $siteURL -}}
+{{- $websiteID := printf "%s#website" $siteURL -}}
+{{- $softwareID := printf "%s#software" $siteURL -}}
+{{- $sourceID := printf "%s#source" $siteURL -}}
+{{- $pageID := printf "%s#webpage" $canonical -}}
+{{- $logo := "images/restish-logo.png" | absURL -}}
+{{- $github := .Site.Params.github_repo | default "https://github.com/rest-sh/restish" -}}
+{{- $installURL := printf "%sdocs/getting-started/install/" $siteURL -}}
+{{- $releaseNotesURL := printf "%s/releases" $github -}}
+{{- $graph := slice -}}
+{{- $org := dict
+  "@type" "Organization"
+  "@id" $orgID
+  "name" .Site.Title
+  "url" $siteURL
+  "logo" $logo
+  "sameAs" (slice $github)
+-}}
+{{- $website := dict
+  "@type" "WebSite"
+  "@id" $websiteID
+  "name" .Site.Title
+  "url" $siteURL
+  "description" $siteDescription
+  "publisher" (dict "@id" $orgID)
+-}}
+{{- $graph = $graph | append $org $website -}}
+
+{{- if .IsHome -}}
+  {{- $software := dict
+    "@type" "SoftwareApplication"
+    "@id" $softwareID
+    "name" .Site.Title
+    "url" $siteURL
+    "description" $siteDescription
+    "applicationCategory" "DeveloperApplication"
+    "operatingSystem" "Linux, macOS, Windows"
+    "isAccessibleForFree" true
+    "offers" (dict "@type" "Offer" "price" "0" "priceCurrency" "USD")
+    "downloadUrl" (printf "%s/releases" $github)
+    "installUrl" $installURL
+    "releaseNotes" $releaseNotesURL
+    "softwareHelp" (printf "%sdocs/" $siteURL)
+    "publisher" (dict "@id" $orgID)
+  -}}
+  {{- $source := dict
+    "@type" "SoftwareSourceCode"
+    "@id" $sourceID
+    "name" .Site.Title
+    "url" $github
+    "codeRepository" $github
+    "programmingLanguage" "Go"
+    "license" "https://opensource.org/license/mit"
+    "runtimePlatform" "Go"
+    "isPartOf" (dict "@id" $softwareID)
+  -}}
+  {{- $graph = $graph | append $software $source -}}
+{{- end -}}
+
+{{- if not .IsHome -}}
+  {{- $items := slice (dict
+    "@type" "ListItem"
+    "position" 1
+    "name" .Site.Title
+    "item" $siteURL
+  ) -}}
+  {{- $position := 2 -}}
+  {{- range .Ancestors.Reverse -}}
+    {{- if not .IsHome -}}
+      {{- $items = $items | append (dict
+        "@type" "ListItem"
+        "position" $position
+        "name" (.LinkTitle | default .Title)
+        "item" .Permalink
+      ) -}}
+      {{- $position = add $position 1 -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $items = $items | append (dict
+    "@type" "ListItem"
+    "position" $position
+    "name" (.LinkTitle | default .Title)
+    "item" $canonical
+  ) -}}
+  {{- $graph = $graph | append (dict
+    "@type" "BreadcrumbList"
+    "@id" (printf "%s#breadcrumb" $canonical)
+    "itemListElement" $items
+  ) -}}
+{{- end -}}
+
+{{- $page := dict
+  "@type" "WebPage"
+  "@id" $pageID
+  "url" $canonical
+  "name" (cond .IsHome .Site.Title .Title)
+  "description" $description
+  "isPartOf" (dict "@id" $websiteID)
+-}}
+{{- if not .IsHome -}}
+  {{- $page = merge $page (dict "breadcrumb" (dict "@id" (printf "%s#breadcrumb" $canonical))) -}}
+{{- end -}}
+{{- $graph = $graph | append $page -}}
+
+{{- if and .IsPage (eq .Section "blog") -}}
+  {{- $author := .Params.author | default .Site.Title -}}
+  {{- $article := dict
+    "@type" "BlogPosting"
+    "@id" (printf "%s#blogposting" $canonical)
+    "mainEntityOfPage" (dict "@id" $pageID)
+    "headline" .Title
+    "description" $description
+    "url" $canonical
+    "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+    "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+    "author" (dict "@type" "Person" "name" $author)
+    "publisher" (dict "@id" $orgID)
+    "wordCount" .WordCount
+  -}}
+  {{- with partial "social-image.html" . -}}
+    {{- $article = merge $article (dict "image" .) -}}
+  {{- end -}}
+  {{- with .Params.tags -}}
+    {{- $article = merge $article (dict "keywords" .) -}}
+  {{- end -}}
+  {{- $graph = $graph | append $article -}}
+{{- end -}}
+
+{{- with $graph }}
+<script type="application/ld+json">{{ dict "@context" "https://schema.org" "@graph" . | jsonify | safeJS }}</script>
+{{- end -}}

--- a/site/layouts/blog/baseof.html
+++ b/site/layouts/blog/baseof.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} class="no-js"
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }} td-blog restish-blog {{- with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="td-main">
+      <main role="main">
+        {{ block "main" . }}{{ end }}
+      </main>
+    </div>
+    <div class="container-fluid">
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/site/layouts/blog/list.html
+++ b/site/layouts/blog/list.html
@@ -1,0 +1,46 @@
+{{ define "main" -}}
+<section class="restish-blog-hero restish-blog-hero--index">
+  <div class="restish-blog-hero__inner">
+    <p class="restish-blog-hero__eyebrow">Restish Blog</p>
+    <h1>{{ .Title }}</h1>
+    {{ with .Description -}}
+      <p class="restish-blog-hero__dek">{{ . }}</p>
+    {{ end -}}
+    {{ with .Content -}}
+      <div class="restish-blog-hero__intro">{{ . }}</div>
+    {{ end -}}
+  </div>
+</section>
+
+{{ $pages := where .Site.RegularPages "Section" .Section -}}
+<section class="restish-blog-index">
+  <div class="restish-blog-index__inner">
+    {{ if $pages -}}
+      <div class="restish-blog-index__grid">
+        {{ range $pages -}}
+          <article class="restish-blog-card">
+            <div class="restish-blog-card__meta">
+              <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (.Site.Params.time_format_blog | default "Jan 2, 2006") }}</time>
+              {{ with index .Params.categories 0 -}}
+                <span>{{ . }}</span>
+              {{ end -}}
+            </div>
+            <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+            {{ with .Description -}}
+              <p>{{ . }}</p>
+            {{ end -}}
+            <div class="restish-blog-card__footer">
+              <a href="{{ .RelPermalink }}">Read article</a>
+              {{ with .Params.tags -}}
+                <span>{{ delimit (first 3 .) " / " }}</span>
+              {{ end -}}
+            </div>
+          </article>
+        {{ end -}}
+      </div>
+    {{ else -}}
+      <p>No posts yet.</p>
+    {{ end -}}
+  </div>
+</section>
+{{ end -}}

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -1,0 +1,46 @@
+{{ define "main" -}}
+<article class="restish-blog-article">
+  <header class="restish-blog-hero restish-blog-hero--article">
+    <div class="restish-blog-hero__inner">
+      <p class="restish-blog-hero__eyebrow">
+        {{ with index .Params.categories 0 }}{{ . }}{{ else }}Restish Blog{{ end }}
+      </p>
+      <h1>{{ .Title }}</h1>
+      {{ with .Description -}}
+        <p class="restish-blog-hero__dek">{{ . }}</p>
+      {{ end -}}
+      <div class="restish-blog-hero__meta">
+        {{ with .Params.author -}}<span>By {{ . | markdownify }}</span>{{ end -}}
+        <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format (.Site.Params.time_format_blog | default "Jan 2, 2006") }}</time>
+        {{ with .ReadingTime -}}<span>{{ . }} min read</span>{{ end -}}
+      </div>
+      {{ with .Params.tags -}}
+        <div class="restish-blog-hero__tags" aria-label="Article tags">
+          {{ range . -}}<span>{{ . }}</span>{{ end -}}
+        </div>
+      {{ end -}}
+    </div>
+  </header>
+
+  <div class="restish-blog-article__shell">
+    <div class="restish-blog-article__content td-content">
+      {{ .Content }}
+      {{ partial "blog-footer-cta.html" . }}
+    </div>
+    <aside class="restish-blog-article__rail" aria-label="Article links">
+      {{ with .CurrentSection.OutputFormats.Get "rss" -}}
+        <a class="restish-blog-rail-card" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
+          <i class="fa-solid fa-rss" aria-hidden="true"></i>
+          Blog RSS
+        </a>
+      {{ end -}}
+      {{ with .TableOfContents -}}
+        <div class="restish-blog-rail-card restish-blog-rail-card--toc">
+          <strong>On this page</strong>
+          {{ . }}
+        </div>
+      {{ end -}}
+    </aside>
+  </div>
+</article>
+{{ end -}}

--- a/site/layouts/robots.txt
+++ b/site/layouts/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/site/layouts/shortcodes/restish-home.html
+++ b/site/layouts/shortcodes/restish-home.html
@@ -6,8 +6,8 @@
         <p class="restish-hero__lead">Discover operations, auth, and schemas from the server. No local clients to build or update.</p>
         <div class="restish-hero__actions">
           <a class="restish-button restish-button--primary" href="{{ "docs/getting-started/tour/" | relURL }}">Get started <span aria-hidden="true">&rarr;</span></a>
-          <div class="restish-install-copy" data-restish-install-copy data-copy-text="brew install rest-sh/tap/restish">
-            <code><span class="token-symbol">$</span> brew install rest-sh/tap/restish</code>
+          <div class="restish-install-copy" data-restish-install-copy data-copy-text="brew install restish">
+            <code><span class="token-symbol">$</span> brew install restish</code>
             <button class="restish-install-copy__button" type="button" aria-label="Copy Homebrew install command" title="Copy command">
               <i class="fas fa-copy" aria-hidden="true"></i>
               <span class="visually-hidden" data-restish-copy-status>Copy command</span>

--- a/site/scripts/generate-social-images.mjs
+++ b/site/scripts/generate-social-images.mjs
@@ -241,7 +241,7 @@ const renderGithubOverview = () =>
       description:
         "Explore REST-ish APIs with generic HTTP verbs, generated OpenAPI commands, shorthand input, auth, response filtering & projection, pagination, and plugins.",
       section: "Always Free. Always Open Source.",
-      command: "$ brew install rest-sh/tap/restish",
+      command: "$ brew install restish",
       descMaxLines: 5,
     }),
   );

--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -1996,6 +1996,9 @@
       rows.sort((a, b) => compareTableCells(a && a[sortBy], b && b[sortBy]));
     }
     const cols = columns ? columns.split(",").map((item) => item.trim()).filter(Boolean) : inferColumns(rows);
+    if (!cols.length) {
+      return "";
+    }
     const body = rows.map((row) => cols.map((col) => truncateTableCell(tableScalar(row && row[col]), 40)));
     const widths = cols.map((col, index) => Math.max(
       displayWidth(col),

--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -645,6 +645,7 @@
     const parts = [];
     let current = "";
     let quote = "";
+    let depth = 0;
     for (const ch of text) {
       if (quote) {
         if (ch === quote) {
@@ -658,7 +659,17 @@
         current += ch;
         continue;
       }
-      if (ch === ",") {
+      if (ch === "[" || ch === "{" || ch === "(") {
+        depth += 1;
+        current += ch;
+        continue;
+      }
+      if ((ch === "]" || ch === "}" || ch === ")") && depth > 0) {
+        depth -= 1;
+        current += ch;
+        continue;
+      }
+      if (ch === "," && depth === 0) {
         parts.push(current);
         current = "";
         continue;
@@ -674,6 +685,10 @@
   function parseScalar(value) {
     if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
       return value.slice(1, -1);
+    }
+    if (value.startsWith("[") && value.endsWith("]")) {
+      const inner = value.slice(1, -1).trim();
+      return inner ? splitCommas(inner).map((item) => parseScalar(item.trim())) : [];
     }
     if (value === "true") return true;
     if (value === "false") return false;
@@ -1970,26 +1985,32 @@
   }
 
   function tableOutput(value, columns, sortBy) {
-    if (!Array.isArray(value)) {
+    const rows = tableRows(value);
+    if (!rows) {
       return readableOutput(value);
     }
-    const rows = value.slice();
+    if (!rows.length) {
+      return "(empty)\n";
+    }
     if (sortBy) {
-      rows.sort((a, b) => String(a && a[sortBy] || "").localeCompare(String(b && b[sortBy] || "")));
+      rows.sort((a, b) => compareTableCells(a && a[sortBy], b && b[sortBy]));
     }
     const cols = columns ? columns.split(",").map((item) => item.trim()).filter(Boolean) : inferColumns(rows);
-    if (!cols.length) {
-      return "";
-    }
-    const tableRows = [cols].concat(rows.map((row) => cols.map((col) => tableScalar(row && row[col]))));
-    const widths = cols.map((_, index) => Math.max(...tableRows.map((row) => row[index].length)));
-    return tableRows.map((row, rowIndex) => {
-      const line = row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd();
-      if (rowIndex === 0) {
-        return line + "\n" + widths.map((width) => "-".repeat(width)).join("  ");
-      }
-      return line;
-    }).join("\n") + "\n";
+    const body = rows.map((row) => cols.map((col) => truncateTableCell(tableScalar(row && row[col]), 40)));
+    const widths = cols.map((col, index) => Math.max(
+      displayWidth(col),
+      ...body.map((row) => displayWidth(row[index]))
+    ));
+
+    const sep = (left, mid, right) => left + widths.map((width) => "─".repeat(width + 2)).join(mid) + right;
+    const renderRow = (row) => "│" + row.map((cell, index) => ` ${padTableCell(cell, widths[index])} `).join("│") + "│";
+    return [
+      sep("┌", "┬", "┐"),
+      renderRow(cols),
+      sep("├", "┼", "┤"),
+      ...body.map(renderRow),
+      sep("└", "┴", "┘")
+    ].join("\n") + "\n";
   }
 
   function ndjsonOutput(value) {
@@ -2058,6 +2079,57 @@
       return JSON.stringify(value);
     }
     return String(value);
+  }
+
+  function tableRows(value) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return [value];
+    }
+    if (!Array.isArray(value)) {
+      return null;
+    }
+    const rows = [];
+    for (const item of value) {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return null;
+      }
+      rows.push(item);
+    }
+    return rows;
+  }
+
+  function compareTableCells(a, b) {
+    const an = tableNumber(a);
+    const bn = tableNumber(b);
+    if (an !== null && bn !== null) {
+      return an < bn ? -1 : an > bn ? 1 : 0;
+    }
+    const as = tableScalar(a);
+    const bs = tableScalar(b);
+    return as < bs ? -1 : as > bs ? 1 : 0;
+  }
+
+  function tableNumber(value) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    return null;
+  }
+
+  function truncateTableCell(value, maxChars) {
+    const chars = Array.from(value);
+    if (chars.length <= maxChars) {
+      return value;
+    }
+    return chars.slice(0, Math.max(0, maxChars - 1)).join("") + "…";
+  }
+
+  function displayWidth(value) {
+    return Array.from(value).length;
+  }
+
+  function padTableCell(value, width) {
+    return value + " ".repeat(Math.max(0, width - displayWidth(value)));
   }
 
   function yamlOutput(value, depth) {
@@ -2204,8 +2276,22 @@
   }
 
   function inferColumns(rows) {
-    const first = rows.find((row) => row && typeof row === "object" && !Array.isArray(row));
-    return first ? Object.keys(first).slice(0, 4) : [];
+    if (!rows.length) {
+      return [];
+    }
+    const seen = new Set();
+    const cols = Object.keys(rows[0]).sort();
+    cols.forEach((col) => seen.add(col));
+    const extra = [];
+    rows.slice(1).forEach((row) => {
+      Object.keys(row).forEach((col) => {
+        if (!seen.has(col)) {
+          seen.add(col);
+          extra.push(col);
+        }
+      });
+    });
+    return cols.concat(extra.sort());
   }
 
   function setOutput(node, output, isError, highlight = true, language = "language-readable") {
@@ -2231,6 +2317,7 @@
     const pane = node.parentElement;
     pane.hidden = false;
     pane.classList.toggle("restish-playground__output--error", Boolean(isError));
+    pane.classList.toggle("restish-playground__output--table", typeof output === "string" && output.startsWith("┌"));
     pane.scrollTop = pane.scrollHeight;
     if (highlight && window.Prism && typeof output === "string") {
       node.className = language;
@@ -2243,6 +2330,7 @@
     const pane = node.parentElement;
     pane.hidden = true;
     pane.classList.remove("restish-playground__output--error");
+    pane.classList.remove("restish-playground__output--table");
   }
 
   function setState(node, text, mode) {


### PR DESCRIPTION
## Summary
- add the new Restish blog section and the first v2 announcement post
- add blog layouts, CTA styling, canonical/Open Graph/schema metadata, robots support, and linkable headings
- update the browser playground examples/table rendering used by the post
- update Homebrew install wording to use `brew install restish`

## Validation
- `hugo --source site --quiet`
- `node --check site/static/js/restish-playground.js`
- `ruby scripts/check-doc-examples.rb --root site/content/en/blog`
- `git diff --check`