### PR TITLE
Add release QA skill

### DIFF
--- a/.agents/skills/rsh-release-qa/SKILL.md
+++ b/.agents/skills/rsh-release-qa/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: rsh-release-qa
+description: Run Restish release readiness QA from main using recent commits, built-in historical risk patterns, docs, and full release gates; report reproducible issues without patching product code
+---
+
+# Restish Release QA
+
+Run an evidence-first release readiness pass for Restish. The goal is high
+confidence and clear reproducible findings, not implementation work.
+
+## Use This Skill For
+
+- Preparing a Restish release or release candidate from `main`.
+- Turning recent commits, docs changes, and historical Restish QA risk patterns
+  into a concrete release strategy.
+- Running the full pre-release gate, targeted regression probes, built-binary
+  smoke checks, and docs validation.
+- Reporting blockers, non-blocking risks, unrun checks, and reproduction steps.
+
+## Do Not Use This Skill For
+
+- Patching release-blocking bugs.
+- Refactoring, test authoring, or docs edits during QA.
+- Making release tags, publishing artifacts, or changing release workflows
+  unless the user explicitly asks for those separate actions.
+
+If a bug is found, document it thoroughly and suggest the smallest credible fix.
+Do not edit product code. Only write `TODO.md` when the user has explicitly
+allowed local follow-up notes for the current run. `TODO.md` is local-only and
+must never be staged or committed.
+
+## Core Workflow
+
+1. Confirm the exact release candidate:
+   - Check `git status --short`, current branch, and `git rev-parse HEAD`.
+   - Fetch `origin` when currentness matters.
+   - Prefer testing the fetched `origin/main` or an exact candidate commit. If
+     the user's working branch should not move, create a temporary worktree.
+2. Determine the diff surface:
+   - Find the last release tag or user-provided baseline.
+   - Read recent first-parent merges and non-merge commits.
+   - Classify touched areas: generated OpenAPI commands, auth/config,
+     request pipeline, pagination, plugins, output, docs, packaging, CI.
+3. Apply the built-in risk map:
+   - Read `references/release-risk-map.md` for the distilled release matrix.
+   - Read `references/findings-mining.md` for historical finding classes and
+     safe repro patterns.
+   - Match recent commits to the risk areas and choose targeted probes.
+4. Build a run-specific strategy:
+   - Always include the full release gate unless the user explicitly narrows it.
+   - Add targeted probes for recent commits and relevant findings.
+   - Include user-facing docs checks for docs or command-surface changes.
+5. Run the checks:
+   - Create a fresh temporary run directory and use isolated config/cache paths
+     for built-binary smokes.
+   - Prefer harmless local servers, `--rsh-print`, `--rsh-server` overrides,
+     localhost failure targets, and read-only public specs.
+   - Never use real user credentials or destructive provider calls.
+6. Report release readiness:
+   - Lead with blockers or "no release blockers found".
+   - Include exact candidate commit, commands run, failures, environment issues,
+     targeted probes, and residual risk.
+   - For each issue, include severity, expected behavior, actual behavior,
+     reproduction commands, impact, and a suggested fix direction.
+
+## Full Gate
+
+Use the release gate reference for the canonical command set:
+`references/release-gates.md`.
+
+Default full gate:
+
+- `go test ./...`
+- `go test -tags=integration ./...`
+- Targeted `go test -race` over risk-bearing packages.
+- Build `restish` and first-party plugin binaries.
+- `go run ./cmd/restish-docgen --check`
+- `npm --prefix site ci` with a disposable npm cache when needed.
+- `npm --prefix site run build` for the docs site.
+- Built-binary smoke checks for help, version, redaction, and at least one
+  generated OpenAPI command surface when the release touches CLI/OpenAPI/auth.
+
+Use per-run `GOCACHE` and `GOPATH` paths under the temporary run directory when
+the default Go caches are not writable in the sandbox. Report any resulting
+network, toolchain-download, or module-download limitation instead of changing
+dependencies during release QA.
+
+## Findings Mining
+
+Use `references/findings-mining.md` for distilled historical issue classes,
+triage rules, and repro selection.
+
+High or security findings with open or uncertain status are release blockers
+until verified fixed or explicitly deferred by the user. Medium findings are
+blockers when they affect common workflows, release packaging, data integrity,
+credential leakage, or newly changed code.
+
+## Targeted Probe Rules
+
+- Generated OpenAPI changes: connect or load a small public/local spec, inspect
+  help, run `doctor api`, and test request construction without provider writes.
+- Auth/config changes: check noninteractive setup, missing env diagnostics,
+  redaction, profile precedence, and trusted project config boundaries.
+- Request pipeline changes: check content negotiation, redirects, retries,
+  TLS flags, server overrides, and network-error diagnostics.
+- Pagination changes: check page parameters, Link headers, metadata filters,
+  max page/item limits, and strict `items_path` behavior.
+- Plugin changes: build first-party plugins and run relevant integration/race
+  tests; check subprocess lifecycle risks.
+- Docs/command-surface changes: run docgen drift and Hugo build; smoke the
+  affected help output from a built binary.
+- Security/redaction changes: test verbose and non-verbose errors with URL
+  userinfo, credential-looking query params, headers, JSON bodies, forms, and
+  generated credentials.
+
+## Reporting Template
+
+Use this shape unless the user asks for something else:
+
+```text
+Release candidate: <commit> on <branch/ref>
+Baseline: <tag or commit>
+
+Readiness: ready / not ready / ready with noted risks
+
+Findings:
+- P1/P2/... <title>
+  Impact:
+  Repro:
+  Expected:
+  Actual:
+  Suggested fix direction:
+
+Checks run:
+- <command> - passed/failed/skipped
+
+Targeted probes:
+- <scenario> - passed/failed
+
+Residual risk:
+- <unrun check, environmental limitation, or deferred finding>
+```
+
+If every required check passes and no blocking issue is found, say so clearly.
+Do not bury skipped checks or environmental limitations.

--- a/.agents/skills/rsh-release-qa/agents/openai.yaml
+++ b/.agents/skills/rsh-release-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Restish Release QA"
+  short_description: "Run evidence-first Restish release checks"
+  default_prompt: "Use $rsh-release-qa to assess Restish release readiness from main with full tests, docs validation, historical-risk probes, and reproducible findings."

--- a/.agents/skills/rsh-release-qa/references/findings-mining.md
+++ b/.agents/skills/rsh-release-qa/references/findings-mining.md
@@ -1,0 +1,182 @@
+# Historical Finding Classes
+
+This reference distills prior Restish release findings into reusable QA
+heuristics. Use it to choose targeted probes without depending on local
+planning files.
+
+## Triage Rules
+
+- Credential leakage, data loss, corrupted config/cache state, or common
+  generated-command breakage is release-blocking until verified fixed or
+  explicitly deferred by the user.
+- Medium issues are blockers when they affect common workflows, credentials,
+  generated commands, config/cache integrity, release packaging, or code changed
+  since the last release.
+- Low issues become targeted smoke checks when a nearby subsystem changed.
+- Help/example bugs are release risks when they teach users to send the wrong
+  value, leak secret-looking values, or make common copy/paste examples fail.
+- Rejected historical findings are still useful for documentation and
+  "working as intended" checks.
+
+## Historical Blocker And Near-Blocker Classes
+
+### Auth And Redaction
+
+- Optional anonymous OpenAPI security alternatives (`{}` plus a credential)
+  must remain callable when optional env-backed credentials are unresolved.
+  Ready credentials should still be preferred; required-auth operations should
+  still fail on missing env.
+- OpenAPI `mutualTLS` should be satisfied by resolved TLS client cert/key or TLS
+  signer transport settings, then fail later with normal TLS diagnostics if the
+  files/plugins are bad.
+- Noninteractive `api connect` auth setup should reject unknown credential IDs,
+  wrong-case credential IDs, unknown fields, and unused credential-scoped
+  prompts.
+- Verbose body redaction must catch `password`, `password2`,
+  `confirm_password`, `client_secret`, `secret`, `token`, and similar fields,
+  while preserving ordinary numeric fields such as `max_tokens` and
+  `token_budget`.
+- Network-error diagnostics must redact URL userinfo, credential-looking query
+  params from the original URL, secrets added by `--rsh-query`/env/defaults,
+  and generated query apiKey credentials in both the top-level error prefix and
+  nested transport URL.
+- Verbose request traces should redact configured credentials in headers,
+  query, cookies, JSON bodies, form bodies, response headers, plugin stderr, and
+  redirect diagnostics.
+
+### Generated OpenAPI Commands
+
+- Duplicate path/operation header parameters with the same HTTP header name,
+  including case variants, should merge before generated flag creation and
+  should not skip the whole operation.
+- Generated fallback command names should remain short, stable, and traceable
+  when `operationId` is absent or when `operation_base` is configured.
+- Specs with `description` fields that look like `$ref` objects must not be
+  treated as schema refs.
+- OpenAPI extension effects (`x-cli-*`) should be visible and should not report
+  nested effects for ignored entries.
+- Stale local spec files should refresh raw spec and generated operation caches
+  before generated command registration or execution.
+- Concurrent `api connect` runs should preserve config entries and generated
+  spec/operation caches for every successful connect.
+
+### Schema Help And Examples
+
+- OpenAPI 3.1 conditionals inside `allOf` should not hide direct object
+  properties in generated help. Conditional required branches should render as
+  useful constraints.
+- Schema help should keep effective flag types consistent after invalid
+  enum/type fallback, such as string enum values declared under an integer
+  schema.
+- Generated body examples should normalize string-valued boolean/integer/number
+  defaults/examples to real JSON scalar values when unambiguous.
+- JSON nulls in `enum`, `default`, `example`, and `const` should render as
+  `null`, not Go-ish `<nil>`, and generated examples should avoid contradicting
+  null-only constraints.
+- Mixed-type root `enum`/`const` values should not make generated body examples
+  contradict an object schema.
+- Generated examples should redact real secret-like explicit examples but avoid
+  over-redacting ordinary non-secret token counters or logprob fields.
+- Generated shorthand examples should not turn URI/URL/URN strings into `@file`
+  control syntax.
+- Generated shorthand examples for arrays of objects should be shell-safe and
+  structurally copyable; otherwise prefer JSON file input.
+- Generated root help should handle absent, short, multiline Markdown, and
+  README-length `info.description` values without overwhelming command help.
+
+### Query, Path, And Pagination
+
+- `deepObject` and `form` object query help should show syntax Restish accepts,
+  and runtime serialization should match each OpenAPI style.
+- JSON-content query parameters should encode one JSON query value matching the
+  schema. Whole-array parent values should work; repeated array-of-object flags
+  must not silently become arrays of JSON strings.
+- String-or-array query flags should support multiple values or clearly point
+  users to an accepted `--rsh-query` workaround.
+- Placeholder/free-form query parameter names should either be modeled
+  deliberately or documented as requiring `--rsh-query`.
+- Path parameters with slashes, commas, percent signs, spaces, question marks,
+  and already-escaped input should encode consistently. Pathful
+  `--rsh-server` overrides are a known place to check for double encoding.
+- Page-param pagination should honor the effective query parameter, preserve
+  strict `items_path` behavior, respect max-page/max-item limits, and handle
+  metadata filters.
+- Link-header pagination should handle relative next URLs, quoted parameters
+  with commas, malformed targets, unsupported schemes, and standalone `links`
+  output.
+
+### Media Types And Bodies
+
+- Generated XML request-body `@file` input should send raw XML bytes with the
+  declared XML media type.
+- Generated NDJSON request-body `@file` input should send raw newline-delimited
+  bytes with the declared NDJSON media type, not a JSON-encoded string.
+- Wildcard or protocol-specific raw binary media types such as `*/*`,
+  `application/*`, and `application/offset+octet-stream` should send raw bytes
+  for `string format: binary` bodies while preserving the declared
+  `Content-Type`.
+- Multipart examples should be usable or should explain `@file` syntax clearly.
+  Check missing files, unreadable files, literal `@`, repeated file parts,
+  binary parts, and per-part encoding metadata.
+- Operations advertising multiple request or response `content` entries should
+  choose sensible defaults and respect `--rsh-content-type`, explicit `Accept`,
+  vendor `+json`, XML/text alternatives, and strict provider expectations.
+
+### Built-Ins, Plugins, And Docs
+
+- Built-in commands should reject unsupported output formats clearly and should
+  avoid advertising inherited output/filter flags they do not support.
+- Unknown subcommands under command groups such as `cache` and `plugin` should
+  fail, not silently exit 0.
+- Explicit `--rsh-header` and `--rsh-query` should have documented precedence
+  against env/default values and should not unexpectedly drop unrelated entries
+  unless that is intentional.
+- First-party command plugins should expose long help consistently for root
+  `--help`, `-h`, `help`, and subcommand `--help` forms.
+- Plugin protocol changes should remain additive or bump/check compatibility.
+  Subprocesses that start must be waited on; timeout/error paths must close
+  pipes and avoid goroutine/process leaks.
+- Generated docs regions, README install guidance, plugin docs, release
+  packaging docs, and Hugo site build should stay in sync with command behavior.
+
+## Safe Repro Patterns
+
+Use these shapes when turning a historical class into a release probe.
+
+- Local fixture: write a small OpenAPI file under `t.TempDir()` in tests or
+  under `${TMPDIR:-/tmp}` for manual QA; connect it with isolated config/cache.
+- Public spec: connect into isolated config/cache with fake credentials, then
+  inspect help, `doctor api`, `api auth inspect`, `--rsh-generate-body`, or
+  request construction only.
+- Request construction: use `--rsh-print H`, `--rsh-print B`, verbose output,
+  `--rsh-server https://httpbin.org/anything`, or a localhost failure target.
+- Redaction: intentionally use fake secrets with unique strings and grep the
+  resulting stderr/stdout for leaks.
+- Network diagnostics: use `127.0.0.1:9`, `--rsh-timeout 200ms`, and
+  `--rsh-retry 0` so failures are quick and local.
+- Provider drift: compare generated command output against generic requests or
+  curl only with safe read-only endpoints.
+
+## Issue Report Shape
+
+For every new problem, capture:
+
+- Candidate commit and platform.
+- Exact commands and environment variables, with fake secrets only.
+- Expected behavior.
+- Actual behavior, including relevant stderr/stdout excerpts.
+- Whether the issue is a release blocker.
+- Severity and impact.
+- Related historical class from this reference.
+- Suggested fix direction, without patching code during QA.
+
+## Residual Risk Notes
+
+Call out:
+
+- Checks skipped because a tool was unavailable, such as local GoReleaser.
+- Network-dependent probes that were not run or were inconclusive.
+- Public APIs that failed for provider/network reasons rather than Restish
+  behavior.
+- Dirty worktrees, non-candidate branches, or tests run against a commit that
+  differs from the requested release candidate.

--- a/.agents/skills/rsh-release-qa/references/release-gates.md
+++ b/.agents/skills/rsh-release-qa/references/release-gates.md
@@ -1,0 +1,166 @@
+# Restish Release Gate Reference
+
+These are the default checks for a full Restish release readiness pass. Run
+from the exact release candidate checkout or a temporary worktree.
+
+## Candidate Orientation
+
+Create a fresh run directory first and reuse it for temporary build artifacts,
+config files, caches, and smoke state. This keeps repeated QA runs independent
+and makes cleanup simple.
+
+```bash
+TMP_ROOT="${TMPDIR:-/tmp}"
+RUN_DIR="$(mktemp -d "$TMP_ROOT/restish-release-qa.XXXXXX")"
+mkdir -p "$RUN_DIR/bin" "$RUN_DIR/go-cache" "$RUN_DIR/go-path" "$RUN_DIR/smoke-cache" "$RUN_DIR/npm-cache"
+```
+
+```bash
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git fetch origin
+git log --oneline --first-parent --max-count=20
+git describe --tags --abbrev=0 --match 'v*'
+```
+
+If the current branch is not the candidate, prefer a detached temporary
+worktree over switching the user's branch. Run the remaining checks from the
+candidate checkout.
+
+```bash
+git worktree add --detach "$RUN_DIR/worktree" origin/main
+cd "$RUN_DIR/worktree"
+```
+
+## Diff Surface
+
+Replace `<baseline>` with the last release tag or the user-provided baseline.
+
+```bash
+git log --oneline --first-parent <baseline>..HEAD
+git log --oneline --no-merges <baseline>..HEAD
+git diff --stat <baseline>..HEAD
+git diff --name-only <baseline>..HEAD
+```
+
+## Full Go Gate
+
+Use writable caches when the sandbox cannot write the default Go build cache or
+`GOPATH` module/checksum state.
+
+```bash
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go test ./...
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go test -tags=integration ./...
+```
+
+Run targeted race coverage for the release-risk packages. Broaden the list when
+the diff touches other concurrent or subprocess-heavy code.
+
+```bash
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go test -race ./internal/cli ./internal/auth ./internal/request ./internal/plugin ./internal/spec ./cmd/restish-mcp
+```
+
+If the isolated `GOPATH` requires fresh toolchain or module downloads and the
+network is unavailable, report that limitation instead of changing dependencies
+during release QA.
+
+## Release Binary Builds
+
+Build the core CLI and first-party plugins into a temp directory.
+
+```bash
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go build -o "$RUN_DIR/bin/restish" ./cmd/restish
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go build -o "$RUN_DIR/bin/restish-bulk" ./cmd/restish-bulk
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go build -o "$RUN_DIR/bin/restish-csv" ./cmd/restish-csv
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go build -o "$RUN_DIR/bin/restish-mcp" ./cmd/restish-mcp
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go build -o "$RUN_DIR/bin/restish-pkcs11" ./cmd/restish-pkcs11
+```
+
+Local `go build` binaries usually print the development version. Treat that as
+expected unless testing GoReleaser injection specifically.
+
+```bash
+"$RUN_DIR/bin/restish" --version
+printf '{}\n' > "$RUN_DIR/empty.json"
+chmod 600 "$RUN_DIR/empty.json"
+"$RUN_DIR/bin/restish" --rsh-config "$RUN_DIR/empty.json" help
+```
+
+## Generated Docs And Site
+
+```bash
+env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go run ./cmd/restish-docgen --check
+```
+
+For the docs site, use a disposable npm cache if the user cache is not writable
+or contains permission problems. These commands must run against `site/`, which
+contains the docs site's `package.json` and lockfile.
+
+```bash
+npm --prefix site ci --cache "$RUN_DIR/npm-cache"
+npm --prefix site run build
+```
+
+Hugo deprecation warnings are non-blocking unless they break the build or imply
+near-term publish failure.
+
+## Built-Binary Smokes
+
+Use isolated config/cache files and harmless targets.
+
+```bash
+env RSH_CACHE_DIR="$RUN_DIR/smoke-cache" \
+  "$RUN_DIR/bin/restish" \
+  --rsh-config "$RUN_DIR/smoke.json" \
+  api connect smokepet https://petstore3.swagger.io/api/v3 \
+  --spec https://petstore3.swagger.io/api/v3/openapi.json \
+  --yes prompt.credentials.api_key.value:fake-key
+```
+
+Then inspect generated command state without provider writes.
+
+```bash
+env RSH_CACHE_DIR="$RUN_DIR/smoke-cache" \
+  "$RUN_DIR/bin/restish" \
+  --rsh-config "$RUN_DIR/smoke.json" \
+  doctor api smokepet
+
+env RSH_CACHE_DIR="$RUN_DIR/smoke-cache" \
+  "$RUN_DIR/bin/restish" \
+  --rsh-config "$RUN_DIR/smoke.json" \
+  smokepet get-pet-by-id 1 \
+  --rsh-server https://httpbin.org/anything \
+  --rsh-print H \
+  --rsh-ignore-status-code
+```
+
+Check network-error redaction locally.
+
+```bash
+printf '{}\n' > "$RUN_DIR/redaction.json"
+chmod 600 "$RUN_DIR/redaction.json"
+
+env RSH_CACHE_DIR="$RUN_DIR/smoke-cache" \
+  "$RUN_DIR/bin/restish" \
+  --rsh-config "$RUN_DIR/redaction.json" \
+  get \
+  'http://alice:s3cr3t@127.0.0.1:9/anything?api_key=url-secret' \
+  --rsh-query token=flag-secret \
+  --rsh-retry 0 \
+  --rsh-timeout 200ms
+```
+
+The command should fail, but the diagnostic must not expose `alice`,
+`s3cr3t`, `url-secret`, or `flag-secret`.
+
+## Optional Packaging Checks
+
+If GoReleaser is installed:
+
+```bash
+goreleaser check
+```
+
+If it is not installed, report that limitation instead of installing new tools
+during QA unless the user asks.

--- a/.agents/skills/rsh-release-qa/references/release-risk-map.md
+++ b/.agents/skills/rsh-release-qa/references/release-risk-map.md
@@ -1,0 +1,96 @@
+# Restish Release Risk Map
+
+This reference distills the recurring release-QA matrix from prior Restish
+real-world API sweeps and regression campaigns. Use it to choose targeted
+checks after reading recent commits.
+
+## Highest-Value Release Surfaces
+
+- Generated OpenAPI command discovery and execution.
+- Auth planning, credential readiness, redaction, and profile precedence.
+- Spec cache, operation cache, `api connect`, `api sync`, and local spec
+  freshness.
+- Request construction: content negotiation, media-type encoders, query/path
+  serialization, redirects, retries, TLS, and server overrides.
+- Pagination and hypermedia: page params, Link headers, item extraction,
+  limits, metadata filters, and streaming output.
+- Output formatting: terminal color, JSON/table stability, scalar utility
+  output, plugin formatter behavior, and golden/reference drift.
+- Plugin lifecycle: command plugins, formatter plugins, hook plugins,
+  `restish-mcp`, subprocess cleanup, and protocol compatibility.
+- User-facing docs and generated command reference.
+- Release packaging: GoReleaser config, first-party plugin artifacts, docs site,
+  Homebrew/OCI metadata, and version injection.
+
+## Standard Matrix
+
+Run these classes when the changed code or release risk justifies them.
+
+- OpenAPI auth fixtures for env-backed query/header credentials, missing env
+  diagnostics, `security: []`, optional anonymous `{}` alternatives, OR/AND
+  auth combinations, explicit `--rsh-auth`, and verbose redaction.
+- Generated command edge cases for parameter serialization, content negotiation,
+  request/response schema help, generated examples, provider drift, and generic
+  request controls.
+- OpenAPI 3.1 schema rendering for nullable types, `const`, `enum`, `oneOf`,
+  `anyOf`, `allOf`, conditionals, `contains`, tuple/prefix items,
+  `dependentRequired`, and unsupported annotations.
+- Local and public spec loading for malformed JSON/YAML, non-OpenAPI documents,
+  external refs, missing refs, webhook-only specs, large modular specs, server
+  variables, and operation/path-level servers.
+- Request body media types: JSON, form URL encoded, multipart, XML, NDJSON,
+  `application/stream+json`, `application/octet-stream`, wildcard raw types,
+  protocol-specific raw types, stdin, `@file`, missing files, literal `@`, and
+  `--rsh-content-type` overrides.
+- Query handling: `deepObject`, `form` object styles, repeated arrays,
+  JSON-content query params, free-form filter params, env/flag precedence, and
+  explicit `--rsh-query` controls.
+- Path handling: simple/label/matrix styles, arrays, slashes, commas, percent
+  signs, spaces, question marks, already-escaped input, and pathful
+  `--rsh-server` overrides.
+- Redaction: URL userinfo, credential query params, headers, cookies, JSON
+  bodies, form bodies, verbose request/response traces, network errors,
+  redirects, plugin stderr, and ambiguous ordinary parameters.
+- Pagination: page-param pagination, strict `items_path`, relative Link next
+  URLs, quoted Link parameters with commas, malformed Link targets,
+  unsupported schemes, max-page/max-item cutoffs, and standalone `links`.
+- Built-ins and utilities: `doctor`, `doctor api`, `plugin list`, `api list`,
+  `api inspect`, `config show`, `config path`, `cache info`, `version`,
+  output/filter flag support, and invalid global flag validation ordering.
+- Config and migration: trusted project config, shared project config without
+  secrets, concurrent config mutation, v1-to-v2 migration, malformed legacy
+  fields, JSONC editing, config directory modes, and cache cleanup.
+- Docs: generated docs drift, command help smoke checks, docs site build,
+  social images, README install paths, release packaging docs, and examples
+  that are shell-safe.
+
+## Useful Public Spec Families
+
+Use public specs only for safe connect/help/request-construction checks. Avoid
+provider writes. Prefer local fixtures when a small repro is enough.
+
+- Petstore / Redocly / SFTPGo: baseline generated commands and anonymous auth.
+- OpenAPI Generator Echo Server: query serialization, multipart, XML, NDJSON,
+  octet-stream, and mixed parameter styles.
+- OpenProject / ownCloud / Pirate Weather: operation servers and delimiter-heavy
+  path parameters.
+- Mailcow: confirm-password fields and generated example sensitivity.
+- Tailscale: free-form/dynamic query filters.
+- VictoriaLogs / Ollama: NDJSON and streaming JSON.
+- UKHO / TUS / SFTPGo / ComfyUI / Walrus: binary and raw upload bodies.
+- Gematik Push Gateway: OpenAPI `mutualTLS`.
+- Trigger.dev / Backstage / PowerDNS / Hookdeck: object query and pagination
+  shapes.
+- Adobe Substance 3D / Speakeasy / Livepeer / MarkItDown: multipart,
+  file-upload, and complex generated examples.
+
+## Safe Probe Principles
+
+- Use isolated `--rsh-config` and `RSH_CACHE_DIR`.
+- Use fake credentials only.
+- Use `--rsh-print`, `--rsh-generate-body`, `--help-all`,
+  `--rsh-server https://httpbin.org/anything`, or localhost failure targets
+  instead of live provider mutations.
+- Verify request shape through headers, verbose output, or echo bodies.
+- Treat provider downtime or spec drift as residual risk, not an immediate
+  Restish bug, unless local controls reproduce it.


### PR DESCRIPTION
## Summary

Adds a Restish release QA skill under `.agents/skills/rsh-release-qa/`.

The skill guides an evidence-first release readiness pass using:

- recent commit and baseline review
- full Go, integration, race, binary, docgen, and docs-site gates
- isolated temporary config/cache paths for built-binary smoke checks
- historical Restish release-risk patterns and safe repro guidance
- structured readiness reporting with blockers, skipped checks, and residual risk

## Validation

- Reviewed the skill contents and references for stale paths, command correctness, and isolation gaps.
- Ran `env GOCACHE=/private/tmp/restish-release-qa.verify/go-cache GOPATH=/private/tmp/restish-release-qa.verify/go-path go test ./cmd/restish-docgen`.
- Verified docs-site npm command shape with `npm --prefix site ci --cache /private/tmp/restish-release-qa.verify/npm-cache --dry-run`.
- Smoke-tested the documented built-binary help, Petstore connect, and redaction checks during local review.

## Notes

This PR targets `main`. The QA branch was rebased from `blog` onto `origin/main` so the diff is scoped to the release QA skill only.