### PR TITLE
docs: polish homepage and blog CTAs

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1058,6 +1058,7 @@ body.td-home .td-navbar__search .td-search-input {
   font-weight: 700;
   line-height: 0.96;
   letter-spacing: 0;
+  text-wrap: balance;
 }
 
 .restish-blog-hero--index h1 {
@@ -1314,6 +1315,7 @@ body.td-home .td-navbar__search .td-search-input {
   color: var(--restish-card-title);
   font-size: clamp(1.55rem, 3vw, 2rem);
   line-height: 1.12;
+  text-wrap: balance;
 }
 
 .td-content .restish-blog-cta h2::after {
@@ -1662,6 +1664,13 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
   align-items: center;
   gap: 1rem;
   margin-top: 1.85rem;
+}
+
+.restish-hero__actions .restish-install-copy,
+.restish-blog-cta__actions .restish-install-copy {
+  flex: 0 1 auto;
+  width: auto;
+  max-width: 18rem;
 }
 
 .restish-button {
@@ -2298,6 +2307,11 @@ body.td-home .td-default main > section.restish-hero:first-of-type {
   .restish-install-copy {
     grid-template-columns: minmax(0, 1fr) 2.5rem;
     max-width: 100%;
+  }
+
+  .restish-hero__actions .restish-install-copy,
+  .restish-blog-cta__actions .restish-install-copy {
+    width: 100%;
   }
 
   .restish-install-copy code {

--- a/site/layouts/_partials/blog-footer-cta.html
+++ b/site/layouts/_partials/blog-footer-cta.html
@@ -1,10 +1,10 @@
 <section class="restish-blog-cta" aria-labelledby="restish-blog-cta-title">
   <div>
     <p class="restish-blog-cta__eyebrow">Try Restish</p>
-    <h2 id="restish-blog-cta-title">Start with one request, then let the API become a CLI.</h2>
+    <h2 id="restish-blog-cta-title">Make any REST-ish API feel shell-native.</h2>
     <p>
-      Run the browser tour for more live examples, or install Restish locally and
-      connect an OpenAPI-described API.
+      Run the browser tour for live examples, or install Restish locally to turn
+      OpenAPI-described REST APIs into command-line workflows.
     </p>
   </div>
   <div class="restish-blog-cta__actions">


### PR DESCRIPTION
## Summary
- tighten the homepage and blog install command boxes so they size to the short command instead of stretching across action rows
- update the blog footer CTA headline and supporting copy
- balance wrapping for blog hero and CTA titles

## Validation
- `hugo --source site --quiet`