### PR TITLE
fix(auth): migrate legacy token cache keys on first use after upgrade

### DIFF
--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -794,7 +794,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	}
 	if err != nil || s == nil {
 		if !spec.HasLocalSpecFiles(apiCfg.SpecFiles) {
-			if !forceRefresh && (apiCfg.BaseURL != "" || apiCfg.SpecURL != "" || len(apiCfg.SpecFiles) > 0) {
+			if err == nil && !forceRefresh && (apiCfg.BaseURL != "" || apiCfg.SpecURL != "" || len(apiCfg.SpecFiles) > 0) {
 				c.hintf("spec cache for API %q is empty; run \"restish api sync %s\" to populate it", apiName, apiName)
 			}
 			return spec.OperationSet{}, false, err

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -794,6 +794,9 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	}
 	if err != nil || s == nil {
 		if !spec.HasLocalSpecFiles(apiCfg.SpecFiles) {
+			if !forceRefresh && (apiCfg.BaseURL != "" || apiCfg.SpecURL != "" || len(apiCfg.SpecFiles) > 0) {
+				c.hintf("spec cache for API %q is empty; run \"restish api sync %s\" to populate it", apiName, apiName)
+			}
 			return spec.OperationSet{}, false, err
 		}
 		s, err = spec.Discover(ctx, spec.DiscoverConfig{

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -299,11 +299,29 @@ func (c *CLI) cachedOAuthTokenEntry(authType string, cacheKey, apiName, profileN
 	if cacheKey == ":" || cacheKey == "" {
 		return nil
 	}
-	cached, err := auth.NewTokenCache(c.tokenCachePath()).Get(cacheKey)
+	tc := auth.NewTokenCache(c.tokenCachePath())
+	cached, err := tc.Get(cacheKey)
 	if err != nil {
 		return nil
 	}
-	return cached
+	if cached != nil {
+		return cached
+	}
+	// The cache key format changed from "apiName:profileName" to "oauth:HASH" at
+	// some point, silently invalidating existing tokens on upgrade. Fall back to
+	// the legacy key here; if found, migrate it to the new key and drop the old one.
+	legacyKey := c.apiCacheNamespace(apiName, profileName)
+	if legacyKey == cacheKey || legacyKey == ":" || legacyKey == "" {
+		return nil
+	}
+	legacy, err := tc.Get(legacyKey)
+	if err != nil || legacy == nil {
+		return nil
+	}
+	if setErr := tc.Set(cacheKey, *legacy); setErr == nil {
+		_ = tc.Delete(legacyKey)
+	}
+	return legacy
 }
 
 func (c *CLI) cachedOAuthAuthCodeUsable(authType, cacheKey, apiName, profileName string) bool {

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -433,7 +433,7 @@ func TestOperationSetForAPINoHintWhenForceRefresh(t *testing.T) {
 	c.Stderr = &stderr
 	c.Hooks().SpecCachePath = t.TempDir()
 
-	apiCfg := &config.APIConfig{BaseURL: "https://203.0.113.1"} // unroutable, discovery will fail
+	apiCfg := &config.APIConfig{BaseURL: "https://203.0.113.1"}
 	_, _, _ = c.operationSetForAPI(context.Background(), "example", apiCfg, "default", true)
 	if strings.Contains(stderr.String(), "api sync") {
 		t.Fatalf("expected no api sync hint during forceRefresh, got: %q", stderr.String())

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -197,6 +197,49 @@ func TestInlineAuthCacheKeyDeduplicatesAbsoluteAuthCodeEndpoints(t *testing.T) {
 	}
 }
 
+func TestCachedOAuthTokenEntryMigratesLegacyInlineAuthCodeCacheKey(t *testing.T) {
+	cacheFile := filepath.Join(t.TempDir(), "tokens.cbor")
+	c := New()
+	c.Hooks().TokenCachePath = cacheFile
+
+	ac := &config.AuthConfig{
+		Type: "oauth-authorization-code",
+		Params: map[string]string{
+			"client_id":     "restish",
+			"authorize_url": "https://dex.example.com/auth",
+			"token_url":     "https://dex.example.com/token",
+		},
+	}
+	cacheKey := inlineAuthCacheKey("demo:default", ac, "https://api.example.com")
+	if cacheKey == "" || cacheKey == "demo:default" {
+		t.Fatalf("inline auth code cache key = %q, want hashed oauth key", cacheKey)
+	}
+
+	tc := auth.NewTokenCache(cacheFile)
+	if err := tc.Set("demo:default", auth.CachedToken{AccessToken: "legacy-token"}); err != nil {
+		t.Fatalf("seed legacy token: %v", err)
+	}
+
+	got := c.cachedOAuthTokenEntry("oauth-authorization-code", cacheKey, "demo", "default")
+	if got == nil || got.AccessToken != "legacy-token" {
+		t.Fatalf("migrated token = %+v, want legacy-token", got)
+	}
+	migrated, err := tc.Get(cacheKey)
+	if err != nil {
+		t.Fatalf("read migrated token: %v", err)
+	}
+	if migrated == nil || migrated.AccessToken != "legacy-token" {
+		t.Fatalf("migrated cache entry = %+v, want legacy-token", migrated)
+	}
+	legacy, err := tc.Get("demo:default")
+	if err != nil {
+		t.Fatalf("read legacy token: %v", err)
+	}
+	if legacy != nil {
+		t.Fatalf("legacy cache entry still present: %+v", legacy)
+	}
+}
+
 func TestInlineAuthCacheKeyDeduplicatesIssuerAuthCodeEndpoints(t *testing.T) {
 	ac := &config.AuthConfig{
 		Type: "oauth-authorization-code",

--- a/internal/cli/auth_internal_test.go
+++ b/internal/cli/auth_internal_test.go
@@ -363,3 +363,50 @@ func TestAuthHandlerForOAuthUsesThemeCallbackColors(t *testing.T) {
 		t.Fatalf("failure color = %q, want #ff0000", oauthHandler.CallbackFailureColor)
 	}
 }
+
+func TestOperationSetForAPIHintsAPISync_WhenCacheEmpty(t *testing.T) {
+	var stderr bytes.Buffer
+	c := New()
+	c.Stderr = &stderr
+	c.Hooks().SpecCachePath = t.TempDir() // empty cache dir
+
+	apiCfg := &config.APIConfig{BaseURL: "https://api.example.com"}
+	set, ok, err := c.operationSetForAPI(context.Background(), "example", apiCfg, "default", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok || len(set.Operations) > 0 {
+		t.Fatal("expected empty operation set from cold cache")
+	}
+	if !strings.Contains(stderr.String(), "api sync example") {
+		t.Fatalf("expected api sync hint on stderr, got: %q", stderr.String())
+	}
+}
+
+func TestOperationSetForAPINoHintWhenForceRefresh(t *testing.T) {
+	// forceRefresh=true means an explicit sync is already in progress; no hint.
+	var stderr bytes.Buffer
+	c := New()
+	c.Stderr = &stderr
+	c.Hooks().SpecCachePath = t.TempDir()
+
+	apiCfg := &config.APIConfig{BaseURL: "https://203.0.113.1"} // unroutable, discovery will fail
+	_, _, _ = c.operationSetForAPI(context.Background(), "example", apiCfg, "default", true)
+	if strings.Contains(stderr.String(), "api sync") {
+		t.Fatalf("expected no api sync hint during forceRefresh, got: %q", stderr.String())
+	}
+}
+
+func TestOperationSetForAPINoHintWhenNoSpecSource(t *testing.T) {
+	// An API with no BaseURL, no SpecURL, no SpecFiles configured has nothing to sync.
+	var stderr bytes.Buffer
+	c := New()
+	c.Stderr = &stderr
+	c.Hooks().SpecCachePath = t.TempDir()
+
+	apiCfg := &config.APIConfig{}
+	_, _, _ = c.operationSetForAPI(context.Background(), "bare", apiCfg, "default", false)
+	if strings.Contains(stderr.String(), "api sync") {
+		t.Fatalf("expected no api sync hint for API with no spec source, got: %q", stderr.String())
+	}
+}

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -82,6 +82,9 @@ func (c *CLI) resolveTLSSigner(opts request.Options) (request.Options, error) {
 			return opts, nil
 		}
 	}
+	if opts.TLSSignerName == "pkcs11" {
+		return opts, fmt.Errorf("tls signer plugin %q not found; install the restish-pkcs11 binary and make sure it is on your PATH (see https://github.com/rest-sh/restish)", opts.TLSSignerName)
+	}
 	return opts, fmt.Errorf("tls signer plugin %q not found", opts.TLSSignerName)
 }
 

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -228,6 +228,7 @@ func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*APIConfig, [
 		}
 	}
 
+	var migratedPKCS11 bool
 	if legacy.TLS != nil && legacy.TLS.PKCS11 != nil {
 		if api.Profiles == nil {
 			api.Profiles = map[string]*ProfileConfig{}
@@ -249,6 +250,7 @@ func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*APIConfig, [
 		if legacy.TLS.PKCS11.Label != "" && prof.TLSSignerParams["label"] == "" {
 			prof.TLSSignerParams["label"] = legacy.TLS.PKCS11.Label
 		}
+		migratedPKCS11 = true
 	}
 
 	if legacy.TLS != nil && (legacy.TLS.Cert != "" || legacy.TLS.Key != "") {
@@ -271,6 +273,9 @@ func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*APIConfig, [
 	var warnings []string
 	if warning != "" {
 		warnings = append(warnings, warning)
+	}
+	if migratedPKCS11 {
+		warnings = append(warnings, fmt.Sprintf("api %q: migrated PKCS#11 TLS config; install the restish-pkcs11 plugin to continue using it (see https://github.com/rest-sh/restish)", name))
 	}
 	return api, warnings
 }


### PR DESCRIPTION
Addresses: https://github.com/rest-sh/restish/issues/368

3 related fixes for the v1-to-v2 upgrade path.

**Migrate legacy OAuth token cache keys on first use**

The token cache key format changed from `apiName:profileName` to `oauth:<HASH>`, which silently invalidated all cached tokens on upgrade. Users would hit re-auth loops, raw 204/404 responses, or failures in non-interactive environments.

Now, when the new key misses, we fall back to the legacy key. If found, the token is migrated to the new key and the old one is deleted. No user action needed.

**Hint `api sync` when the spec cache is empty**

When an API has a spec source configured but no cached operations, we now print a hint to stderr:

```
hint: spec cache for API "example" is empty; run "restish api sync example" to populate it
```

This covers the common post-upgrade case where the spec cache directory did not carry over from v1. Instead of silently returning no operations, users get a clear next step.

The hint is skipped when `forceRefresh` is true (already syncing), when the API only uses local spec files, or when no spec source is configured at all.

**Warn about restish-pkcs11 on migration, improve missing plugin error**

In v1, PKCS#11 TLS was compiled in. In v2, it is a separate `restish-pkcs11` binary that needs to be installed. The config migration already ports the `tls_signer: "pkcs11"` field correctly, but gave no indication that the binary also needs installing.

Now the migration emits a warning pointing at the install step, and when `restish-pkcs11` is not found on PATH the error message names the binary and links to the repo instead of the generic "not found".

<details>

<summary>Self-contained e2e test Python script</summary>

```python
#!/usr/bin/env python3
"""End-to-end tests for restish: token cache migration, spec discovery, authenticated calls.

Self-contained: all companion files (mock API server, dex config, Dockerfile,
softhsm2 init script, docker-compose.yml) are embedded as string constants and
written to {work_dir}/stage/ at runtime.  Copy this single file anywhere and run it.

Usage:
  python e2e_test.py [--bin /path/to/restish] [--restish-src /path/to/repo]
                     [--mock-api-port 8099] [--use-compose]
                     [--pkcs11-bin /path/to/restish-pkcs11]
                     [--work-dir /path/to/workdir]

Without --use-compose the mock-api is spawned as a subprocess (no container runtime
needed). With --use-compose the full compose stack (dex + mock-api + softhsm2) is
started and pkcs11 auto-detect tests are also run.
"""

from __future__ import annotations

import argparse
import hashlib
import json
import os
import shutil
import signal
import socket
import subprocess
import sys
import time
from datetime import datetime, timedelta, timezone
from pathlib import Path
from typing import Any

try:
    import cbor2
except ImportError:
    sys.exit("cbor2 is required: run `pip install cbor2` or use the project venv")

# ---------------------------------------------------------------------------
# Paths / defaults
# ---------------------------------------------------------------------------

SCRIPT_DIR = Path(__file__).parent.resolve()
# Fallback source directory used when --bin is omitted. Override via --restish-src.
DEFAULT_RESTISH_SRC = Path(os.environ.get("RESTISH_SRC", ""))
# Use a project venv if present next to this file, otherwise fall back to the
# interpreter running this script.
VENV_PYTHON = SCRIPT_DIR / ".venv" / "bin" / "python"

# Compose project name: determines the prefix for named volumes.
COMPOSE_PROJECT = "restish-e2e"
SOFTHSM2_IMAGE = "restish-e2e-softhsm2:latest"
SOFTHSM2_VOLUME = f"{COMPOSE_PROJECT}_softhsm2-data"

# ---------------------------------------------------------------------------
# Embedded support files
#
# All files needed by the compose stack are stored as string constants here
# and written to {work_dir}/stage/ at runtime.  There are no companion files
# to distribute alongside this script.
# ---------------------------------------------------------------------------

_MOCK_API_PY = """\
#!/usr/bin/env python3
\"\"\"Minimal mock API server for restish e2e tests.

No external dependencies: stdlib only.

Endpoints:
  GET  /openapi.json      OpenAPI 3.0.3 spec (no auth)
  GET  /ping              Always 200 (no auth)
  GET  /version           Version info (no auth)
  GET  /health            Requires Bearer token
  GET  /auth/available    Requires Bearer token
  POST /oauth/token       Fake token endpoint (any grant type; issues "test-e2e-*")
\"\"\"

from __future__ import annotations

import json
import os
import secrets
import sys
from http.server import BaseHTTPRequestHandler, HTTPServer
from typing import Any

_SPEC: dict[str, Any] = {
    "openapi": "3.0.3",
    "info": {"title": "Mock API", "version": "1.0.0"},
    "servers": [{"url": "http://localhost:8099"}],
    "paths": {
        "/ping": {
            "get": {
                "operationId": "ping",
                "summary": "Ping (no auth required)",
                "responses": {
                    "200": {
                        "description": "pong",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "type": "object",
                                    "properties": {"ok": {"type": "boolean"}},
                                }
                            }
                        },
                    }
                },
            }
        },
        "/version": {
            "get": {
                "operationId": "version",
                "summary": "Get API version (no auth required)",
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "type": "object",
                                    "properties": {"version": {"type": "string"}},
                                }
                            }
                        },
                    }
                },
            }
        },
        "/health": {
            "get": {
                "operationId": "health-check",
                "summary": "Health check (requires auth)",
                "security": [{"BearerAuth": []}],
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {
                                    "type": "object",
                                    "properties": {"ok": {"type": "boolean"}},
                                }
                            }
                        },
                    },
                    "401": {"description": "Unauthorized"},
                },
            }
        },
        "/auth/available": {
            "get": {
                "operationId": "auth-available",
                "summary": "List available auth methods (requires auth)",
                "security": [{"BearerAuth": []}],
                "responses": {
                    "200": {
                        "description": "OK",
                        "content": {
                            "application/json": {
                                "schema": {"type": "array", "items": {"type": "string"}}
                            }
                        },
                    },
                    "401": {"description": "Unauthorized"},
                },
            }
        },
    },
    "components": {
        "securitySchemes": {
            "BearerAuth": {"type": "http", "scheme": "bearer"},
        }
    },
}


class _Handler(BaseHTTPRequestHandler):
    def log_message(self, fmt: str, *args: object) -> None:
        print(f"[mock-api] {fmt % args}", file=sys.stderr, flush=True)

    def _bearer(self) -> str | None:
        h = self.headers.get("Authorization", "")
        if h.startswith("Bearer "):
            return h[7:].strip()
        return None

    def _json(self, status: int, body: Any) -> None:
        data = json.dumps(body).encode()
        self.send_response(status)
        self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(data)))
        self.end_headers()
        self.wfile.write(data)

    def _require_auth(self) -> bool:
        if not self._bearer():
            self._json(401, {"error": "unauthorized"})
            return False
        return True

    def do_GET(self) -> None:
        path = self.path.split("?", 1)[0]
        if path == "/openapi.json":
            self._json(200, _SPEC)
        elif path in ("/ping", "/version"):
            self._json(200, {"ok": True, "version": "1.0.0"})
        elif path == "/health":
            if self._require_auth():
                self._json(200, {"ok": True})
        elif path == "/auth/available":
            if self._require_auth():
                self._json(200, ["oauth-authorization-code"])
        else:
            self._json(404, {"error": "not found"})

    def do_POST(self) -> None:
        length = int(self.headers.get("Content-Length", 0))
        self.rfile.read(length)  # consume body
        path = self.path.split("?", 1)[0]
        if path == "/oauth/token":
            self._json(200, {
                "access_token": "test-e2e-token-" + secrets.token_hex(8),
                "token_type": "bearer",
                "expires_in": 3600,
            })
        else:
            self._json(404, {"error": "not found"})


if __name__ == "__main__":
    port = int(os.environ.get("PORT", "8099"))
    server = HTTPServer(("0.0.0.0", port), _Handler)
    print(f"[mock-api] listening on :{port}", file=sys.stderr, flush=True)
    try:
        server.serve_forever()
    except KeyboardInterrupt:
        pass
"""

_DEX_CONFIG_YAML = """\
issuer: http://localhost:5556/dex

storage:
  type: memory

web:
  http: 0.0.0.0:5556

oauth2:
  skipApprovalScreen: true
  responseTypes:
    - code

enablePasswordDB: true

# Password: "password"
# Hash generated with: echo "password" | htpasswd -niB x | cut -d: -f2
# or: dex bcrypt-hash password
staticPasswords:
  - email: "test@test.local"
    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
    username: "test"

staticClients:
  - id: restish
    name: restish
    # public: true enables PKCE (no client secret required), which is what
    # restish uses by default for oauth-authorization-code.
    public: true
    redirectURIs:
      - http://127.0.0.1:9999/oauth/callback
      - http://127.0.0.1:9998/oauth/callback
      - http://127.0.0.1:9997/oauth/callback
"""

_DOCKER_COMPOSE_YML = """\
volumes:
  softhsm2-data:

services:
  # Initialises a SoftHSM2 token and writes a JSON manifest to the shared
  # volume. The e2e tests read the manifest to locate the library + slot.
  softhsm2-init:
    image: restish-e2e-softhsm2:latest
    build:
      context: .
      dockerfile: softhsm2/Dockerfile
    environment:
      SOFTHSM2_VOLUME: /softhsm2
      SOFTHSM2_TOKEN_LABEL: e2e-test
      SOFTHSM2_TOKEN_PIN: "1234"
      SOFTHSM2_TOKEN_SO_PIN: "5678"
      SOFTHSM2_KEY_LABEL: e2e-key
    volumes:
      - softhsm2-data:/softhsm2
    # run-once init container; restarts are no-ops (manifest already exists)
    restart: "no"

  dex:
    image: ghcr.io/dexidp/dex:v2.41.1
    ports:
      - "5556:5556"
    volumes:
      - ./dex:/etc/dex:ro
    command: ["dex", "serve", "/etc/dex/config.yaml"]
    healthcheck:
      test:
        - "CMD"
        - "wget"
        - "-q"
        - "-O-"
        - "http://localhost:5556/dex/.well-known/openid-configuration"
      interval: 2s
      timeout: 5s
      retries: 20

  mock-api:
    image: python:3.12-slim
    ports:
      - "8099:8099"
    volumes:
      - ./mock_api.py:/app/mock_api.py:ro
    working_dir: /app
    command: ["python3", "mock_api.py"]
    healthcheck:
      test:
        - "CMD"
        - "python3"
        - "-c"
        - "import urllib.request; urllib.request.urlopen('http://localhost:8099/ping')"
      interval: 2s
      timeout: 5s
      retries: 10
"""

_SOFTHSM2_DOCKERFILE = """\
FROM debian:bookworm-slim

RUN apt-get update -qq && \\
    apt-get install -y --no-install-recommends \\
        softhsm2 \\
        opensc \\
        openssl \\
    && rm -rf /var/lib/apt/lists/*

# softhsm2 stores tokens under /var/lib/softhsm/tokens by default but we
# want a volume-mounted path so the host can access the library and token dir.
ENV SOFTHSM2_CONF=/softhsm2/softhsm2.conf

COPY softhsm2/init.sh /init.sh
RUN chmod +x /init.sh

VOLUME ["/softhsm2"]

ENTRYPOINT ["/init.sh"]
"""

_SOFTHSM2_INIT_SH = """\
#!/usr/bin/env bash
# Initialise a SoftHSM2 token, import a private key and a self-signed
# certificate (with matching CKA_ID so crypto11 can pair them), then write
# a JSON manifest that tells the e2e tests where to find the library and
# what slot/label/PIN to use.
#
# The script is idempotent: if the manifest already exists it exits 0 so
# the container can be restarted without reinitialising everything.

set -euo pipefail

VOLUME_DIR="${SOFTHSM2_VOLUME:-/softhsm2}"
CONF="${SOFTHSM2_CONF:-${VOLUME_DIR}/softhsm2.conf}"
TOKEN_DIR="${VOLUME_DIR}/tokens"
MANIFEST="${VOLUME_DIR}/manifest.json"

TOKEN_LABEL="${SOFTHSM2_TOKEN_LABEL:-e2e-test}"
TOKEN_PIN="${SOFTHSM2_TOKEN_PIN:-1234}"
TOKEN_SO_PIN="${SOFTHSM2_TOKEN_SO_PIN:-5678}"
KEY_LABEL="${SOFTHSM2_KEY_LABEL:-e2e-key}"
CERT_PATH="${VOLUME_DIR}/cert.pem"

if [[ -f "${MANIFEST}" ]]; then
    echo "[softhsm2-init] manifest already exists, skipping init"
    cat "${MANIFEST}"
    exit 0
fi

mkdir -p "${TOKEN_DIR}"

cat >"${CONF}" <<EOF
directories.tokendir = ${TOKEN_DIR}
objectstore.backend = file
log.level = INFO
slots.removable = false
EOF

echo "[softhsm2-init] initialising token ${TOKEN_LABEL}"
softhsm2-util \\
    --init-token \\
    --free \\
    --label "${TOKEN_LABEL}" \\
    --pin "${TOKEN_PIN}" \\
    --so-pin "${TOKEN_SO_PIN}"

# Retrieve the slot number assigned to the new token.
SLOT=$(softhsm2-util --show-slots | awk -v label="${TOKEN_LABEL}" '
    /^Slot / { slot=$2 }
    /Label:/ && $2 == label { print slot; exit }
')

echo "[softhsm2-init] token in slot ${SLOT}"

# Generate RSA-2048 key and a self-signed cert entirely with openssl so
# that the cert's public key matches the private key.
TMPKEY_PEM="${VOLUME_DIR}/tmpkey.pem"
TMPKEY_DER="${VOLUME_DIR}/tmpkey.der"
CERT_DER="${VOLUME_DIR}/cert.der"

openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \\
    -out "${TMPKEY_PEM}" 2>/dev/null
openssl req -new -x509 -key "${TMPKEY_PEM}" -out "${CERT_PATH}" \\
    -days 3650 -subj "/CN=restish-e2e-test" 2>/dev/null

# Convert to DER for pkcs11-tool import.
openssl pkcs8 -topk8 -nocrypt \\
    -in "${TMPKEY_PEM}" -outform DER -out "${TMPKEY_DER}" 2>/dev/null
openssl x509 -in "${CERT_PATH}" -outform DER -out "${CERT_DER}" 2>/dev/null

# Import the private key with CKA_ID=0x01.
pkcs11-tool \\
    --module /usr/lib/softhsm/libsofthsm2.so \\
    --login --pin "${TOKEN_PIN}" \\
    --token-label "${TOKEN_LABEL}" \\
    --write-object "${TMPKEY_DER}" \\
    --type privkey \\
    --id 01 \\
    --label "${KEY_LABEL}" 2>/dev/null

# Import the certificate with the same CKA_ID=0x01 so that
# crypto11.FindAllPairedCertificates can pair them.
pkcs11-tool \\
    --module /usr/lib/softhsm/libsofthsm2.so \\
    --login --pin "${TOKEN_PIN}" \\
    --token-label "${TOKEN_LABEL}" \\
    --write-object "${CERT_DER}" \\
    --type cert \\
    --id 01 \\
    --label "${KEY_LABEL}" 2>/dev/null

rm -f "${TMPKEY_PEM}" "${TMPKEY_DER}" "${CERT_DER}"

# Write manifest for the test runner.
LIBRARY=$(find /usr/lib -name "libsofthsm2.so" 2>/dev/null | head -1)
cat >"${MANIFEST}" <<EOF
{
  "library": "${LIBRARY}",
  "conf": "${CONF}",
  "token_label": "${TOKEN_LABEL}",
  "slot": ${SLOT},
  "pin": "${TOKEN_PIN}",
  "key_label": "${KEY_LABEL}",
  "cert_pem": "${CERT_PATH}"
}
EOF

echo "[softhsm2-init] done"
cat "${MANIFEST}"
"""

# ---------------------------------------------------------------------------
# Token cache helpers (must match restish's internal/cli/auth.go logic)
# ---------------------------------------------------------------------------

_CACHE_KEY_IGNORED_PARAMS = {
    "_base_url", "_cache_key", "auth_method", "cache_key", "client_secret",
    "callback_error_html", "callback_success_html",
    "redirect_cert", "redirect_key", "redirect_path", "redirect_port", "redirect_scheme",
}


def compute_oauth_cache_key(auth_params: dict[str, str]) -> str | None:
    """Return the 'oauth:HASH' cache key restish would use for an inline
    oauth-authorization-code profile with absolute endpoints, or None when
    restish would fall back to the legacy apiName:profileName key."""
    token_url = auth_params.get("token_url", "")
    issuer_url = auth_params.get("issuer_url", "")
    client_id = auth_params.get("client_id", "")
    if not client_id:
        return None
    if not (_is_absolute(token_url) or _is_absolute(issuer_url)):
        return None
    relevant = {"type": "oauth-authorization-code"}
    for k, v in auth_params.items():
        if v and k not in _CACHE_KEY_IGNORED_PARAMS:
            relevant[k] = v
    material = "".join(f"{k}={v}\n" for k, v in sorted(relevant.items()))
    digest = hashlib.sha256(material.encode()).digest()[:8]
    return "oauth:" + digest.hex()


def _is_absolute(url: str) -> bool:
    if not url:
        return False
    from urllib.parse import urlparse
    p = urlparse(url)
    return bool(p.scheme and p.netloc)


def seed_legacy_token(cache_path: Path, api_name: str, profile_name: str, access_token: str) -> None:
    """Write a token under the pre-hash 'apiName:profileName' key format."""
    legacy_key = f"{api_name}:{profile_name}"
    cache: dict[str, Any] = {}
    if cache_path.exists():
        try:
            cache = cbor2.loads(cache_path.read_bytes())
        except Exception:
            cache = {}
    cache[legacy_key] = {
        "access_token": access_token,
        "token_type": "bearer",
        "expiry": datetime.now(timezone.utc) + timedelta(hours=1),
    }
    cache_path.parent.mkdir(parents=True, exist_ok=True)
    cache_path.write_bytes(cbor2.dumps(cache))
    cache_path.chmod(0o600)


def read_cache(cache_path: Path) -> dict[str, Any]:
    if not cache_path.exists():
        return {}
    return cbor2.loads(cache_path.read_bytes())


# ---------------------------------------------------------------------------
# Sandbox / restish helpers
# ---------------------------------------------------------------------------

def sandbox_env(sandbox_home: Path) -> dict[str, str]:
    env = os.environ.copy()
    env["XDG_CONFIG_HOME"] = str(sandbox_home / ".config")
    env["XDG_CACHE_HOME"] = str(sandbox_home / ".cache")
    env.pop("BROWSER", None)
    env["BROWSER"] = ""  # suppress browser during tests
    return env


def write_restish_config(sandbox_home: Path, config: dict[str, Any]) -> None:
    cfg_dir = sandbox_home / ".config" / "restish"
    cfg_dir.mkdir(parents=True, exist_ok=True)
    path = cfg_dir / "restish.json"
    path.write_text(json.dumps(config, indent=2) + "\n")
    path.chmod(0o600)


def token_cache_path(sandbox_home: Path) -> Path:
    return sandbox_home / ".config" / "restish" / "tokens.cbor"


def run_restish(
    restish_bin: Path,
    sandbox_home: Path,
    args: list[str],
    timeout: int = 30,
) -> subprocess.CompletedProcess[str]:
    return subprocess.run(
        [str(restish_bin), *args],
        env=sandbox_env(sandbox_home),
        text=True,
        stdin=subprocess.DEVNULL,   # prevent TTY detection → no browser launch
        stdout=subprocess.PIPE,
        stderr=subprocess.PIPE,
        timeout=timeout,
    )


# ---------------------------------------------------------------------------
# Infrastructure: mock-api subprocess / compose
# ---------------------------------------------------------------------------

def wait_for_port(host: str, port: int, timeout: float = 30.0) -> bool:
    deadline = time.monotonic() + timeout
    while time.monotonic() < deadline:
        try:
            with socket.create_connection((host, port), timeout=1):
                return True
        except OSError:
            time.sleep(0.3)
    return False


def start_mock_api_subprocess(mock_api_script: Path, port: int = 8099) -> subprocess.Popen[str]:
    python = str(VENV_PYTHON) if VENV_PYTHON.exists() else sys.executable
    proc = subprocess.Popen(
        [python, str(mock_api_script)],
        env={**os.environ, "PORT": str(port)},
        stdout=subprocess.DEVNULL,
        stderr=subprocess.PIPE,
        text=True,
    )
    if not wait_for_port("127.0.0.1", port, timeout=10):
        proc.terminate()
        raise RuntimeError(f"mock-api did not start on port {port}")
    return proc


def compose_cmd() -> list[str]:
    """Return the base compose command including the project name flag."""
    for cmd in (["podman-compose"], ["docker-compose"], ["docker", "compose"]):
        if shutil.which(cmd[0]):
            return cmd + ["-p", COMPOSE_PROJECT]
    raise RuntimeError("No compose tool found (podman-compose / docker-compose)")


def start_compose(compose_file: Path, mock_api_port: int = 8099, dex_port: int = 5556) -> None:
    # --wait is Docker Compose v2 only; podman-compose doesn't support it.
    # Start detached, then poll ports directly.
    subprocess.run(
        [*compose_cmd(), "-f", str(compose_file), "up", "-d"],
        cwd=str(compose_file.parent),
        check=True,
    )
    for host, port, name in [
        ("127.0.0.1", mock_api_port, "mock-api"),
        ("127.0.0.1", dex_port, "dex"),
    ]:
        if not wait_for_port(host, port, timeout=30):
            raise RuntimeError(f"{name} did not become ready on port {port}")


def stop_compose(compose_file: Path) -> None:
    subprocess.run(
        [*compose_cmd(), "-f", str(compose_file), "down"],
        cwd=str(compose_file.parent),
        check=False,
    )


def setup_compose_stage(stage_dir: Path) -> None:
    """Write all embedded support files to stage_dir for use by the compose stack."""
    stage_dir.mkdir(parents=True, exist_ok=True)
    (stage_dir / "mock_api.py").write_text(_MOCK_API_PY)
    (stage_dir / "dex").mkdir(exist_ok=True)
    (stage_dir / "dex" / "config.yaml").write_text(_DEX_CONFIG_YAML)
    (stage_dir / "softhsm2").mkdir(exist_ok=True)
    (stage_dir / "softhsm2" / "Dockerfile").write_text(_SOFTHSM2_DOCKERFILE)
    sh = stage_dir / "softhsm2" / "init.sh"
    sh.write_text(_SOFTHSM2_INIT_SH)
    sh.chmod(0o755)
    (stage_dir / "docker-compose.yml").write_text(_DOCKER_COMPOSE_YML)


# ---------------------------------------------------------------------------
# PKCS#11 helpers (only used with --use-compose)
# ---------------------------------------------------------------------------


def _run_in_softhsm2_container(
    image: str,
    volume_name: str,
    entrypoint: str,
    args: list[str],
    input_data: bytes | None = None,
    extra_volumes: list[str] | None = None,
) -> subprocess.CompletedProcess[bytes]:
    """Run a command in a fresh container that has the softhsm2 library and token volume."""
    cmd = ["podman", "run", "--rm"]
    if input_data is not None:
        cmd.append("-i")
    cmd += [
        "--entrypoint", entrypoint,
        "-v", f"{volume_name}:/softhsm2",
        "-e", "SOFTHSM2_CONF=/softhsm2/softhsm2.conf",
    ]
    for v in (extra_volumes or []):
        cmd += ["-v", v]
    cmd.append(image)
    cmd += args
    return subprocess.run(cmd, input=input_data, capture_output=True, timeout=60)


def wait_for_softhsm2_manifest(image: str, volume_name: str, timeout: float = 60.0) -> dict[str, Any]:
    """Poll until init.sh has written manifest.json, then return its contents."""
    deadline = time.monotonic() + timeout
    while time.monotonic() < deadline:
        r = _run_in_softhsm2_container(image, volume_name, "cat", ["/softhsm2/manifest.json"])
        if r.returncode == 0 and r.stdout:
            return json.loads(r.stdout.decode())
        time.sleep(1)
    raise RuntimeError("softhsm2-init did not write manifest.json in time")


def run_pkcs11_plugin(
    image: str,
    volume_name: str,
    plugin_bin: Path,
    params: dict[str, str],
) -> tuple[bool, dict[str, Any] | None, str]:
    """Send a TLSSignerInitMsg + TLSSignerShutdownMsg to the plugin binary.

    Returns (success, response_dict, error_message).  On success the plugin
    writes a TLSSignerReadyMsg to stdout and exits 0 after receiving the
    shutdown message.  On error it writes to stderr and exits non-zero.
    """
    init_msg = cbor2.dumps({"type": "init", "params": params})
    shutdown_msg = cbor2.dumps({"type": "shutdown"})
    r = _run_in_softhsm2_container(
        image, volume_name, "/plugin", [],
        input_data=init_msg + shutdown_msg,
        extra_volumes=[f"{plugin_bin}:/plugin:ro"],
    )
    if r.returncode != 0:
        return False, None, r.stderr.decode(errors="replace").strip()
    if not r.stdout:
        return False, None, "plugin produced no output on stdout"
    try:
        response = cbor2.loads(r.stdout)
        return True, response, ""
    except Exception as exc:
        return False, None, f"failed to decode plugin response: {exc}"


def _softhsm2_util(image: str, volume_name: str, *args: str) -> subprocess.CompletedProcess[bytes]:
    return _run_in_softhsm2_container(image, volume_name, "softhsm2-util", list(args))


# ---------------------------------------------------------------------------
# Test: pkcs11 auto-detect: single token, no selector
# ---------------------------------------------------------------------------

def test_pkcs11_auto_detect_single_token(
    plugin_bin: Path, image: str, volume_name: str, manifest: dict[str, Any],
) -> bool:
    """No slot/label selector → plugin detects the single token and sends ready."""
    params = {"module": manifest["library"], "pin": manifest["pin"]}
    ok, resp, err = run_pkcs11_plugin(image, volume_name, plugin_bin, params)
    if not ok:
        print(f"    plugin error: {err}")
        return False
    if resp.get("type") != "ready":
        print(f"    expected type=ready, got: {resp}")
        return False
    if not resp.get("certificate"):
        print(f"    missing certificate in ready response")
        return False
    return True


# ---------------------------------------------------------------------------
# Test: pkcs11 auto-detect: two tokens should produce a clear error
# ---------------------------------------------------------------------------

def test_pkcs11_two_tokens_error(
    plugin_bin: Path, image: str, volume_name: str, manifest: dict[str, Any],
) -> bool:
    """Two tokens, no selector → plugin returns 'found 2 pkcs11 tokens' error."""
    r = _softhsm2_util(
        image, volume_name,
        "--init-token", "--free",
        "--label", "extra-e2e-token",
        "--pin", "9999", "--so-pin", "9999",
    )
    if r.returncode != 0:
        print(f"    failed to init extra token: {r.stderr.decode(errors='replace')}")
        return False
    try:
        params = {"module": manifest["library"], "pin": manifest["pin"]}
        ok, resp, err = run_pkcs11_plugin(image, volume_name, plugin_bin, params)
        if ok:
            print(f"    expected error with two tokens, got ready response")
            return False
        if "found 2 pkcs11 tokens" not in err:
            print(f"    expected 'found 2 pkcs11 tokens' in error, got: {err!r}")
            return False
        return True
    finally:
        _softhsm2_util(image, volume_name, "--delete-token", "--token", "extra-e2e-token")


# ---------------------------------------------------------------------------
# Test: pkcs11 explicit slot: bypasses auto-detect
# ---------------------------------------------------------------------------

def test_pkcs11_explicit_slot(
    plugin_bin: Path, image: str, volume_name: str, manifest: dict[str, Any],
) -> bool:
    """Explicit slot=N → plugin skips auto-detect and sends ready."""
    params = {
        "module": manifest["library"],
        "pin": manifest["pin"],
        "slot": str(manifest["slot"]),
    }
    ok, resp, err = run_pkcs11_plugin(image, volume_name, plugin_bin, params)
    if not ok:
        print(f"    plugin error: {err}")
        return False
    if resp.get("type") != "ready":
        print(f"    expected type=ready, got: {resp}")
        return False
    return True


# ---------------------------------------------------------------------------
# Test: spec discovery
# ---------------------------------------------------------------------------

def test_spec_discovery(restish_bin: Path, run_dir: Path, mock_api_url: str) -> bool:
    """api sync discovers operations from mock-api's OpenAPI spec."""
    sandbox = run_dir / "spec_discovery"
    write_restish_config(sandbox, {
        "apis": {
            "mock-api": {
                "base_url": mock_api_url,
                "spec_files": [f"{mock_api_url}/openapi.json"],
                "profiles": {"default": {}},
            }
        },
        "cache": {},
    })

    sync = run_restish(restish_bin, sandbox, ["api", "sync", "--yes", "mock-api"])
    if sync.returncode != 0:
        print(f"    api sync failed (exit {sync.returncode}):\n{sync.stdout}\n{sync.stderr}")
        return False

    # api list should show the API with discovered operations
    lst = run_restish(restish_bin, sandbox, ["api", "list"])
    if "mock-api" not in lst.stdout:
        print(f"    api list missing mock-api:\n{lst.stdout}")
        return False

    # --help should list at least ping and health-check
    hlp = run_restish(restish_bin, sandbox, ["mock-api", "--help"])
    for op in ("health-check", "ping"):
        if op not in hlp.stdout:
            print(f"    missing operation {op!r} in mock-api --help:\n{hlp.stdout}")
            return False

    return True


# ---------------------------------------------------------------------------
# Test: unauthenticated commands work without a token
# ---------------------------------------------------------------------------

def test_unauthenticated_commands(restish_bin: Path, run_dir: Path, mock_api_url: str) -> bool:
    """GET /ping succeeds with no auth configured."""
    sandbox = run_dir / "unauth_cmds"
    write_restish_config(sandbox, {
        "apis": {
            "mock-api": {
                "base_url": mock_api_url,
                "spec_files": [f"{mock_api_url}/openapi.json"],
                "profiles": {"default": {}},
            }
        },
        "cache": {},
    })
    run_restish(restish_bin, sandbox, ["api", "sync", "--yes", "mock-api"])

    result = run_restish(restish_bin, sandbox, ["mock-api", "ping"])
    if result.returncode != 0:
        print(f"    ping failed (exit {result.returncode}):\n{result.stdout}\n{result.stderr}")
        return False
    return True


# ---------------------------------------------------------------------------
# Test: token cache migration shim (the whole point of PR #367)
# ---------------------------------------------------------------------------

def test_token_migration(restish_bin: Path, run_dir: Path, mock_api_url: str) -> bool:
    """Plant a token under the legacy key, run an auth'd command, verify migration.

    Flow:
      1. Configure restish with oauth-authorization-code + absolute token_url
         → restish will key tokens under 'oauth:HASH', not 'mock-api:default'
      2. Seed 'mock-api:default' in the CBOR cache (simulates a pre-upgrade token)
      3. Run `mock-api health-check`: requires Bearer auth
      4. The migration shim in cachedOAuthTokenEntry finds the legacy key,
         migrates it to the new key, and uses it for the request
      5. mock-api accepts any non-empty Bearer → 200
      6. Verify: legacy key gone, new key present, request succeeded
    """
    sandbox = run_dir / "token_migration"

    auth_params = {
        "authorize_url": f"{mock_api_url}/oauth/authorize",
        "client_id": "restish",
        "scopes": "openid",
        "token_url": f"{mock_api_url}/oauth/token",
    }
    write_restish_config(sandbox, {
        "apis": {
            "mock-api": {
                "base_url": mock_api_url,
                "spec_files": [f"{mock_api_url}/openapi.json"],
                "profiles": {
                    "default": {
                        "auth": {
                            "type": "oauth-authorization-code",
                            "params": auth_params,
                        }
                    }
                },
            }
        },
        "cache": {},
    })

    # Plant token under the legacy 'apiName:profileName' key BEFORE syncing so
    # the migration shim fires during api sync itself (realistic upgrade scenario).
    fake_token = "test-e2e-migration-token-" + hashlib.sha256(b"seed").hexdigest()[:8]
    cache_path = token_cache_path(sandbox)
    seed_legacy_token(cache_path, "mock-api", "default", fake_token)

    # Sync spec: auth is needed here too; migration shim provides the token.
    sync = run_restish(restish_bin, sandbox, ["api", "sync", "--yes", "mock-api"])
    if sync.returncode != 0:
        print(f"    spec sync failed:\n{sync.stdout}\n{sync.stderr}")
        return False

    new_key = compute_oauth_cache_key(auth_params)
    assert new_key is not None, "auth_params should produce an oauth:HASH key"

    # Run an authenticated command: should trigger the migration shim
    result = run_restish(restish_bin, sandbox, ["mock-api", "health-check"])

    cache_after = read_cache(cache_path)
    legacy_gone = "mock-api:default" not in cache_after
    new_key_present = new_key in cache_after
    request_ok = result.returncode == 0

    if not request_ok:
        print(f"    health-check failed (exit {result.returncode}):")
        print(f"      stdout: {result.stdout.strip()}")
        print(f"      stderr: {result.stderr.strip()}")
    if not legacy_gone:
        print(f"    legacy key 'mock-api:default' still present in cache")
    if not new_key_present:
        print(f"    new key {new_key!r} not found in cache")
        print(f"    cache keys: {list(cache_after.keys())}")

    return request_ok and legacy_gone and new_key_present


# ---------------------------------------------------------------------------
# Test: auth-required command fails gracefully without a token (no browser)
# ---------------------------------------------------------------------------

def test_auth_required_without_token(restish_bin: Path, run_dir: Path, mock_api_url: str) -> bool:
    """health-check without any cached token and no browser should error cleanly."""
    sandbox = run_dir / "auth_required_no_token"
    auth_params = {
        "authorize_url": f"{mock_api_url}/oauth/authorize",
        "client_id": "restish",
        "scopes": "openid",
        "token_url": f"{mock_api_url}/oauth/token",
    }
    write_restish_config(sandbox, {
        "apis": {
            "mock-api": {
                "base_url": mock_api_url,
                "spec_files": [f"{mock_api_url}/openapi.json"],
                "profiles": {
                    "default": {
                        "auth": {
                            "type": "oauth-authorization-code",
                            "params": auth_params,
                        }
                    }
                },
            }
        },
        "cache": {},
    })
    run_restish(restish_bin, sandbox, ["api", "sync", "--yes", "mock-api"])

    # No token seeded, BROWSER="" → should fail with a descriptive error, not panic
    result = run_restish(restish_bin, sandbox, ["mock-api", "health-check"])
    if result.returncode == 0:
        print("    expected non-zero exit when no token and no browser, got 0")
        return False
    if "panic" in result.stderr.lower():
        print(f"    unexpected panic:\n{result.stderr}")
        return False
    return True


# ---------------------------------------------------------------------------
# Main
# ---------------------------------------------------------------------------

def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description="Restish e2e tests")
    parser.add_argument(
        "--bin",
        default=None,
        help="Path to a pre-built restish binary. Builds from --restish-src if absent.",
    )
    parser.add_argument(
        "--pkcs11-bin",
        default=None,
        help="Path to a pre-built restish-pkcs11 binary. Builds from --restish-src if absent.",
    )
    parser.add_argument(
        "--restish-src",
        default=str(DEFAULT_RESTISH_SRC),
        help="Path to the restish source repo (used when --bin / --pkcs11-bin are not set). "
             "Also set via $RESTISH_SRC.",
    )
    parser.add_argument("--mock-api-port", type=int, default=8099)
    parser.add_argument(
        "--dex-url",
        default=None,
        help="Dex base URL, e.g. http://localhost:5556/dex. Enables OIDC flow tests.",
    )
    parser.add_argument(
        "--use-compose",
        action="store_true",
        help="Start services via docker-compose / podman-compose instead of subprocess",
    )
    parser.add_argument(
        "--work-dir",
        default=str(SCRIPT_DIR),
        help="Directory for run artifacts and the compose staging area",
    )
    return parser.parse_args()


def main() -> int:
    args = parse_args()
    work_dir = Path(args.work_dir)
    run_dir = work_dir / "runs" / datetime.now().strftime("e2e-%Y%m%d-%H%M%S")
    run_dir.mkdir(parents=True, exist_ok=True)

    # Write embedded support files to a stable staging directory so that
    # docker-compose can find them and image builds are cached across runs.
    stage_dir = work_dir / "stage"
    setup_compose_stage(stage_dir)
    compose_file = stage_dir / "docker-compose.yml"

    # Build or locate the restish binary.
    if args.bin:
        restish_bin = Path(args.bin).expanduser().resolve()
        if not restish_bin.exists():
            print(f"ERROR: --bin binary not found: {restish_bin}")
            return 1
        print(f"Using binary: {restish_bin}")
    else:
        restish_bin = run_dir / "restish"
        src = Path(args.restish_src)
        print(f"Building restish from {src} ...")
        r = subprocess.run(["go", "build", "-o", str(restish_bin), "./cmd/restish"], cwd=str(src))
        if r.returncode != 0:
            print("ERROR: build failed")
            return 1
        print(f"Built: {restish_bin}")

    # Start services and optionally build the pkcs11 plugin.
    mock_proc: subprocess.Popen[str] | None = None
    mock_api_url = f"http://localhost:{args.mock_api_port}"
    pkcs11_bin: Path | None = None

    if args.use_compose:
        print(f"Staging compose files in {stage_dir} ...")
        print(f"Starting services via compose ...")
        start_compose(compose_file, mock_api_port=args.mock_api_port)

        # Build or locate the pkcs11 plugin binary.
        if args.pkcs11_bin:
            pkcs11_bin = Path(args.pkcs11_bin).expanduser().resolve()
            if not pkcs11_bin.exists():
                print(f"WARNING: --pkcs11-bin not found: {pkcs11_bin}; skipping pkcs11 tests")
                pkcs11_bin = None
        else:
            pkcs11_bin = run_dir / "restish-pkcs11"
            src = Path(args.restish_src)
            print(f"Building restish-pkcs11 from {src} ...")
            r = subprocess.run(
                ["go", "build", "-o", str(pkcs11_bin), "./cmd/restish-pkcs11"], cwd=str(src),
            )
            if r.returncode != 0:
                print("WARNING: restish-pkcs11 build failed; skipping pkcs11 tests")
                pkcs11_bin = None
            else:
                print(f"Built: {pkcs11_bin}")
    else:
        print(f"Starting mock-api on :{args.mock_api_port} ...")
        mock_proc = start_mock_api_subprocess(stage_dir / "mock_api.py", args.mock_api_port)

    # Build the test list.  pkcs11 tests are added when compose is running and
    # the plugin binary is available.
    tests: list[tuple[str, Any]] = [
        ("spec_discovery",              test_spec_discovery),
        ("unauthenticated_commands",    test_unauthenticated_commands),
        ("token_migration",             test_token_migration),
        ("auth_required_without_token", test_auth_required_without_token),
    ]

    if pkcs11_bin is not None:
        print("Waiting for softhsm2-init to complete ...")
        manifest = wait_for_softhsm2_manifest(SOFTHSM2_IMAGE, SOFTHSM2_VOLUME)
        _pb, _img, _vol, _mf = pkcs11_bin, SOFTHSM2_IMAGE, SOFTHSM2_VOLUME, manifest
        tests += [
            ("pkcs11_auto_detect_single_token",
             lambda rb, rd, url: test_pkcs11_auto_detect_single_token(_pb, _img, _vol, _mf)),
            ("pkcs11_two_tokens_error",
             lambda rb, rd, url: test_pkcs11_two_tokens_error(_pb, _img, _vol, _mf)),
            ("pkcs11_explicit_slot",
             lambda rb, rd, url: test_pkcs11_explicit_slot(_pb, _img, _vol, _mf)),
        ]

    results: dict[str, bool] = {}
    try:
        for name, fn in tests:
            print(f"\n[{len(results) + 1}/{len(tests)}] {name}")
            try:
                ok = fn(restish_bin, run_dir, mock_api_url)
            except Exception as exc:
                print(f"    ERROR: {exc}")
                ok = False
            results[name] = ok
            print("    ok" if ok else "    FAIL")
    finally:
        if mock_proc is not None:
            mock_proc.terminate()
            mock_proc.wait(timeout=5)
        elif args.use_compose:
            stop_compose(compose_file)

    passed = sum(results.values())
    total = len(results)
    print(f"\n{'=' * 50}")
    for name, ok in results.items():
        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
    print(f"\n{passed}/{total} passed")
    print(f"Run artifacts: {run_dir}")

    return 0 if passed == total else 1


if __name__ == "__main__":
    sys.exit(main())
```
</details>