### PR TITLE
feat(output): add TOON output format for token-efficient agent consumption

### DIFF
--- a/docs/design/041-toon-output-format.md
+++ b/docs/design/041-toon-output-format.md
@@ -1,0 +1,248 @@
+# TOON Output Format
+
+## Summary
+
+Add a `toon` output formatter that renders a normalized response body as
+[Token-Oriented Object Notation (TOON)](https://github.com/toon-format/spec), a
+compact, indentation-based, schema-aware encoding of the JSON data model
+designed to reduce token usage when structured data is fed to large language
+models.
+
+The motivating workflow is using Restish as the tool surface for an LLM agent
+(in place of, or alongside, an MCP server — see design 023). In that setup every
+response the agent reads, and every list it pages through, costs input tokens.
+TOON's tabular encoding of uniform object arrays declares field names once and
+streams rows, which materially cuts token count for the list/collection
+responses that dominate REST APIs.
+
+This is an **output-only, opt-in, additive** change: a new value for
+`-o/--rsh-output-format`. It introduces no new default behavior and no
+compatibility risk to existing formats.
+
+## Product Frame
+
+**Problem:**
+Agents that consume Restish output pay for every token of every response. JSON
+repeats every object key on every array element, so collection responses are
+token-expensive. There is no way to ask Restish for a more token-dense
+representation of the same data.
+
+**Goals:**
+
+- Provide `-o toon` to render response bodies as TOON.
+- Make the largest savings reachable where they exist: uniform arrays of objects
+  (list endpoints, or `-f` projections that produce such lists).
+- Compose with existing filtering, pagination, and streaming, since the agent
+  use case almost always projects before encoding.
+- Track a pinned TOON spec version with golden-file tests so output is a stable,
+  auditable contract.
+
+**Non-goals:**
+
+- Accepting TOON as a **request body** content type (agent → API). That belongs
+  to the content-type/encoding subsystem (design 003), is a larger lift, and has
+  low marginal value because agents emit JSON request bodies well. Out of scope
+  for v1.
+- Making TOON a default. JSON remains the machine default.
+- Guaranteeing token savings for arbitrary shapes (see Tradeoffs).
+- Round-trip decoding of TOON inside Restish.
+
+**Primary workflow:**
+
+1. `restish api list-things -o toon` — render a collection response as TOON.
+2. `restish api get-thing -f body.items -o toon` — project to the token-dense
+   shape first, then encode. This is the recommended, highest-savings pattern.
+
+**CLI surface:**
+
+- Command/flag/config: new `toon` value for `-o/--rsh-output-format` and
+  `RSH_OUTPUT_FORMAT`. Registered in `output.DefaultFormatters()`, so it appears
+  automatically in `root.go` flag help and in error messages via
+  `FormatterNames`.
+- Defaults: unchanged. `auto` in a TTY, `json` when piped.
+- TTY behavior: optional syntax highlighting via the existing `highlight` path;
+  otherwise plain.
+- Non-TTY behavior: deterministic, color-free TOON to stdout.
+- Output: encodes `resp.Body` only, matching `-o json`/`gron` (status and
+  headers are not part of structured body output).
+- Errors: encoder failures return through the existing `Formatter` error path;
+  the command surfaces them like any other format error.
+
+**Compatibility:**
+
+- Existing behavior preserved: no change to any existing formatter, flag
+  default, or output contract.
+- Intentional break: none.
+
+**Validation:**
+
+- Tests: golden-file tests in `internal/output/testdata` covering objects,
+  uniform object arrays (tabular form), non-uniform arrays (expanded list form),
+  nested structures, primitive arrays, empty arrays/objects, null, booleans,
+  numeric normalization, and strings requiring quoting. Behavior tests that
+  `-o toon` is selectable and composes with `-f`.
+- Docs/help: `site/` output docs gain a TOON section; flag help updates
+  automatically.
+- Manual checks: confirm token reduction on a representative list response vs
+  minified JSON, and confirm parse-back fidelity against the reference decoder.
+
+## Architecture Fit
+
+Output formatting is a clean, first-class extension point. A formatter
+implements `output.Formatter` (`internal/output/format.go`) and is registered in
+`DefaultFormatters()`. Library-backed formatters are already house style — the
+CBOR formatter wraps `github.com/fxamacker/cbor/v2`.
+
+The new `TOONFormatter` will:
+
+- Implement `Formatter.Format` to encode `resp.Body`.
+- Implement `ValueFormatter.FormatValue` so it works for filtered values and
+  paginated/streamed item values — the cases where TOON's tabular form is most
+  valuable.
+
+It will **not** implement `ValueStream`/`FramedValueStreamFormatter` in v1.
+True tabular TOON needs the full array in hand to emit one header and a known
+row count (`key[N]{...}`), which is incompatible with incremental row-at-a-time
+streaming. Streamed output falls back to per-value encoding, which is documented
+rather than silently degraded.
+
+## Key Decision: Hand-Roll the Encoder (No New Dependency)
+
+**Decision: implement a self-contained, output-only TOON encoder in
+`internal/output`, pinned to spec v3.3, locked with golden tests.**
+
+Rationale:
+
+- The only official Go implementation (`github.com/toon-format/toon-go`) is
+  MIT-licensed but very early: no tagged release, single author, ~9 commits, a
+  module pseudo-version only. That is a different maturity tier from the CBOR
+  precedent (`github.com/fxamacker/cbor`, mature and widely used) and a
+  realistic merge blocker for a security-sensitive CLI's output surface.
+- The encoder is output-only and bounded: objects, inline primitive arrays,
+  tabular uniform-object arrays, expanded-list fallback, plus the quoting and
+  number-canonicalization rules. The spec is precise enough to implement
+  directly.
+- Owning the code keeps the dependency footprint flat and makes the output
+  contract fully auditable in-repo.
+
+Cost and mitigation:
+
+- We own spec-conformance and any future spec drift. Mitigation: pin to spec
+  v3.3 explicitly in code comments and the design doc, and lock observable
+  output with golden tests so behavior changes are deliberate and reviewable.
+
+Alternative considered — vendor `toon-format/toon-go`: less code to own and
+tracks the spec, but the dependency's immaturity outweighs that for an upstream
+contribution. Revisit if/when the library reaches a stable tagged release.
+
+## Token Benchmark
+
+Tokens counted with `tiktoken` `o200k_base` (GPT-4o-class), rendering each
+fixture through the real Restish formatters. The four fixtures:
+
+- **Uniform 5** — a real `api.rest.sh/images` response: 5 records, each a flat
+  object with three short string fields (`format`, `name`, `self`). The smallest
+  realistic list; shows that declaring the header once pays off even at a few
+  rows.
+- **Uniform 100** — 100 synthetic user records, each a flat object with mixed
+  scalar types: `id` (int), `name`/`email`/`role` (strings), `active` (bool),
+  `age` (int). The canonical list-endpoint shape at scale: TOON names the six
+  fields once, then streams 100 comma-separated rows.
+- **Nested 40** — 40 synthetic objects that are deliberately *not* tabular: each
+  has a nested `meta` object (a `created` timestamp, a variable-length `tags`
+  array, an `owner` sub-object) and a `settings` object with a nested
+  `thresholds` map. Non-uniform shape plus nested values force TOON's
+  expanded-list form, where per-line indentation is the dominant cost.
+- **String-heavy** — the real `sedric-labs deployments-list-for-model` response:
+  3 deployment objects, each dominated by a ~1.5 KB embedded LLM `prompt` string
+  plus nested per-version `configuration` maps. Represents payloads where one
+  large leaf string dwarfs the structure, so format choice barely matters.
+
+| Format | Uniform 5 | Uniform 100 | Nested 40 | String-heavy |
+| --- | --: | --: | --: | --: |
+| **toon** | **71** | **1,689** | **3,343** | **2,048** |
+| json (compact) | 96 | 2,903 | 2,762 | 1,978 |
+| json (pretty, `-o json`) | 155 | 5,002 | 4,842 | 2,184 |
+| yaml | 108 | 3,700 | 3,360 | 2,009 |
+| ndjson | 98 | 3,000 | 2,800 | 2,191 |
+| gron | 196 | 6,403 | 6,783 | 2,560 |
+| table ¹ | 141 | 2,743 | 1,556 | 686 |
+| lines ² | n/a | n/a | n/a | n/a |
+| cbor ³ | 288 B | 8,311 B | 6,359 B | 8,121 B |
+
+TOON token savings vs each text format (negative = TOON uses more):
+
+| vs | Uniform 5 | Uniform 100 | Nested 40 | String-heavy |
+| --- | --: | --: | --: | --: |
+| json (compact) | +26% | +42% | −21% | −4% |
+| json (pretty) | +54% | +66% | +31% | +6% |
+| yaml | +34% | +54% | +1% | −2% |
+| ndjson | +28% | +44% | −19% | +7% |
+| gron | +64% | +74% | +51% | +20% |
+| table ¹ | +50% | +38% | −115% | −199% |
+
+¹ `table` truncates long cell values (~40 chars) and flattens nested objects, so
+its low counts on the nested and string-heavy shapes reflect **dropped data**,
+not efficiency. It is also human-only ("not stable machine parsing") and loses
+type fidelity (`null` vs `"null"`, `3` vs `"3"` render identically).
+² `lines` only renders arrays of scalars; it rejects record/object arrays.
+³ `cbor` is binary (bytes shown, not tokens) and is not consumable as LLM text.
+
+`cl100k_base` (GPT-4) agrees within ~1 point on the uniform cases. Takeaways:
+
+- On uniform record collections — the shape of REST list endpoints — TOON beats
+  every other text format, and the win **grows with row count** (+26% → +42% vs
+  compact JSON from 5 to 100 rows).
+- On nested/irregular or string-dominated payloads, compact JSON and ndjson are
+  slightly smaller than TOON (its per-line indentation outweighs the brace/quote
+  savings). This is why the format is opt-in and the docs steer users to project
+  to a uniform list first.
+- TOON beats pretty JSON, YAML, and gron on every shape tested.
+
+## Tradeoffs / Honest Limitations
+
+- **Savings are shape-dependent.** TOON wins big on uniform arrays of objects,
+  scaling with row count. For deeply nested or irregular JSON, compact JSON can
+  be *smaller* than TOON (its indentation overhead exceeds the brace/quote
+  savings). Docs state this and steer users to `-f` projection first.
+- **Filtering is the bigger lever.** `-f` (jq/shorthand) drops unneeded fields
+  entirely and usually saves more tokens than re-encoding. TOON is complementary,
+  not a replacement; the docs lead with `-f ... -o toon`.
+- **Model comprehension is the real open risk.** Token savings only pay off if
+  the agent parses TOON as reliably as JSON. The format's own benchmarks claim
+  parity-or-better on tabular retrieval; we present this as a measured claim, not
+  a guarantee, and recommend users validate on their own model/data.
+
+## Future Work
+
+- **Tabular output for paginated collections.** Streamed items encode one
+  document each, so a large paginated list never becomes a single table. Verified
+  that `--rsh-collect -o toon` materializes the full array first and produces one
+  table; documented as the recommended path for large list endpoints. True
+  per-row streaming is spec-constrained (the `[N]` header needs the row count
+  upfront).
+- **Delimiter selection.** Tab/pipe delimiters can avoid quoting comma-bearing
+  values; revisit only if users hit it.
+
+### Rejected: narrower indentation
+
+Measured 1-space indentation: it saves ~6% tokens on tabular output (uniform-100:
+1689 → 1589 with `o200k_base`) but **breaks the expanded-list form**. The dash
+list-item marker `- ` is two characters wide and is deliberately coupled to the
+two-space indent so a list item's continuation fields align under its first
+field. At one-space indent that alignment is off by a column, producing
+structurally ambiguous output. The tabular gain is not worth correctness loss on
+the non-uniform path, so indentation stays at the spec default of two.
+
+## Open Questions
+
+- Should `-o toon` emit a trailing newline (json/gron do) — yes, for consistency
+  with other structured formatters, even though the TOON document itself ends
+  without one.
+
+## References
+
+- TOON spec: https://github.com/toon-format/spec
+- Official Go implementation: https://github.com/toon-format/toon-go
+- Related: design 003 (content types), 009 (response normalization and output),
+  010 (filtering and projection), 023 (restish-mcp plugin).

--- a/docs/design/041-toon-output-format.md
+++ b/docs/design/041-toon-output-format.md
@@ -11,9 +11,9 @@ models.
 The motivating workflow is using Restish as the tool surface for an LLM agent
 (in place of, or alongside, an MCP server — see design 023). In that setup every
 response the agent reads, and every list it pages through, costs input tokens.
-TOON's tabular encoding of uniform object arrays declares field names once and
-streams rows, which materially cuts token count for the list/collection
-responses that dominate REST APIs.
+TOON's tabular encoding of uniform arrays of flat, primitive-valued objects
+declares field names once and streams rows, which materially cuts token count
+for the list/collection responses that dominate REST APIs.
 
 This is an **output-only, opt-in, additive** change: a new value for
 `-o/--rsh-output-format`. It introduces no new default behavior and no
@@ -30,8 +30,9 @@ representation of the same data.
 **Goals:**
 
 - Provide `-o toon` to render response bodies as TOON.
-- Make the largest savings reachable where they exist: uniform arrays of objects
-  (list endpoints, or `-f` projections that produce such lists).
+- Make the largest savings reachable where they exist: uniform arrays of flat,
+  primitive-valued objects (list endpoints, or `-f` projections that produce
+  such lists).
 - Compose with existing filtering, pagination, and streaming, since the agent
   use case almost always projects before encoding.
 - Track a pinned TOON spec version with official encode fixtures and focused
@@ -77,11 +78,11 @@ representation of the same data.
 **Validation:**
 
 - Tests: formatter tests plus official TOON encode fixtures under
-  `internal/output/testdata` covering objects, uniform object arrays (tabular
-  form), non-uniform arrays (expanded list form), nested structures, primitive
-  arrays, empty arrays/objects, null, booleans, numeric normalization, and
-  strings requiring quoting. Behavior tests verify that `-o toon` is selectable
-  and composes with `-f`.
+  `internal/output/testdata` covering objects, flat primitive-valued object
+  arrays (tabular form), non-uniform arrays (expanded list form), nested
+  structures, primitive arrays, empty arrays/objects, null, booleans, numeric
+  normalization, and strings requiring quoting. Behavior tests verify that
+  `-o toon` is selectable and composes with `-f`.
 - Docs/help: `site/` output docs gain a TOON section; flag help updates
   automatically.
 - Manual checks: confirm token reduction on a representative list response vs
@@ -121,9 +122,9 @@ Rationale:
   precedent (`github.com/fxamacker/cbor`, mature and widely used) and a
   realistic merge blocker for a security-sensitive CLI's output surface.
 - The encoder is output-only and bounded: objects, inline primitive arrays,
-  tabular uniform-object arrays, expanded-list fallback, plus the quoting and
-  number-canonicalization rules. The spec is precise enough to implement
-  directly.
+  tabular flat primitive-valued object arrays, expanded-list fallback, plus the
+  quoting and number-canonicalization rules. The spec is precise enough to
+  implement directly.
 - Owning the code keeps the dependency footprint flat and makes the output
   contract fully auditable in-repo.
 
@@ -204,10 +205,11 @@ type fidelity (`null` vs `"null"`, `3` vs `"3"` render identically).
 
 ## Tradeoffs / Honest Limitations
 
-- **Savings are shape-dependent.** TOON wins big on uniform arrays of objects,
-  scaling with row count. For deeply nested or irregular JSON, compact JSON can
-  be *smaller* than TOON (its indentation overhead exceeds the brace/quote
-  savings). Docs state this and steer users to `-f` projection first.
+- **Savings are shape-dependent.** TOON wins big on uniform arrays of flat,
+  primitive-valued objects, scaling with row count. For deeply nested or
+  irregular JSON, compact JSON can be *smaller* than TOON (its indentation
+  overhead exceeds the brace/quote savings). Docs state this and steer users to
+  `-f` projection first.
 - **Filtering is the bigger lever.** `-f` (jq/shorthand) drops unneeded fields
   entirely and usually saves more tokens than re-encoding. TOON is complementary,
   not a replacement; the docs lead with `-f ... -o toon`.

--- a/docs/design/041-toon-output-format.md
+++ b/docs/design/041-toon-output-format.md
@@ -34,8 +34,8 @@ representation of the same data.
   (list endpoints, or `-f` projections that produce such lists).
 - Compose with existing filtering, pagination, and streaming, since the agent
   use case almost always projects before encoding.
-- Track a pinned TOON spec version with golden-file tests so output is a stable,
-  auditable contract.
+- Track a pinned TOON spec version with official encode fixtures and focused
+  formatter tests so output is a stable, auditable contract.
 
 **Non-goals:**
 
@@ -76,11 +76,12 @@ representation of the same data.
 
 **Validation:**
 
-- Tests: golden-file tests in `internal/output/testdata` covering objects,
-  uniform object arrays (tabular form), non-uniform arrays (expanded list form),
-  nested structures, primitive arrays, empty arrays/objects, null, booleans,
-  numeric normalization, and strings requiring quoting. Behavior tests that
-  `-o toon` is selectable and composes with `-f`.
+- Tests: formatter tests plus official TOON encode fixtures under
+  `internal/output/testdata` covering objects, uniform object arrays (tabular
+  form), non-uniform arrays (expanded list form), nested structures, primitive
+  arrays, empty arrays/objects, null, booleans, numeric normalization, and
+  strings requiring quoting. Behavior tests verify that `-o toon` is selectable
+  and composes with `-f`.
 - Docs/help: `site/` output docs gain a TOON section; flag help updates
   automatically.
 - Manual checks: confirm token reduction on a representative list response vs
@@ -109,7 +110,8 @@ rather than silently degraded.
 ## Key Decision: Hand-Roll the Encoder (No New Dependency)
 
 **Decision: implement a self-contained, output-only TOON encoder in
-`internal/output`, pinned to spec v3.3, locked with golden tests.**
+`internal/output`, pinned to spec v3.3, locked with official encode fixtures
+and focused formatter tests.**
 
 Rationale:
 
@@ -129,7 +131,8 @@ Cost and mitigation:
 
 - We own spec-conformance and any future spec drift. Mitigation: pin to spec
   v3.3 explicitly in code comments and the design doc, and lock observable
-  output with golden tests so behavior changes are deliberate and reviewable.
+  output with official encode fixtures and focused formatter tests so behavior
+  changes are deliberate and reviewable.
 
 Alternative considered — vendor `toon-format/toon-go`: less code to own and
 tracks the spec, but the dependency's immaturity outweighs that for an upstream

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -170,6 +170,7 @@ were a recurring source of remediation work.
 - [038-doctor-and-health-checks.md](./038-doctor-and-health-checks.md) - Operator diagnostics, health checks, stderr behavior, bounded network probing, and v1 migration recovery.
 - [039-http-cache-spike.md](./039-http-cache-spike.md) - Spike comparing the current HTTP cache transport with a maintained fork and defining acceptance tests for a safer cache swap.
 - [040-generated-docs-and-drift-checks.md](./040-generated-docs-and-drift-checks.md) - Maintainer docs generation, inline generated regions, plugin-binary command references, and CI drift checks.
+- [041-toon-output-format.md](./041-toon-output-format.md) - Token-dense TOON output formatter for feeding responses to LLM agents, including the hand-rolled encoder decision and shape-dependent savings.
 
 **Extensibility**
 

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -1381,17 +1381,27 @@ func (c *CLI) selectFormatter(cmd *cobra.Command, fmtName string, tty bool) (out
 	return formatter, nil
 }
 
+// outputFormatSuggestion returns the format name closest to a mistyped name, or
+// "" when nothing is within edit distance 2 or the nearest distance is shared by
+// more than one format (an ambiguous guess is worse than none). Picking the
+// strictly nearest match keeps suggestions stable as more formats are added.
 func outputFormatSuggestion(name string, fmts map[string]output.Formatter) string {
-	var matches []string
+	best := ""
+	bestDist := 3 // only distances <= 2 are considered
+	tie := false
 	for candidate := range fmts {
-		if levenshteinDistance(name, candidate) <= 2 {
-			matches = append(matches, candidate)
+		switch d := levenshteinDistance(name, candidate); {
+		case d > 2:
+		case d < bestDist:
+			best, bestDist, tie = candidate, d, false
+		case d == bestDist:
+			tie = true
 		}
 	}
-	if len(matches) == 1 {
-		return matches[0]
+	if tie {
+		return ""
 	}
-	return ""
+	return best
 }
 
 func explicitAutoOutputFormat(gf GlobalFlags) bool {

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -302,6 +302,28 @@ func TestFilteredStructuredOutputPrettyByDefault(t *testing.T) {
 	}
 }
 
+func TestTOONOutputRendersResponseBody(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	useJSONResponse(c, 200, `[{"name":"Ada","format":"json"},{"name":"Bob","format":"xml"}]`)
+	if err := c.Run([]string{"restish", "get", "-o", "toon", "https://api.example.com/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := out.String(), "[2]{format,name}:\n  json,Ada\n  xml,Bob\n"; got != want {
+		t.Fatalf("toon output = %q, want %q", got, want)
+	}
+}
+
+func TestTOONOutputRendersFilteredValue(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	useJSONResponse(c, 200, `{"items":[{"id":1,"name":"Ada"},{"id":2,"name":"Bob"}],"ignored":true}`)
+	if err := c.Run([]string{"restish", "get", "-f", "body.items", "-o", "toon", "https://api.example.com/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := out.String(), "[2]{id,name}:\n  1,Ada\n  2,Bob\n"; got != want {
+		t.Fatalf("filtered toon output = %q, want %q", got, want)
+	}
+}
+
 func TestFilteredTTYOutputColorsPrettyJSONByDefault(t *testing.T) {
 	t.Setenv("NO_COLOR", "")
 	t.Setenv("NOCOLOR", "")

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -459,6 +459,27 @@ func TestUnknownOutputFormatSuggestsNearestFormat(t *testing.T) {
 	}
 }
 
+// TestUnknownOutputFormatAmbiguousOmitsSuggestion verifies that a typo equally
+// near two formats (here "tron" is one edit from both "gron" and "toon") lists
+// the available formats without an ambiguous "did you mean" guess.
+func TestUnknownOutputFormatAmbiguousOmitsSuggestion(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		t.Fatal("request should not be sent with unknown output format")
+		return nil, nil
+	})
+	err := c.Run([]string{"restish", "get", "-o", "tron", "https://api.example.com/items"})
+	if err == nil {
+		t.Fatal("expected error for unknown output format")
+	}
+	if !strings.Contains(err.Error(), `unknown output format "tron"`) {
+		t.Fatalf("expected unknown-format error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "did you mean") {
+		t.Fatalf("expected no suggestion for ambiguous typo, got: %v", err)
+	}
+}
+
 // TestPrintResponseHeadersOnly verifies that --rsh-print h writes only
 // response headers and no body.
 func TestPrintResponseHeadersOnly(t *testing.T) {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -58,6 +58,7 @@ func DefaultFormatters() map[string]Formatter {
 		"ndjson": &NDJSONFormatter{},
 		"table":  &TableFormatter{},
 		"gron":   &GronFormatter{},
+		"toon":   &TOONFormatter{},
 		"cbor":   &CBORFormatter{},
 		"image":  &ImageFormatter{},
 		"yaml":   &YAMLFormatter{},

--- a/internal/output/testdata/toon/SOURCE.md
+++ b/internal/output/testdata/toon/SOURCE.md
@@ -1,0 +1,14 @@
+# TOON Fixtures
+
+The files under `encode/` are copied from the official TOON specification
+repository:
+
+https://github.com/toon-format/spec/tree/main/tests/fixtures/encode
+
+Copied from `toon-format/spec` tag `v3.3.0`, commit
+`07161ccc84242a5571f14d33504fc0b4b84da0b2`.
+
+They are MIT-licensed as part of the upstream `toon-format/spec` repository.
+Restish runs the default encoder-profile cases and skips upstream fixtures for
+encoder options it does not currently expose, such as custom delimiters and key
+folding.

--- a/internal/output/testdata/toon/encode/arrays-nested.json
+++ b/internal/output/testdata/toon/encode/arrays-nested.json
@@ -1,0 +1,105 @@
+{
+  "version": "3.1",
+  "category": "encode",
+  "description": "Nested and mixed array encoding - arrays of arrays, mixed type arrays, root arrays",
+  "tests": [
+    {
+      "name": "encodes nested arrays of primitives",
+      "input": {
+        "pairs": [["a", "b"], ["c", "d"]]
+      },
+      "expected": "pairs[2]:\n  - [2]: a,b\n  - [2]: c,d",
+      "specSection": "9.2"
+    },
+    {
+      "name": "quotes strings containing delimiters in nested arrays",
+      "input": {
+        "pairs": [["a", "b"], ["c,d", "e:f", "true"]]
+      },
+      "expected": "pairs[2]:\n  - [2]: a,b\n  - [3]: \"c,d\",\"e:f\",\"true\"",
+      "specSection": "9.2"
+    },
+    {
+      "name": "encodes empty inner arrays",
+      "input": {
+        "pairs": [[], []]
+      },
+      "expected": "pairs[2]:\n  - [0]:\n  - [0]:",
+      "specSection": "9.2"
+    },
+    {
+      "name": "encodes mixed-length inner arrays",
+      "input": {
+        "pairs": [[1], [2, 3]]
+      },
+      "expected": "pairs[2]:\n  - [1]: 1\n  - [2]: 2,3",
+      "specSection": "9.2"
+    },
+    {
+      "name": "encodes root-level primitive array",
+      "input": ["x", "y", "true", true, 10],
+      "expected": "[5]: x,y,\"true\",true,10",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes root-level array of uniform objects in tabular format",
+      "input": [{ "id": 1 }, { "id": 2 }],
+      "expected": "[2]{id}:\n  1\n  2",
+      "specSection": "9.3"
+    },
+    {
+      "name": "encodes root-level array of non-uniform objects in list format",
+      "input": [{ "id": 1 }, { "id": 2, "name": "Ada" }],
+      "expected": "[2]:\n  - id: 1\n  - id: 2\n    name: Ada",
+      "specSection": "9.4"
+    },
+    {
+      "name": "encodes root-level array mixing primitive, object, and array of objects in list format",
+      "input": ["summary", { "id": 1, "name": "Ada" }, [{ "id": 2 }, { "status": "draft" }]],
+      "expected": "[3]:\n  - summary\n  - id: 1\n    name: Ada\n  - [2]:\n    - id: 2\n    - status: draft",
+      "specSection": "9.4"
+    },
+    {
+      "name": "encodes root-level arrays of arrays",
+      "input": [[1, 2], []],
+      "expected": "[2]:\n  - [2]: 1,2\n  - [0]:",
+      "specSection": "9.2"
+    },
+    {
+      "name": "encodes empty root-level array",
+      "input": [],
+      "expected": "[]",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes complex nested structure",
+      "input": {
+        "user": {
+          "id": 123,
+          "name": "Ada",
+          "tags": ["reading", "gaming"],
+          "active": true,
+          "prefs": []
+        }
+      },
+      "expected": "user:\n  id: 123\n  name: Ada\n  tags[2]: reading,gaming\n  active: true\n  prefs: []",
+      "specSection": "8"
+    },
+    {
+      "name": "uses list format for arrays mixing primitives and objects",
+      "input": {
+        "items": [1, { "a": 1 }, "text"]
+      },
+      "expected": "items[3]:\n  - 1\n  - a: 1\n  - text",
+      "specSection": "9.4"
+    },
+    {
+      "name": "uses list format for arrays mixing objects and arrays",
+      "input": {
+        "items": [{ "a": 1 }, [1, 2]]
+      },
+      "expected": "items[2]:\n  - a: 1\n  - [2]: 1,2",
+      "specSection": "9.4"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/arrays-objects.json
+++ b/internal/output/testdata/toon/encode/arrays-objects.json
@@ -1,0 +1,168 @@
+{
+  "version": "3.1",
+  "category": "encode",
+  "description": "Arrays of objects encoding - list format for non-uniform objects and complex structures",
+  "tests": [
+    {
+      "name": "uses list format for objects with different fields",
+      "input": {
+        "items": [
+          { "id": 1, "name": "First" },
+          { "id": 2, "name": "Second", "extra": true }
+        ]
+      },
+      "expected": "items[2]:\n  - id: 1\n    name: First\n  - id: 2\n    name: Second\n    extra: true",
+      "specSection": "9.4"
+    },
+    {
+      "name": "uses list format for objects with nested values",
+      "input": {
+        "items": [
+          { "id": 1, "nested": { "x": 1 } }
+        ]
+      },
+      "expected": "items[1]:\n  - id: 1\n    nested:\n      x: 1",
+      "specSection": "9.4"
+    },
+    {
+      "name": "preserves field order in list items - array first",
+      "input": {
+        "items": [{ "nums": [1, 2, 3], "name": "Ada" }]
+      },
+      "expected": "items[1]:\n  - nums[3]: 1,2,3\n    name: Ada",
+      "specSection": "10"
+    },
+    {
+      "name": "preserves field order in list items - primitive first",
+      "input": {
+        "items": [{ "name": "Ada", "nums": [1, 2, 3] }]
+      },
+      "expected": "items[1]:\n  - name: Ada\n    nums[3]: 1,2,3",
+      "specSection": "10"
+    },
+    {
+      "name": "uses list format for objects containing arrays of arrays",
+      "input": {
+        "items": [
+          { "matrix": [[1, 2], [3, 4]], "name": "grid" }
+        ]
+      },
+      "expected": "items[1]:\n  - matrix[2]:\n      - [2]: 1,2\n      - [2]: 3,4\n    name: grid",
+      "specSection": "10"
+    },
+    {
+      "name": "uses tabular format for nested uniform object arrays",
+      "input": {
+        "items": [
+          { "users": [{ "id": 1, "name": "Ada" }, { "id": 2, "name": "Bob" }], "status": "active" }
+        ]
+      },
+      "expected": "items[1]:\n  - users[2]{id,name}:\n      1,Ada\n      2,Bob\n    status: active",
+      "specSection": "10",
+      "note": "YAML-style encoding for list-item objects with tabular array as first field"
+    },
+    {
+      "name": "uses list format for nested object arrays with mismatched keys",
+      "input": {
+        "items": [
+          { "users": [{ "id": 1, "name": "Ada" }, { "id": 2 }], "status": "active" }
+        ]
+      },
+      "expected": "items[1]:\n  - users[2]:\n      - id: 1\n        name: Ada\n      - id: 2\n    status: active",
+      "specSection": "10"
+    },
+    {
+      "name": "uses list format for objects with multiple array fields",
+      "input": {
+        "items": [{ "nums": [1, 2], "tags": ["a", "b"], "name": "test" }]
+      },
+      "expected": "items[1]:\n  - nums[2]: 1,2\n    tags[2]: a,b\n    name: test",
+      "specSection": "10"
+    },
+    {
+      "name": "uses list format for objects with only array fields",
+      "input": {
+        "items": [{ "nums": [1, 2, 3], "tags": ["a", "b"] }]
+      },
+      "expected": "items[1]:\n  - nums[3]: 1,2,3\n    tags[2]: a,b",
+      "specSection": "10"
+    },
+    {
+      "name": "encodes objects with empty arrays in list format",
+      "input": {
+        "items": [
+          { "name": "Ada", "data": [] }
+        ]
+      },
+      "expected": "items[1]:\n  - name: Ada\n    data: []",
+      "specSection": "10"
+    },
+    {
+      "name": "uses canonical encoding for multi-field list-item objects with tabular arrays",
+      "input": {
+        "items": [{ "users": [{ "id": 1 }, { "id": 2 }], "note": "x" }]
+      },
+      "expected": "items[1]:\n  - users[2]{id}:\n      1\n      2\n    note: x",
+      "specSection": "10",
+      "note": "Tabular header on hyphen line with rows at depth +2 and sibling fields at depth +1"
+    },
+    {
+      "name": "uses canonical encoding for single-field list-item tabular arrays",
+      "input": {
+        "items": [{ "users": [{ "id": 1, "name": "Ada" }, { "id": 2, "name": "Bob" }] }]
+      },
+      "expected": "items[1]:\n  - users[2]{id,name}:\n      1,Ada\n      2,Bob",
+      "specSection": "10",
+      "note": "Tabular header on hyphen line with rows at depth +2"
+    },
+    {
+      "name": "places empty arrays on hyphen line when first",
+      "input": {
+        "items": [{ "data": [], "name": "x" }]
+      },
+      "expected": "items[1]:\n  - data: []\n    name: x",
+      "specSection": "10"
+    },
+    {
+      "name": "encodes empty object list items as bare hyphen",
+      "input": {
+        "items": ["first", "second", {}]
+      },
+      "expected": "items[3]:\n  - first\n  - second\n  -",
+      "specSection": "10",
+      "note": "Empty object list items encode as a single \"-\" line at the list-item depth"
+    },
+    {
+      "name": "uses field order from first object for tabular headers",
+      "input": {
+        "items": [
+          { "a": 1, "b": 2, "c": 3 },
+          { "c": 30, "b": 20, "a": 10 }
+        ]
+      },
+      "expected": "items[2]{a,b,c}:\n  1,2,3\n  10,20,30",
+      "specSection": "9.3"
+    },
+    {
+      "name": "uses list format when one object has nested field",
+      "input": {
+        "items": [
+          { "id": 1, "data": "string" },
+          { "id": 2, "data": { "nested": true } }
+        ]
+      },
+      "expected": "items[2]:\n  - id: 1\n    data: string\n  - id: 2\n    data:\n      nested: true",
+      "specSection": "9.4"
+    },
+    {
+      "name": "uses expanded list for arrays containing empty objects",
+      "input": {
+        "items": [{}, {}]
+      },
+      "expected": "items[2]:\n  -\n  -",
+      "specSection": "9.4",
+      "minSpecVersion": "3.2",
+      "note": "Empty objects {} MUST NOT use tabular form per §9.3; encoded via §9.4 expanded list with bare hyphen markers per §10"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/arrays-primitive.json
+++ b/internal/output/testdata/toon/encode/arrays-primitive.json
@@ -1,0 +1,103 @@
+{
+  "version": "3.1",
+  "category": "encode",
+  "description": "Primitive array encoding - inline arrays of strings, numbers, booleans",
+  "tests": [
+    {
+      "name": "encodes string arrays inline",
+      "input": {
+        "tags": ["reading", "gaming"]
+      },
+      "expected": "tags[2]: reading,gaming",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes number arrays inline",
+      "input": {
+        "nums": [1, 2, 3]
+      },
+      "expected": "nums[3]: 1,2,3",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes mixed primitive arrays inline",
+      "input": {
+        "data": ["x", "y", true, 10]
+      },
+      "expected": "data[4]: x,y,true,10",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes empty arrays",
+      "input": {
+        "items": []
+      },
+      "expected": "items: []",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes empty string keys for inline arrays",
+      "input": {
+        "": [1, 2, 3]
+      },
+      "expected": "\"\"[3]: 1,2,3",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes empty string keys for empty arrays",
+      "input": {
+        "": []
+      },
+      "expected": "\"\": []",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes empty string in single-item array",
+      "input": {
+        "items": [""]
+      },
+      "expected": "items[1]: \"\"",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes empty string in multi-item array",
+      "input": {
+        "items": ["a", "", "b"]
+      },
+      "expected": "items[3]: a,\"\",b",
+      "specSection": "9.1"
+    },
+    {
+      "name": "encodes whitespace-only strings in arrays",
+      "input": {
+        "items": [" ", "  "]
+      },
+      "expected": "items[2]: \" \",\"  \"",
+      "specSection": "9.1"
+    },
+    {
+      "name": "quotes array strings with comma",
+      "input": {
+        "items": ["a", "b,c", "d:e"]
+      },
+      "expected": "items[3]: a,\"b,c\",\"d:e\"",
+      "specSection": "9.1"
+    },
+    {
+      "name": "quotes strings that look like booleans in arrays",
+      "input": {
+        "items": ["x", "true", "42", "-3.14"]
+      },
+      "expected": "items[4]: x,\"true\",\"42\",\"-3.14\"",
+      "specSection": "9.1"
+    },
+    {
+      "name": "quotes strings with structural meanings in arrays",
+      "input": {
+        "items": ["[5]", "- item", "{key}"]
+      },
+      "expected": "items[3]: \"[5]\",\"- item\",\"{key}\"",
+      "specSection": "9.1"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/arrays-tabular.json
+++ b/internal/output/testdata/toon/encode/arrays-tabular.json
@@ -1,0 +1,73 @@
+{
+  "version": "1.4",
+  "category": "encode",
+  "description": "Tabular array encoding - arrays of uniform objects with primitive values",
+  "tests": [
+    {
+      "name": "encodes arrays of uniform objects in tabular format",
+      "input": {
+        "items": [
+          { "sku": "A1", "qty": 2, "price": 9.99 },
+          { "sku": "B2", "qty": 1, "price": 14.5 }
+        ]
+      },
+      "expected": "items[2]{sku,qty,price}:\n  A1,2,9.99\n  B2,1,14.5",
+      "specSection": "9.3"
+    },
+    {
+      "name": "encodes null values in tabular format",
+      "input": {
+        "items": [
+          { "id": 1, "value": null },
+          { "id": 2, "value": "test" }
+        ]
+      },
+      "expected": "items[2]{id,value}:\n  1,null\n  2,test",
+      "specSection": "9.3"
+    },
+    {
+      "name": "quotes strings containing delimiters in tabular rows",
+      "input": {
+        "items": [
+          { "sku": "A,1", "desc": "cool", "qty": 2 },
+          { "sku": "B2", "desc": "wip: test", "qty": 1 }
+        ]
+      },
+      "expected": "items[2]{sku,desc,qty}:\n  \"A,1\",cool,2\n  B2,\"wip: test\",1",
+      "specSection": "9.3"
+    },
+    {
+      "name": "quotes ambiguous strings in tabular rows",
+      "input": {
+        "items": [
+          { "id": 1, "status": "true" },
+          { "id": 2, "status": "false" }
+        ]
+      },
+      "expected": "items[2]{id,status}:\n  1,\"true\"\n  2,\"false\"",
+      "specSection": "9.3"
+    },
+    {
+      "name": "encodes tabular arrays with keys needing quotes",
+      "input": {
+        "items": [
+          { "order:id": 1, "full name": "Ada" },
+          { "order:id": 2, "full name": "Bob" }
+        ]
+      },
+      "expected": "items[2]{\"order:id\",\"full name\"}:\n  1,Ada\n  2,Bob",
+      "specSection": "9.3"
+    },
+    {
+      "name": "encodes tabular arrays with empty string keys",
+      "input": {
+        "": [
+          { "id": 1, "name": "Ada" },
+          { "id": 2, "name": "Bob" }
+        ]
+      },
+      "expected": "\"\"[2]{id,name}:\n  1,Ada\n  2,Bob",
+      "specSection": "9.3"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/delimiters.json
+++ b/internal/output/testdata/toon/encode/delimiters.json
@@ -1,0 +1,253 @@
+{
+  "version": "1.4",
+  "category": "encode",
+  "description": "Delimiter options - tab and pipe delimiters, delimiter-aware quoting",
+  "tests": [
+    {
+      "name": "encodes primitive arrays with tab delimiter",
+      "input": {
+        "tags": ["reading", "gaming", "coding"]
+      },
+      "expected": "tags[3\t]: reading\tgaming\tcoding",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes primitive arrays with pipe delimiter",
+      "input": {
+        "tags": ["reading", "gaming", "coding"]
+      },
+      "expected": "tags[3|]: reading|gaming|coding",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes primitive arrays with comma delimiter",
+      "input": {
+        "tags": ["reading", "gaming", "coding"]
+      },
+      "expected": "tags[3]: reading,gaming,coding",
+      "options": {
+        "delimiter": ","
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes tabular arrays with tab delimiter",
+      "input": {
+        "items": [
+          { "sku": "A1", "qty": 2, "price": 9.99 },
+          { "sku": "B2", "qty": 1, "price": 14.5 }
+        ]
+      },
+      "expected": "items[2\t]{sku\tqty\tprice}:\n  A1\t2\t9.99\n  B2\t1\t14.5",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes tabular arrays with pipe delimiter",
+      "input": {
+        "items": [
+          { "sku": "A1", "qty": 2, "price": 9.99 },
+          { "sku": "B2", "qty": 1, "price": 14.5 }
+        ]
+      },
+      "expected": "items[2|]{sku|qty|price}:\n  A1|2|9.99\n  B2|1|14.5",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes nested arrays with tab delimiter",
+      "input": {
+        "pairs": [["a", "b"], ["c", "d"]]
+      },
+      "expected": "pairs[2\t]:\n  - [2\t]: a\tb\n  - [2\t]: c\td",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes nested arrays with pipe delimiter",
+      "input": {
+        "pairs": [["a", "b"], ["c", "d"]]
+      },
+      "expected": "pairs[2|]:\n  - [2|]: a|b\n  - [2|]: c|d",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes root-level array with tab delimiter",
+      "input": ["x", "y", "z"],
+      "expected": "[3\t]: x\ty\tz",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes root-level array with pipe delimiter",
+      "input": ["x", "y", "z"],
+      "expected": "[3|]: x|y|z",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes root-level array of objects with tab delimiter",
+      "input": [{ "id": 1 }, { "id": 2 }],
+      "expected": "[2\t]{id}:\n  1\n  2",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "encodes root-level array of objects with pipe delimiter",
+      "input": [{ "id": 1 }, { "id": 2 }],
+      "expected": "[2|]{id}:\n  1\n  2",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "quotes strings containing tab delimiter",
+      "input": {
+        "items": ["a", "b\tc", "d"]
+      },
+      "expected": "items[3\t]: a\t\"b\\tc\"\td",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "quotes strings containing pipe delimiter",
+      "input": {
+        "items": ["a", "b|c", "d"]
+      },
+      "expected": "items[3|]: a|\"b|c\"|d",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "does not quote commas with tab delimiter",
+      "input": {
+        "items": ["a,b", "c,d"]
+      },
+      "expected": "items[2\t]: a,b\tc,d",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "does not quote commas with pipe delimiter",
+      "input": {
+        "items": ["a,b", "c,d"]
+      },
+      "expected": "items[2|]: a,b|c,d",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "quotes tabular values containing comma delimiter",
+      "input": {
+        "items": [
+          { "id": 1, "note": "a,b" },
+          { "id": 2, "note": "c,d" }
+        ]
+      },
+      "expected": "items[2]{id,note}:\n  1,\"a,b\"\n  2,\"c,d\"",
+      "options": {
+        "delimiter": ","
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "does not quote commas in tabular values with tab delimiter",
+      "input": {
+        "items": [
+          { "id": 1, "note": "a,b" },
+          { "id": 2, "note": "c,d" }
+        ]
+      },
+      "expected": "items[2\t]{id\tnote}:\n  1\ta,b\n  2\tc,d",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "does not quote commas in object values with pipe delimiter",
+      "input": {
+        "note": "a,b"
+      },
+      "expected": "note: a,b",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "does not quote commas in object values with tab delimiter",
+      "input": {
+        "note": "a,b"
+      },
+      "expected": "note: a,b",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "quotes nested array values containing pipe delimiter",
+      "input": {
+        "pairs": [["a", "b|c"]]
+      },
+      "expected": "pairs[1|]:\n  - [2|]: a|\"b|c\"",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "quotes nested array values containing tab delimiter",
+      "input": {
+        "pairs": [["a", "b\tc"]]
+      },
+      "expected": "pairs[1\t]:\n  - [2\t]: a\t\"b\\tc\"",
+      "options": {
+        "delimiter": "\t"
+      },
+      "specSection": "11"
+    },
+    {
+      "name": "preserves ambiguity quoting regardless of delimiter",
+      "input": {
+        "items": ["true", "42", "-3.14"]
+      },
+      "expected": "items[3|]: \"true\"|\"42\"|\"-3.14\"",
+      "options": {
+        "delimiter": "|"
+      },
+      "specSection": "11"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/key-folding.json
+++ b/internal/output/testdata/toon/encode/key-folding.json
@@ -1,0 +1,201 @@
+{
+  "version": "1.5",
+  "category": "encode",
+  "description": "Key folding with safe mode, depth control, collision avoidance",
+  "tests": [
+    {
+      "name": "encodes folded chain to primitive (safe mode)",
+      "input": {
+        "a": {
+          "b": {
+            "c": 1
+          }
+        }
+      },
+      "expected": "a.b.c: 1",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes folded chain with inline array",
+      "input": {
+        "data": {
+          "meta": {
+            "items": ["x", "y"]
+          }
+        }
+      },
+      "expected": "data.meta.items[2]: x,y",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes folded chain with tabular array",
+      "input": {
+        "a": {
+          "b": {
+            "items": [
+              { "id": 1, "name": "A" },
+              { "id": 2, "name": "B" }
+            ]
+          }
+        }
+      },
+      "expected": "a.b.items[2]{id,name}:\n  1,A\n  2,B",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "skips folding when segment requires quotes (safe mode)",
+      "input": {
+        "data": {
+          "full-name": {
+            "x": 1
+          }
+        }
+      },
+      "expected": "data:\n  \"full-name\":\n    x: 1",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "skips folding on sibling literal-key collision (safe mode)",
+      "input": {
+        "data": {
+          "meta": {
+            "items": [1, 2]
+          }
+        },
+        "data.meta.items": "literal"
+      },
+      "expected": "data:\n  meta:\n    items[2]: 1,2\ndata.meta.items: literal",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4",
+      "note": "Collision avoidance: folding would create duplicate key"
+    },
+    {
+      "name": "encodes partial folding with flattenDepth=2",
+      "input": {
+        "a": {
+          "b": {
+            "c": {
+              "d": 1
+            }
+          }
+        }
+      },
+      "expected": "a.b:\n  c:\n    d: 1",
+      "options": {
+        "keyFolding": "safe",
+        "flattenDepth": 2
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes full chain with flattenDepth=Infinity (default)",
+      "input": {
+        "a": {
+          "b": {
+            "c": {
+              "d": 1
+            }
+          }
+        }
+      },
+      "expected": "a.b.c.d: 1",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes standard nesting with flattenDepth=0 (no folding)",
+      "input": {
+        "a": {
+          "b": {
+            "c": 1
+          }
+        }
+      },
+      "expected": "a:\n  b:\n    c: 1",
+      "options": {
+        "keyFolding": "safe",
+        "flattenDepth": 0
+      },
+      "specSection": "13.4",
+      "note": "flattenDepth=0 disables all folding"
+    },
+    {
+      "name": "encodes standard nesting with keyFolding=off (baseline)",
+      "input": {
+        "a": {
+          "b": {
+            "c": 1
+          }
+        }
+      },
+      "expected": "a:\n  b:\n    c: 1",
+      "options": {
+        "keyFolding": "off"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes folded chain ending with empty object",
+      "input": {
+        "a": {
+          "b": {
+            "c": {}
+          }
+        }
+      },
+      "expected": "a.b.c:",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "stops folding at array boundary (not single-key object)",
+      "input": {
+        "a": {
+          "b": [1, 2]
+        }
+      },
+      "expected": "a.b[2]: 1,2",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    },
+    {
+      "name": "encodes folded chains preserving sibling field order",
+      "input": {
+        "first": {
+          "second": {
+            "third": 1
+          }
+        },
+        "simple": 2,
+        "short": {
+          "path": 3
+        }
+      },
+      "expected": "first.second.third: 1\nsimple: 2\nshort.path: 3",
+      "options": {
+        "keyFolding": "safe"
+      },
+      "specSection": "13.4"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/objects.json
+++ b/internal/output/testdata/toon/encode/objects.json
@@ -1,0 +1,238 @@
+{
+  "version": "1.4",
+  "category": "encode",
+  "description": "Object encoding - simple objects, nested objects, key encoding",
+  "tests": [
+    {
+      "name": "preserves key order in objects",
+      "input": {
+        "id": 123,
+        "name": "Ada",
+        "active": true
+      },
+      "expected": "id: 123\nname: Ada\nactive: true",
+      "specSection": "8"
+    },
+    {
+      "name": "encodes null values in objects",
+      "input": {
+        "id": 123,
+        "value": null
+      },
+      "expected": "id: 123\nvalue: null",
+      "specSection": "8"
+    },
+    {
+      "name": "encodes empty objects as empty string",
+      "input": {},
+      "expected": "",
+      "specSection": "8"
+    },
+    {
+      "name": "quotes string value with colon",
+      "input": {
+        "note": "a:b"
+      },
+      "expected": "note: \"a:b\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value with comma",
+      "input": {
+        "note": "a,b"
+      },
+      "expected": "note: \"a,b\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value with newline",
+      "input": {
+        "text": "line1\nline2"
+      },
+      "expected": "text: \"line1\\nline2\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value with embedded quotes",
+      "input": {
+        "text": "say \"hello\""
+      },
+      "expected": "text: \"say \\\"hello\\\"\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value with leading space",
+      "input": {
+        "text": " padded "
+      },
+      "expected": "text: \" padded \"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value with only spaces",
+      "input": {
+        "text": "  "
+      },
+      "expected": "text: \"  \"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value that looks like true",
+      "input": {
+        "v": "true"
+      },
+      "expected": "v: \"true\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value that looks like number",
+      "input": {
+        "v": "42"
+      },
+      "expected": "v: \"42\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string value that looks like negative decimal",
+      "input": {
+        "v": "-7.5"
+      },
+      "expected": "v: \"-7.5\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes key with colon",
+      "input": {
+        "order:id": 7
+      },
+      "expected": "\"order:id\": 7",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with brackets",
+      "input": {
+        "[index]": 5
+      },
+      "expected": "\"[index]\": 5",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with braces",
+      "input": {
+        "{key}": 5
+      },
+      "expected": "\"{key}\": 5",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with comma",
+      "input": {
+        "a,b": 1
+      },
+      "expected": "\"a,b\": 1",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with spaces",
+      "input": {
+        "full name": "Ada"
+      },
+      "expected": "\"full name\": Ada",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with leading hyphen",
+      "input": {
+        "-lead": 1
+      },
+      "expected": "\"-lead\": 1",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes key with leading and trailing spaces",
+      "input": {
+        " a ": 1
+      },
+      "expected": "\" a \": 1",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes numeric key",
+      "input": {
+        "123": "x"
+      },
+      "expected": "\"123\": x",
+      "specSection": "7.3"
+    },
+    {
+      "name": "quotes empty string key",
+      "input": {
+        "": 1
+      },
+      "expected": "\"\": 1",
+      "specSection": "7.3"
+    },
+    {
+      "name": "escapes newline in key",
+      "input": {
+        "line\nbreak": 1
+      },
+      "expected": "\"line\\nbreak\": 1",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes tab in key",
+      "input": {
+        "tab\there": 2
+      },
+      "expected": "\"tab\\there\": 2",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes quotes in key",
+      "input": {
+        "he said \"hi\"": 1
+      },
+      "expected": "\"he said \\\"hi\\\"\": 1",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes U+0004 control character in key via \\uXXXX",
+      "input": {
+        "a\u0004b": 1
+      },
+      "expected": "\"a\\u0004b\": 1",
+      "specSection": "7.1",
+      "minSpecVersion": "3.1"
+    },
+    {
+      "name": "escapes U+001F control character in key via \\uXXXX",
+      "input": {
+        "x\u001fy": 2
+      },
+      "expected": "\"x\\u001fy\": 2",
+      "specSection": "7.1",
+      "minSpecVersion": "3.1"
+    },
+    {
+      "name": "encodes deeply nested objects",
+      "input": {
+        "a": {
+          "b": {
+            "c": "deep"
+          }
+        }
+      },
+      "expected": "a:\n  b:\n    c: deep",
+      "specSection": "8"
+    },
+    {
+      "name": "encodes empty nested object",
+      "input": {
+        "user": {}
+      },
+      "expected": "user:",
+      "specSection": "8"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/primitives.json
+++ b/internal/output/testdata/toon/encode/primitives.json
@@ -1,0 +1,257 @@
+{
+  "version": "3.1",
+  "category": "encode",
+  "description": "Primitive value encoding - strings, numbers, booleans, null",
+  "tests": [
+    {
+      "name": "encodes safe strings without quotes",
+      "input": "hello",
+      "expected": "hello",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes safe string with underscore and numbers",
+      "input": "Ada_99",
+      "expected": "Ada_99",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes empty string",
+      "input": "",
+      "expected": "\"\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string that looks like true",
+      "input": "true",
+      "expected": "\"true\"",
+      "specSection": "7.2",
+      "note": "String representation of boolean must be quoted"
+    },
+    {
+      "name": "quotes string that looks like false",
+      "input": "false",
+      "expected": "\"false\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string that looks like null",
+      "input": "null",
+      "expected": "\"null\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string that looks like integer",
+      "input": "42",
+      "expected": "\"42\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string that looks like negative decimal",
+      "input": "-3.14",
+      "expected": "\"-3.14\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string that looks like scientific notation",
+      "input": "1e-6",
+      "expected": "\"1e-6\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string with leading zero",
+      "input": "05",
+      "expected": "\"05\"",
+      "specSection": "7.2",
+      "note": "Leading zeros make it non-numeric"
+    },
+    {
+      "name": "escapes newline in string",
+      "input": "line1\nline2",
+      "expected": "\"line1\\nline2\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes tab in string",
+      "input": "tab\there",
+      "expected": "\"tab\\there\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes carriage return in string",
+      "input": "return\rcarriage",
+      "expected": "\"return\\rcarriage\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "encodes string with U+0004 control character via \\uXXXX",
+      "input": { "val": "a\u0004b" },
+      "expected": "val: \"a\\u0004b\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "escapes backslash in string",
+      "input": "C:\\Users\\path",
+      "expected": "\"C:\\\\Users\\\\path\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "quotes string with array-like syntax",
+      "input": "[3]: x,y",
+      "expected": "\"[3]: x,y\"",
+      "specSection": "7.2",
+      "note": "Looks like array header"
+    },
+    {
+      "name": "quotes string starting with hyphen-space",
+      "input": "- item",
+      "expected": "\"- item\"",
+      "specSection": "7.2",
+      "note": "Looks like list item marker"
+    },
+    {
+      "name": "quotes single hyphen as object value",
+      "input": { "marker": "-" },
+      "expected": "marker: \"-\"",
+      "specSection": "7.2",
+      "note": "Single hyphen must be quoted to avoid list item ambiguity"
+    },
+    {
+      "name": "quotes string starting with hyphen as object value",
+      "input": { "note": "- item" },
+      "expected": "note: \"- item\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes single hyphen in array",
+      "input": { "items": ["-"] },
+      "expected": "items[1]: \"-\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes leading-hyphen string in array",
+      "input": { "tags": ["a", "- item", "b"] },
+      "expected": "tags[3]: a,\"- item\",b",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string with bracket notation",
+      "input": "[test]",
+      "expected": "\"[test]\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "quotes string with brace notation",
+      "input": "{key}",
+      "expected": "\"{key}\"",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes Unicode string without quotes",
+      "input": "café",
+      "expected": "café",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes Chinese characters without quotes",
+      "input": "你好",
+      "expected": "你好",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes emoji without quotes",
+      "input": "🚀",
+      "expected": "🚀",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes string with emoji and spaces",
+      "input": "hello 👋 world",
+      "expected": "hello 👋 world",
+      "specSection": "7.2"
+    },
+    {
+      "name": "encodes positive integer",
+      "input": 42,
+      "expected": "42",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes decimal number",
+      "input": 3.14,
+      "expected": "3.14",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes negative integer",
+      "input": -7,
+      "expected": "-7",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes zero",
+      "input": 0,
+      "expected": "0",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes negative zero as zero",
+      "input": -0,
+      "expected": "0",
+      "specSection": "2",
+      "note": "Negative zero normalizes to zero"
+    },
+    {
+      "name": "encodes scientific notation as decimal",
+      "input": 1000000,
+      "expected": "1000000",
+      "specSection": "2",
+      "note": "1e6 input, but represented as decimal"
+    },
+    {
+      "name": "encodes small decimal from scientific notation",
+      "input": 0.000001,
+      "expected": "0.000001",
+      "specSection": "2",
+      "note": "1e-6 input"
+    },
+    {
+      "name": "encodes large number",
+      "input": 100000000000000000000,
+      "expected": "100000000000000000000",
+      "specSection": "2",
+      "note": "1e20"
+    },
+    {
+      "name": "encodes MAX_SAFE_INTEGER",
+      "input": 9007199254740991,
+      "expected": "9007199254740991",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes repeating decimal with full precision",
+      "input": 0.3333333333333333,
+      "expected": "0.3333333333333333",
+      "specSection": "2",
+      "note": "Result of 1/3 in JavaScript"
+    },
+    {
+      "name": "encodes true",
+      "input": true,
+      "expected": "true",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes false",
+      "input": false,
+      "expected": "false",
+      "specSection": "2"
+    },
+    {
+      "name": "encodes null",
+      "input": null,
+      "expected": "null",
+      "specSection": "2"
+    }
+  ]
+}

--- a/internal/output/testdata/toon/encode/whitespace.json
+++ b/internal/output/testdata/toon/encode/whitespace.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.4",
+  "category": "encode",
+  "description": "Whitespace and formatting invariants - no trailing spaces, no trailing newlines",
+  "tests": [
+    {
+      "name": "produces no trailing newline at end of output",
+      "input": {
+        "id": 123
+      },
+      "expected": "id: 123",
+      "specSection": "12",
+      "note": "Output should not end with newline character"
+    },
+    {
+      "name": "maintains proper indentation for nested structures",
+      "input": {
+        "user": {
+          "id": 123,
+          "name": "Ada"
+        },
+        "items": ["a", "b"]
+      },
+      "expected": "user:\n  id: 123\n  name: Ada\nitems[2]: a,b",
+      "specSection": "12",
+      "note": "2-space indentation, no trailing spaces on any line"
+    },
+    {
+      "name": "respects custom indent size option",
+      "input": {
+        "user": {
+          "name": "Ada",
+          "role": "admin"
+        }
+      },
+      "expected": "user:\n    name: Ada\n    role: admin",
+      "specSection": "12",
+      "options": {
+        "indent": 4
+      },
+      "note": "4-space indentation for nested objects when indent option is set to 4"
+    }
+  ]
+}

--- a/internal/output/toon_conformance_test.go
+++ b/internal/output/toon_conformance_test.go
@@ -1,0 +1,142 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type toonEncodeFixture struct {
+	Tests []toonEncodeCase `json:"tests"`
+}
+
+type toonEncodeCase struct {
+	Name        string          `json:"name"`
+	Input       json.RawMessage `json:"input"`
+	Expected    string          `json:"expected"`
+	Options     map[string]any  `json:"options"`
+	ShouldError bool            `json:"shouldError"`
+}
+
+func TestTOONOfficialEncodeFixtures(t *testing.T) {
+	files, err := filepath.Glob("testdata/toon/encode/*.json")
+	if err != nil {
+		t.Fatalf("glob fixtures: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no TOON encode fixtures found")
+	}
+
+	for _, file := range files {
+		file := file
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			var fixture toonEncodeFixture
+			if err := json.Unmarshal(raw, &fixture); err != nil {
+				t.Fatalf("parse fixture: %v", err)
+			}
+			for _, tc := range fixture.Tests {
+				tc := tc
+				t.Run(tc.Name, func(t *testing.T) {
+					if tc.ShouldError {
+						t.Skip("Restish TOON currently implements encoder success cases only")
+					}
+					if !toonFixtureUsesDefaultOptions(tc.Options) {
+						t.Skip("Restish TOON currently implements the default delimiter, indentation, and key folding profile")
+					}
+					input := decodeOrderedJSONFixtureValue(t, tc.Input)
+					if got := encodeTOONDocument(input); got != tc.Expected {
+						t.Fatalf("official fixture mismatch:\n got: %q\nwant: %q", got, tc.Expected)
+					}
+				})
+			}
+		})
+	}
+}
+
+func toonFixtureUsesDefaultOptions(options map[string]any) bool {
+	for key, value := range options {
+		switch key {
+		case "delimiter":
+			if value != "," {
+				return false
+			}
+		case "indent":
+			if value != float64(2) {
+				return false
+			}
+		case "keyFolding":
+			if value != "off" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func decodeOrderedJSONFixtureValue(t *testing.T, raw json.RawMessage) any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	value, err := decodeOrderedJSONValue(dec)
+	if err != nil {
+		t.Fatalf("decode ordered JSON fixture value: %v", err)
+	}
+	return value
+}
+
+func decodeOrderedJSONValue(dec *json.Decoder) (any, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch tok := tok.(type) {
+	case json.Delim:
+		switch tok {
+		case '{':
+			var obj toonObject
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return nil, fmt.Errorf("object key token is %T", keyTok)
+				}
+				value, err := decodeOrderedJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				obj = append(obj, toonField{key: key, value: value})
+			}
+			_, err := dec.Token()
+			return obj, err
+		case '[':
+			var arr []any
+			for dec.More() {
+				value, err := decodeOrderedJSONValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, value)
+			}
+			_, err := dec.Token()
+			return arr, err
+		default:
+			return nil, fmt.Errorf("unexpected delimiter %q", tok)
+		}
+	case string, bool, nil, json.Number:
+		return tok, nil
+	default:
+		return nil, fmt.Errorf("unexpected token %T", tok)
+	}
+}

--- a/internal/output/toon_formatter.go
+++ b/internal/output/toon_formatter.go
@@ -19,13 +19,15 @@ import (
 //
 // This is an output-only encoder pinned to TOON spec v3.3
 // (https://github.com/toon-format/spec). It uses the default comma delimiter
-// and two-space indentation. Object keys and tabular field names are emitted in
-// sorted order so output is deterministic.
+// and two-space indentation. Map-backed object keys, including tabular field
+// names derived from maps, are emitted in sorted order so normal Restish output
+// is deterministic.
 //
-// TOON's largest savings come from uniform arrays of objects, which collapse
-// into a tabular form that declares field names once and then streams rows.
-// Non-uniform arrays fall back to an expanded dash-marked list, and deeply
-// nested or irregular data saves little versus JSON.
+// TOON's largest savings come from uniform arrays of flat, primitive-valued
+// objects, which collapse into a tabular form that declares field names once and
+// then streams rows. Non-uniform or nested arrays fall back to an expanded
+// dash-marked list, and deeply nested or irregular data saves little versus
+// JSON.
 type TOONFormatter struct{}
 
 // toonIndentUnit is the per-level indentation. The spec mandates spaces (tabs
@@ -127,9 +129,9 @@ func encodeTOONField(buf *bytes.Buffer, depth int, key string, val any) {
 }
 
 // encodeTOONArray writes an array using the most compact applicable form:
-// inline for all-primitive arrays, tabular for uniform object arrays, and an
-// expanded dash list otherwise. keyTok is the already-encoded key, or "" for a
-// root array.
+// inline for all-primitive arrays, tabular for flat primitive-valued object
+// arrays with a uniform key set, and an expanded dash list otherwise. keyTok is
+// the already-encoded key, or "" for a root array.
 func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any, ctx toonArrayContext) {
 	writeTOONIndent(buf, depth)
 	if len(arr) == 0 {

--- a/internal/output/toon_formatter.go
+++ b/internal/output/toon_formatter.go
@@ -1,0 +1,421 @@
+package output
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// TOONFormatter renders the response body as Token-Oriented Object Notation
+// (TOON), a compact, indentation-based encoding of the JSON data model designed
+// to reduce token usage when structured data is fed to large language models.
+//
+// This is an output-only encoder pinned to TOON spec v3.3
+// (https://github.com/toon-format/spec). It uses the default comma delimiter
+// and two-space indentation. Object keys and tabular field names are emitted in
+// sorted order so output is deterministic.
+//
+// TOON's largest savings come from uniform arrays of objects, which collapse
+// into a tabular form that declares field names once and then streams rows.
+// Non-uniform arrays fall back to an expanded dash-marked list, and deeply
+// nested or irregular data saves little versus JSON.
+type TOONFormatter struct{}
+
+// toonIndentUnit is the per-level indentation. The spec mandates spaces (tabs
+// are prohibited for indentation) and defaults to two.
+const toonIndentUnit = "  "
+
+var (
+	// toonUnquotedKey matches keys/field names that may be emitted without
+	// quotes per spec §9.1.
+	toonUnquotedKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*$`)
+	// toonNumericLike matches strings that look like numbers and therefore must
+	// be quoted to stay distinct from numeric primitives.
+	toonNumericLike = regexp.MustCompile(`^-?\d+(\.\d+)?([eE][+-]?\d+)?$`)
+)
+
+// Format encodes the response body as TOON. Like the JSON and gron formatters
+// it renders only resp.Body; status and headers are not part of structured body
+// output.
+func (f *TOONFormatter) Format(w io.Writer, resp *Response, color bool) error {
+	return f.FormatValue(w, resp.Body, color)
+}
+
+// FormatValue encodes an arbitrary body/sub-value as TOON. Implementing
+// ValueFormatter lets filtered (-f) and paginated item values render as TOON,
+// which is where the tabular form is most valuable.
+func (f *TOONFormatter) FormatValue(w io.Writer, value any, color bool) error {
+	var buf bytes.Buffer
+	encodeTOONRoot(&buf, value)
+	// The TOON document itself ends without a trailing newline; append one for
+	// terminal/pipe consistency with the json and gron formatters.
+	out := append(bytes.TrimRight(buf.Bytes(), "\n"), '\n')
+	_, err := w.Write(out)
+	return err
+}
+
+// encodeTOONRoot writes the top-level value, which has no enclosing key.
+func encodeTOONRoot(buf *bytes.Buffer, value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		// An empty object is an empty document, which decodes back to {}.
+		encodeTOONObject(buf, 0, v)
+	case []any:
+		if len(v) == 0 {
+			buf.WriteString("[]\n")
+			return
+		}
+		encodeTOONArray(buf, 0, "", v)
+	default:
+		buf.WriteString(encodeTOONScalar(value))
+		buf.WriteByte('\n')
+	}
+}
+
+// encodeTOONObject writes each field of m at the given depth, sorted by key for
+// deterministic output.
+func encodeTOONObject(buf *bytes.Buffer, depth int, m map[string]any) {
+	for _, k := range sortedKeys(m) {
+		encodeTOONField(buf, depth, k, m[k])
+	}
+}
+
+// encodeTOONField writes a single "key: value" field and any nested content.
+func encodeTOONField(buf *bytes.Buffer, depth int, key string, val any) {
+	keyTok := encodeTOONKey(key)
+	switch v := val.(type) {
+	case map[string]any:
+		// Both empty and non-empty objects emit "key:"; a non-empty object adds
+		// indented fields below.
+		writeTOONIndent(buf, depth)
+		buf.WriteString(keyTok)
+		buf.WriteString(":\n")
+		encodeTOONObject(buf, depth+1, v)
+	case []any:
+		encodeTOONArray(buf, depth, keyTok, v)
+	default:
+		writeTOONIndent(buf, depth)
+		buf.WriteString(keyTok)
+		buf.WriteString(": ")
+		buf.WriteString(encodeTOONScalar(val))
+		buf.WriteByte('\n')
+	}
+}
+
+// encodeTOONArray writes an array using the most compact applicable form:
+// inline for all-primitive arrays, tabular for uniform object arrays, and an
+// expanded dash list otherwise. keyTok is the already-encoded key, or "" for a
+// root array.
+func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any) {
+	writeTOONIndent(buf, depth)
+	if len(arr) == 0 {
+		if keyTok != "" {
+			buf.WriteString(keyTok)
+			buf.WriteString(": ")
+		}
+		buf.WriteString("[]\n")
+		return
+	}
+
+	if allTOONPrimitive(arr) {
+		fmt.Fprintf(buf, "%s[%d]: ", keyTok, len(arr))
+		for i, item := range arr {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			buf.WriteString(encodeTOONScalar(item))
+		}
+		buf.WriteByte('\n')
+		return
+	}
+
+	if fields, ok := toonTabularFields(arr); ok {
+		cols := make([]string, len(fields))
+		for i, f := range fields {
+			cols[i] = encodeTOONKey(f)
+		}
+		fmt.Fprintf(buf, "%s[%d]{%s}:\n", keyTok, len(arr), strings.Join(cols, ","))
+		for _, item := range arr {
+			obj := item.(map[string]any)
+			writeTOONIndent(buf, depth+1)
+			for i, f := range fields {
+				if i > 0 {
+					buf.WriteByte(',')
+				}
+				buf.WriteString(encodeTOONScalar(obj[f]))
+			}
+			buf.WriteByte('\n')
+		}
+		return
+	}
+
+	// Expanded list: header followed by one dash-marked item per element.
+	fmt.Fprintf(buf, "%s[%d]:\n", keyTok, len(arr))
+	for _, item := range arr {
+		encodeTOONListItem(buf, depth+1, item)
+	}
+}
+
+// encodeTOONListItem writes one element of an expanded list at the list-item
+// depth. Composite items reuse the field/array encoders one level deeper and
+// then have their first line's leading indent replaced by the "- " marker, per
+// spec §9.4 (first field on the hyphen line).
+func encodeTOONListItem(buf *bytes.Buffer, depth int, item any) {
+	switch v := item.(type) {
+	case map[string]any:
+		if len(v) == 0 {
+			writeTOONIndent(buf, depth)
+			buf.WriteString("-\n")
+			return
+		}
+		var tmp bytes.Buffer
+		encodeTOONObject(&tmp, depth+1, v)
+		writeTOONDashItem(buf, depth, tmp.Bytes())
+	case []any:
+		var tmp bytes.Buffer
+		encodeTOONArray(&tmp, depth+1, "", v)
+		writeTOONDashItem(buf, depth, tmp.Bytes())
+	default:
+		writeTOONIndent(buf, depth)
+		buf.WriteString("- ")
+		buf.WriteString(encodeTOONScalar(item))
+		buf.WriteByte('\n')
+	}
+}
+
+// writeTOONDashItem emits content (rendered at depth+1) as a dash list item by
+// swapping the first line's leading indent for the "- " marker. The marker is
+// two characters wide, exactly the width of one indent level, so deeper lines
+// keep their existing indentation.
+func writeTOONDashItem(buf *bytes.Buffer, depth int, content []byte) {
+	strip := len(toonIndentUnit) * (depth + 1)
+	writeTOONIndent(buf, depth)
+	buf.WriteString("- ")
+	buf.Write(content[strip:])
+}
+
+// allTOONPrimitive reports whether every element is a primitive (not an object
+// or array), making the array eligible for the compact inline form.
+func allTOONPrimitive(arr []any) bool {
+	for _, item := range arr {
+		switch item.(type) {
+		case map[string]any, []any:
+			return false
+		}
+	}
+	return true
+}
+
+// toonTabularFields reports whether arr qualifies for tabular form and, if so,
+// returns the shared field names in sorted order. Qualification (spec §9.3):
+// every element is a non-empty object, all share the same key set, and every
+// value is a primitive.
+func toonTabularFields(arr []any) ([]string, bool) {
+	var fields []string
+	for i, item := range arr {
+		obj, ok := item.(map[string]any)
+		if !ok || len(obj) == 0 {
+			return nil, false
+		}
+		for _, v := range obj {
+			switch v.(type) {
+			case map[string]any, []any:
+				return nil, false
+			}
+		}
+		if i == 0 {
+			fields = sortedKeys(obj)
+			continue
+		}
+		if len(obj) != len(fields) {
+			return nil, false
+		}
+		for _, f := range fields {
+			if _, ok := obj[f]; !ok {
+				return nil, false
+			}
+		}
+	}
+	return fields, true
+}
+
+// encodeTOONScalar encodes a primitive leaf value as a TOON token, quoting and
+// escaping strings as required.
+func encodeTOONScalar(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case string:
+		return encodeTOONString(x)
+	case float64:
+		return encodeTOONFloat(x)
+	case float32:
+		return encodeTOONFloat(float64(x))
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int8:
+		return strconv.FormatInt(int64(x), 10)
+	case int16:
+		return strconv.FormatInt(int64(x), 10)
+	case int32:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case uint:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10)
+	case uint64:
+		return strconv.FormatUint(x, 10)
+	case []byte:
+		// Mirror JSON, which base64-encodes byte slices as strings.
+		return encodeTOONString(base64.StdEncoding.EncodeToString(x))
+	default:
+		// json.Number satisfies fmt.Stringer; route it (and any other Stringer)
+		// through the numeric normalizer when it looks numeric, else quote it.
+		if s, ok := v.(fmt.Stringer); ok {
+			return encodeTOONNumberString(s.String())
+		}
+		return encodeTOONString(fmt.Sprintf("%v", v))
+	}
+}
+
+// encodeTOONFloat emits a finite float in canonical decimal form (spec §7).
+// Non-finite values (NaN, ±Inf) encode as null, matching JSON-safe conversion.
+func encodeTOONFloat(f float64) string {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return "null"
+	}
+	if f == 0 {
+		return "0" // also normalizes -0
+	}
+	abs := math.Abs(f)
+	// Outside the canonical range exponent notation is permitted; within it the
+	// spec requires plain decimal with no exponent and no trailing zeros.
+	if abs < 1e-6 || abs >= 1e21 {
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// encodeTOONNumberString normalizes an already-textual number (e.g. a
+// json.Number). Integer literals pass through unchanged; anything with a
+// fraction or exponent is re-canonicalized as a float.
+func encodeTOONNumberString(s string) string {
+	if strings.ContainsAny(s, ".eE") {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return encodeTOONFloat(f)
+		}
+	}
+	if toonNumericLike.MatchString(s) {
+		return s
+	}
+	return encodeTOONString(s)
+}
+
+// encodeTOONString returns s quoted and escaped if required, else verbatim.
+func encodeTOONString(s string) string {
+	if toonStringNeedsQuote(s) {
+		return quoteTOONString(s)
+	}
+	return s
+}
+
+// encodeTOONKey returns a key/field name unquoted when it matches the safe
+// pattern, else quoted and escaped.
+func encodeTOONKey(k string) string {
+	if toonUnquotedKey.MatchString(k) {
+		return k
+	}
+	return quoteTOONString(k)
+}
+
+// toonStringNeedsQuote implements the spec's quoting triggers for the default
+// comma delimiter.
+func toonStringNeedsQuote(s string) bool {
+	if s == "" {
+		return true
+	}
+	if s == "true" || s == "false" || s == "null" {
+		return true
+	}
+	if s[0] == '-' {
+		return true // equals "-" or starts with a hyphen
+	}
+	if strings.TrimSpace(s) != s {
+		return true // leading or trailing whitespace
+	}
+	if toonNumericLike.MatchString(s) {
+		return true
+	}
+	if strings.ContainsAny(s, ":\"\\[]{},") {
+		return true // structural characters or the active (comma) delimiter
+	}
+	for _, r := range s {
+		if r <= 0x1f {
+			return true // control characters
+		}
+	}
+	return false
+}
+
+// quoteTOONString wraps s in double quotes and escapes per spec §7.1.
+func quoteTOONString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r <= 0x1f {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// writeTOONIndent writes depth levels of indentation.
+func writeTOONIndent(buf *bytes.Buffer, depth int) {
+	for i := 0; i < depth; i++ {
+		buf.WriteString(toonIndentUnit)
+	}
+}
+
+// sortedKeys returns the keys of m in ascending order for deterministic output.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/output/toon_formatter.go
+++ b/internal/output/toon_formatter.go
@@ -32,6 +32,18 @@ type TOONFormatter struct{}
 // are prohibited for indentation) and defaults to two.
 const toonIndentUnit = "  "
 
+type toonArrayContext struct {
+	allowTabular     bool
+	emptyArrayHeader bool
+}
+
+type toonField struct {
+	key   string
+	value any
+}
+
+type toonObject []toonField
+
 var (
 	// toonUnquotedKey matches keys/field names that may be emitted without
 	// quotes per spec §9.1.
@@ -52,19 +64,25 @@ func (f *TOONFormatter) Format(w io.Writer, resp *Response, color bool) error {
 // ValueFormatter lets filtered (-f) and paginated item values render as TOON,
 // which is where the tabular form is most valuable.
 func (f *TOONFormatter) FormatValue(w io.Writer, value any, color bool) error {
-	var buf bytes.Buffer
-	encodeTOONRoot(&buf, value)
+	out := []byte(encodeTOONDocument(value))
 	// The TOON document itself ends without a trailing newline; append one for
 	// terminal/pipe consistency with the json and gron formatters.
-	out := append(bytes.TrimRight(buf.Bytes(), "\n"), '\n')
+	out = append(out, '\n')
 	_, err := w.Write(out)
 	return err
+}
+
+// encodeTOONDocument returns a TOON document without a trailing newline.
+func encodeTOONDocument(value any) string {
+	var buf bytes.Buffer
+	encodeTOONRoot(&buf, value)
+	return strings.TrimRight(buf.String(), "\n")
 }
 
 // encodeTOONRoot writes the top-level value, which has no enclosing key.
 func encodeTOONRoot(buf *bytes.Buffer, value any) {
 	switch v := value.(type) {
-	case map[string]any:
+	case map[string]any, toonObject:
 		// An empty object is an empty document, which decodes back to {}.
 		encodeTOONObject(buf, 0, v)
 	case []any:
@@ -72,18 +90,17 @@ func encodeTOONRoot(buf *bytes.Buffer, value any) {
 			buf.WriteString("[]\n")
 			return
 		}
-		encodeTOONArray(buf, 0, "", v)
+		encodeTOONArray(buf, 0, "", v, toonArrayContext{allowTabular: true})
 	default:
 		buf.WriteString(encodeTOONScalar(value))
 		buf.WriteByte('\n')
 	}
 }
 
-// encodeTOONObject writes each field of m at the given depth, sorted by key for
-// deterministic output.
-func encodeTOONObject(buf *bytes.Buffer, depth int, m map[string]any) {
-	for _, k := range sortedKeys(m) {
-		encodeTOONField(buf, depth, k, m[k])
+// encodeTOONObject writes each field of obj at the given depth.
+func encodeTOONObject(buf *bytes.Buffer, depth int, obj any) {
+	for _, field := range toonObjectFields(obj) {
+		encodeTOONField(buf, depth, field.key, field.value)
 	}
 }
 
@@ -91,7 +108,7 @@ func encodeTOONObject(buf *bytes.Buffer, depth int, m map[string]any) {
 func encodeTOONField(buf *bytes.Buffer, depth int, key string, val any) {
 	keyTok := encodeTOONKey(key)
 	switch v := val.(type) {
-	case map[string]any:
+	case map[string]any, toonObject:
 		// Both empty and non-empty objects emit "key:"; a non-empty object adds
 		// indented fields below.
 		writeTOONIndent(buf, depth)
@@ -99,7 +116,7 @@ func encodeTOONField(buf *bytes.Buffer, depth int, key string, val any) {
 		buf.WriteString(":\n")
 		encodeTOONObject(buf, depth+1, v)
 	case []any:
-		encodeTOONArray(buf, depth, keyTok, v)
+		encodeTOONArray(buf, depth, keyTok, v, toonArrayContext{allowTabular: true})
 	default:
 		writeTOONIndent(buf, depth)
 		buf.WriteString(keyTok)
@@ -113,14 +130,20 @@ func encodeTOONField(buf *bytes.Buffer, depth int, key string, val any) {
 // inline for all-primitive arrays, tabular for uniform object arrays, and an
 // expanded dash list otherwise. keyTok is the already-encoded key, or "" for a
 // root array.
-func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any) {
+func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any, ctx toonArrayContext) {
 	writeTOONIndent(buf, depth)
 	if len(arr) == 0 {
 		if keyTok != "" {
 			buf.WriteString(keyTok)
 			buf.WriteString(": ")
+			buf.WriteString("[]\n")
+			return
 		}
-		buf.WriteString("[]\n")
+		if ctx.emptyArrayHeader {
+			buf.WriteString("[0]:\n")
+		} else {
+			buf.WriteString("[]\n")
+		}
 		return
 	}
 
@@ -136,24 +159,27 @@ func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any) {
 		return
 	}
 
-	if fields, ok := toonTabularFields(arr); ok {
-		cols := make([]string, len(fields))
-		for i, f := range fields {
-			cols[i] = encodeTOONKey(f)
-		}
-		fmt.Fprintf(buf, "%s[%d]{%s}:\n", keyTok, len(arr), strings.Join(cols, ","))
-		for _, item := range arr {
-			obj := item.(map[string]any)
-			writeTOONIndent(buf, depth+1)
+	if ctx.allowTabular {
+		if fields, ok := toonTabularFields(arr); ok {
+			cols := make([]string, len(fields))
 			for i, f := range fields {
-				if i > 0 {
-					buf.WriteByte(',')
-				}
-				buf.WriteString(encodeTOONScalar(obj[f]))
+				cols[i] = encodeTOONKey(f)
 			}
-			buf.WriteByte('\n')
+			fmt.Fprintf(buf, "%s[%d]{%s}:\n", keyTok, len(arr), strings.Join(cols, ","))
+			for _, item := range arr {
+				objFields, _ := toonObjectFieldsIfObject(item)
+				obj := toonObject(objFields)
+				writeTOONIndent(buf, depth+1)
+				for i, f := range fields {
+					if i > 0 {
+						buf.WriteByte(',')
+					}
+					buf.WriteString(encodeTOONScalar(toonObjectValue(obj, f)))
+				}
+				buf.WriteByte('\n')
+			}
+			return
 		}
-		return
 	}
 
 	// Expanded list: header followed by one dash-marked item per element.
@@ -166,11 +192,12 @@ func encodeTOONArray(buf *bytes.Buffer, depth int, keyTok string, arr []any) {
 // encodeTOONListItem writes one element of an expanded list at the list-item
 // depth. Composite items reuse the field/array encoders one level deeper and
 // then have their first line's leading indent replaced by the "- " marker, per
-// spec §9.4 (first field on the hyphen line).
+// spec §9.4 and §10.
 func encodeTOONListItem(buf *bytes.Buffer, depth int, item any) {
 	switch v := item.(type) {
-	case map[string]any:
-		if len(v) == 0 {
+	case map[string]any, toonObject:
+		fields := toonObjectFields(v)
+		if len(fields) == 0 {
 			writeTOONIndent(buf, depth)
 			buf.WriteString("-\n")
 			return
@@ -180,14 +207,106 @@ func encodeTOONListItem(buf *bytes.Buffer, depth int, item any) {
 		writeTOONDashItem(buf, depth, tmp.Bytes())
 	case []any:
 		var tmp bytes.Buffer
-		encodeTOONArray(&tmp, depth+1, "", v)
-		writeTOONDashItem(buf, depth, tmp.Bytes())
+		// TOON §9.4 does not allow tabular form when the nested array itself is a
+		// list item; there is no key position for the field list.
+		encodeTOONArray(&tmp, depth+1, "", v, toonArrayContext{
+			allowTabular:     false,
+			emptyArrayHeader: true,
+		})
+		writeTOONDashArrayItem(buf, depth, tmp.Bytes())
 	default:
 		writeTOONIndent(buf, depth)
 		buf.WriteString("- ")
 		buf.WriteString(encodeTOONScalar(item))
 		buf.WriteByte('\n')
 	}
+}
+
+// allTOONPrimitive reports whether every element is a primitive (not an object
+// or array), making the array eligible for the compact inline form.
+func allTOONPrimitive(arr []any) bool {
+	for _, item := range arr {
+		switch item.(type) {
+		case map[string]any, toonObject, []any:
+			return false
+		}
+	}
+	return true
+}
+
+// toonTabularFields reports whether arr qualifies for tabular form and, if so,
+// returns the shared field names. Qualification (spec §9.3): every element is a
+// non-empty object, all share the same key set, and every value is a primitive.
+func toonTabularFields(arr []any) ([]string, bool) {
+	var fields []string
+	for i, item := range arr {
+		objFields, ok := toonObjectFieldsIfObject(item)
+		if !ok || len(objFields) == 0 {
+			return nil, false
+		}
+		for _, field := range objFields {
+			switch field.value.(type) {
+			case map[string]any, toonObject, []any:
+				return nil, false
+			}
+		}
+		if i == 0 {
+			fields = make([]string, len(objFields))
+			for j, field := range objFields {
+				fields[j] = field.key
+			}
+			continue
+		}
+		if len(objFields) != len(fields) {
+			return nil, false
+		}
+		obj := toonObject(objFields)
+		for _, f := range fields {
+			if _, ok := toonObjectValueOK(obj, f); !ok {
+				return nil, false
+			}
+		}
+	}
+	return fields, true
+}
+
+func toonObjectFieldsIfObject(obj any) ([]toonField, bool) {
+	switch v := obj.(type) {
+	case map[string]any:
+		return toonMapFields(v), true
+	case toonObject:
+		return []toonField(v), true
+	default:
+		return nil, false
+	}
+}
+
+func toonObjectFields(obj any) []toonField {
+	fields, _ := toonObjectFieldsIfObject(obj)
+	return fields
+}
+
+func toonMapFields(m map[string]any) []toonField {
+	keys := sortedKeys(m)
+	fields := make([]toonField, len(keys))
+	for i, key := range keys {
+		fields[i] = toonField{key: key, value: m[key]}
+	}
+	return fields
+}
+
+func toonObjectValue(obj toonObject, key string) any {
+	value, _ := toonObjectValueOK(obj, key)
+	return value
+}
+
+func toonObjectValueOK(obj toonObject, key string) (any, bool) {
+	for _, field := range obj {
+		if field.key == key {
+			return field.value, true
+		}
+	}
+	return nil, false
 }
 
 // writeTOONDashItem emits content (rendered at depth+1) as a dash list item by
@@ -201,49 +320,25 @@ func writeTOONDashItem(buf *bytes.Buffer, depth int, content []byte) {
 	buf.Write(content[strip:])
 }
 
-// allTOONPrimitive reports whether every element is a primitive (not an object
-// or array), making the array eligible for the compact inline form.
-func allTOONPrimitive(arr []any) bool {
-	for _, item := range arr {
-		switch item.(type) {
-		case map[string]any, []any:
-			return false
-		}
-	}
-	return true
-}
-
-// toonTabularFields reports whether arr qualifies for tabular form and, if so,
-// returns the shared field names in sorted order. Qualification (spec §9.3):
-// every element is a non-empty object, all share the same key set, and every
-// value is a primitive.
-func toonTabularFields(arr []any) ([]string, bool) {
-	var fields []string
-	for i, item := range arr {
-		obj, ok := item.(map[string]any)
-		if !ok || len(obj) == 0 {
-			return nil, false
-		}
-		for _, v := range obj {
-			switch v.(type) {
-			case map[string]any, []any:
-				return nil, false
-			}
-		}
-		if i == 0 {
-			fields = sortedKeys(obj)
+// writeTOONDashArrayItem emits an array as a dash list item. The array header
+// moves onto the hyphen line, so child items move up by one indentation level
+// under that moved header.
+func writeTOONDashArrayItem(buf *bytes.Buffer, depth int, content []byte) {
+	firstLineStrip := len(toonIndentUnit) * (depth + 1)
+	childStrip := []byte(toonIndentUnit)
+	writeTOONIndent(buf, depth)
+	buf.WriteString("- ")
+	for i, line := range bytes.SplitAfter(content, []byte("\n")) {
+		if len(line) == 0 {
 			continue
 		}
-		if len(obj) != len(fields) {
-			return nil, false
+		if i == 0 {
+			line = line[firstLineStrip:]
+		} else if bytes.HasPrefix(line, childStrip) {
+			line = line[len(childStrip):]
 		}
-		for _, f := range fields {
-			if _, ok := obj[f]; !ok {
-				return nil, false
-			}
-		}
+		buf.Write(line)
 	}
-	return fields, true
 }
 
 // encodeTOONScalar encodes a primitive leaf value as a TOON token, quoting and
@@ -302,6 +397,9 @@ func encodeTOONFloat(f float64) string {
 // json.Number). Integer literals pass through unchanged; anything with a
 // fraction or exponent is re-canonicalized as a float.
 func encodeTOONNumberString(s string) string {
+	if s == "-0" {
+		return "0"
+	}
 	if strings.ContainsAny(s, ".eE") {
 		if f, err := strconv.ParseFloat(s, 64); err == nil {
 			return encodeTOONFloat(f)

--- a/internal/output/toon_formatter.go
+++ b/internal/output/toon_formatter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -262,26 +263,10 @@ func encodeTOONScalar(v any) string {
 		return encodeTOONFloat(x)
 	case float32:
 		return encodeTOONFloat(float64(x))
-	case int:
-		return strconv.FormatInt(int64(x), 10)
-	case int8:
-		return strconv.FormatInt(int64(x), 10)
-	case int16:
-		return strconv.FormatInt(int64(x), 10)
-	case int32:
-		return strconv.FormatInt(int64(x), 10)
-	case int64:
-		return strconv.FormatInt(x, 10)
-	case uint:
-		return strconv.FormatUint(uint64(x), 10)
-	case uint8:
-		return strconv.FormatUint(uint64(x), 10)
-	case uint16:
-		return strconv.FormatUint(uint64(x), 10)
-	case uint32:
-		return strconv.FormatUint(uint64(x), 10)
-	case uint64:
-		return strconv.FormatUint(x, 10)
+	case int, int8, int16, int32, int64:
+		return strconv.FormatInt(reflect.ValueOf(v).Int(), 10)
+	case uint, uint8, uint16, uint32, uint64:
+		return strconv.FormatUint(reflect.ValueOf(v).Uint(), 10)
 	case []byte:
 		// Mirror JSON, which base64-encodes byte slices as strings.
 		return encodeTOONString(base64.StdEncoding.EncodeToString(x))

--- a/internal/output/toon_formatter_test.go
+++ b/internal/output/toon_formatter_test.go
@@ -87,6 +87,19 @@ func TestTOONExpandedListMixed(t *testing.T) {
 	}
 }
 
+// TestTOONExpandedListEmptyObject verifies that an empty object inside a
+// non-uniform array renders as a bare dash list item.
+func TestTOONExpandedListEmptyObject(t *testing.T) {
+	body := []any{
+		map[string]any{},
+		map[string]any{"a": float64(1)},
+	}
+	want := "[2]:\n  -\n  - a: 1\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("empty-object list item mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestTOONEmptyContainers verifies empty arrays/objects at root and field
 // positions.
 func TestTOONEmptyContainers(t *testing.T) {
@@ -124,7 +137,18 @@ func TestTOONScalars(t *testing.T) {
 		{"whole float is integer", 1.0, "1\n"},
 		{"no exponent in range", 1000000.0, "1000000\n"},
 		{"negative zero normalized", math.Copysign(0, -1), "0\n"},
+		{"int64", int64(42), "42\n"},
+		{"uint64", uint64(7), "7\n"},
+		{"float32", float32(1.5), "1.5\n"},
+		{"byte slice as base64", []byte("hi"), "aGk=\n"},
+		{"NaN encodes as null", math.NaN(), "null\n"},
+		{"positive infinity as null", math.Inf(1), "null\n"},
+		{"negative infinity as null", math.Inf(-1), "null\n"},
+		{"large magnitude uses exponent", 1e21, "1e+21\n"},
+		{"tiny magnitude uses exponent", 1e-7, "1e-07\n"},
+		{"control char escaped", "a\x01b", "\"a\\u0001b\"\n"},
 		{"json.Number int", json.Number("42"), "42\n"},
+		{"json.Number big int beyond float64", json.Number("123456789012345678901"), "123456789012345678901\n"},
 		{"json.Number trailing zeros", json.Number("1.500"), "1.5\n"},
 		{"quote on delimiter", "a,b", "\"a,b\"\n"},
 		{"quote keyword lookalike", "true", "\"true\"\n"},

--- a/internal/output/toon_formatter_test.go
+++ b/internal/output/toon_formatter_test.go
@@ -87,6 +87,22 @@ func TestTOONExpandedListMixed(t *testing.T) {
 	}
 }
 
+// TestTOONExpandedListArrayItemDisablesTabularForm verifies TOON §9.4: when an
+// array itself is an expanded-list item, tabular form is unavailable because
+// there is no key position for the field list.
+func TestTOONExpandedListArrayItemDisablesTabularForm(t *testing.T) {
+	body := []any{
+		[]any{
+			map[string]any{"a": float64(1)},
+			map[string]any{"a": float64(2)},
+		},
+	}
+	want := "[1]:\n  - [2]:\n    - a: 1\n    - a: 2\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("nested array-list item mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
 // TestTOONExpandedListEmptyObject verifies that an empty object inside a
 // non-uniform array renders as a bare dash list item.
 func TestTOONExpandedListEmptyObject(t *testing.T) {

--- a/internal/output/toon_formatter_test.go
+++ b/internal/output/toon_formatter_test.go
@@ -1,0 +1,187 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/rest-sh/restish/v2/internal/output"
+)
+
+// renderTOON formats value through the public formatter and returns the string.
+func renderTOON(t *testing.T, value any) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := (&output.TOONFormatter{}).FormatValue(&buf, value, false); err != nil {
+		t.Fatalf("FormatValue: %v", err)
+	}
+	return buf.String()
+}
+
+// TestTOONTabularArray verifies the headline case: a uniform array of objects
+// collapses into a table that declares fields once (sorted) and streams rows.
+func TestTOONTabularArray(t *testing.T) {
+	body := []any{
+		map[string]any{"id": float64(1), "name": "Alice", "role": "admin"},
+		map[string]any{"id": float64(2), "name": "Bob", "role": "user"},
+	}
+	want := "[2]{id,name,role}:\n  1,Alice,admin\n  2,Bob,user\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("tabular output mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTOONTabularArrayAsField verifies the tabular form under a key, which is
+// the common shape after `-f` projects a response to a list of records.
+func TestTOONTabularArrayAsField(t *testing.T) {
+	body := map[string]any{
+		"users": []any{
+			map[string]any{"id": float64(1), "name": "Ada"},
+			map[string]any{"id": float64(2), "name": "Bo"},
+		},
+	}
+	want := "users[2]{id,name}:\n  1,Ada\n  2,Bo\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("tabular field mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTOONInlineAndNested verifies inline primitive arrays and nested objects,
+// with keys emitted in sorted order.
+func TestTOONInlineAndNested(t *testing.T) {
+	body := map[string]any{
+		"tags": []any{"go", "cli"},
+		"user": map[string]any{"name": "Alice", "age": float64(30)},
+	}
+	want := "tags[2]: go,cli\nuser:\n  age: 30\n  name: Alice\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("inline/nested mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTOONExpandedListObjects verifies the dash-list fallback for a non-uniform
+// object array, including the first field rendered on the hyphen line.
+func TestTOONExpandedListObjects(t *testing.T) {
+	body := []any{
+		map[string]any{"a": float64(1)},
+		map[string]any{"a": float64(1), "b": float64(2)},
+	}
+	want := "[2]:\n  - a: 1\n  - a: 1\n    b: 2\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("expanded object list mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTOONExpandedListMixed verifies dash items for a nested array and a bare
+// primitive in the same (non-uniform) array.
+func TestTOONExpandedListMixed(t *testing.T) {
+	body := []any{
+		[]any{"x", "y"},
+		"z",
+	}
+	want := "[2]:\n  - [2]: x,y\n  - z\n"
+	if got := renderTOON(t, body); got != want {
+		t.Errorf("expanded mixed list mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestTOONEmptyContainers verifies empty arrays/objects at root and field
+// positions.
+func TestTOONEmptyContainers(t *testing.T) {
+	cases := []struct {
+		name string
+		body any
+		want string
+	}{
+		{"empty object root", map[string]any{}, "\n"},
+		{"empty array root", []any{}, "[]\n"},
+		{"empty array field", map[string]any{"items": []any{}}, "items: []\n"},
+		{"empty object field", map[string]any{"meta": map[string]any{}}, "meta:\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderTOON(t, tc.body); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTOONScalars verifies primitive encoding: null/bool literals, number
+// canonicalization, and the string-quoting triggers.
+func TestTOONScalars(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"null", nil, "null\n"},
+		{"bool", true, "true\n"},
+		{"plain string", "hello", "hello\n"},
+		{"float", 1.5, "1.5\n"},
+		{"whole float is integer", 1.0, "1\n"},
+		{"no exponent in range", 1000000.0, "1000000\n"},
+		{"negative zero normalized", math.Copysign(0, -1), "0\n"},
+		{"json.Number int", json.Number("42"), "42\n"},
+		{"json.Number trailing zeros", json.Number("1.500"), "1.5\n"},
+		{"quote on delimiter", "a,b", "\"a,b\"\n"},
+		{"quote keyword lookalike", "true", "\"true\"\n"},
+		{"quote leading hyphen", "-x", "\"-x\"\n"},
+		{"quote numeric lookalike", "123", "\"123\"\n"},
+		{"quote colon", "a:b", "\"a:b\"\n"},
+		{"escape quote and newline", "a\"\nb", "\"a\\\"\\nb\"\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderTOON(t, tc.value); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTOONKeyQuoting verifies that field names are quoted only when they fall
+// outside the safe-identifier pattern (dots are allowed; spaces and a leading
+// digit are not).
+func TestTOONKeyQuoting(t *testing.T) {
+	cases := []struct {
+		body map[string]any
+		want string
+	}{
+		{map[string]any{"a.b": float64(1)}, "a.b: 1\n"},
+		{map[string]any{"a b": float64(1)}, "\"a b\": 1\n"},
+		{map[string]any{"1foo": float64(1)}, "\"1foo\": 1\n"},
+	}
+	for _, tc := range cases {
+		if got := renderTOON(t, tc.body); got != tc.want {
+			t.Errorf("got %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// TestTOONFormatRendersBodyOnly verifies Format encodes only resp.Body, like the
+// json and gron formatters, without any status/header preamble.
+func TestTOONFormatRendersBodyOnly(t *testing.T) {
+	resp := &output.Response{
+		Proto:   "HTTP/1.1",
+		Status:  200,
+		Headers: map[string][]string{"Content-Type": {"application/json"}},
+		Body:    map[string]any{"ok": true},
+	}
+	var buf bytes.Buffer
+	if err := (&output.TOONFormatter{}).Format(&buf, resp, false); err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if got, want := buf.String(), "ok: true\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTOONFormatterPropagatesWriterError(t *testing.T) {
+	err := (&output.TOONFormatter{}).FormatValue(failingWriter{}, map[string]any{"x": float64(1)}, false)
+	if !errors.Is(err, errFailingWriter) {
+		t.Fatalf("error = %v, want %v", err, errFailingWriter)
+	}
+}

--- a/site/content/en/docs/guides/output.md
+++ b/site/content/en/docs/guides/output.md
@@ -188,6 +188,20 @@ response. Redirect the response to save the image instead.
 restish api.rest.sh/example -o gron | grep -i github
 ```
 
+## Token-Dense Output For Agents
+
+`toon` encodes the response as [TOON](https://github.com/toon-format/spec), a
+compact format that cuts token count when feeding API responses to LLM agents.
+Pair it with a filter that projects to a uniform list of records for the
+largest savings:
+
+```bash
+restish api.rest.sh/images -f '.[] | {name, format}' -o toon
+```
+
+See [Output Formats](/docs/reference/output-formats/#toon-for-agents) for the
+tradeoffs.
+
 ## Related Pages
 
 - [Query Syntax](/docs/reference/query-syntax/)

--- a/site/content/en/docs/reference/global-flags.md
+++ b/site/content/en/docs/reference/global-flags.md
@@ -209,7 +209,7 @@ Filter/project the response using shorthand or jq (auto-detected)
 
 Type: `string`; default: `auto`
 
-Output format for rendered response bodies: auto, cbor, gron, image, json, lines, ndjson, table, yaml (use -o lines for shell-friendly filtered values; see --rsh-columns, --rsh-sort-by for table)
+Output format for rendered response bodies: auto, cbor, gron, image, json, lines, ndjson, table, toon, yaml (use -o lines for shell-friendly filtered values; see --rsh-columns, --rsh-sort-by for table)
 
 **`-p`, `--rsh-profile`**
 
@@ -284,7 +284,7 @@ and leaves generic HTTP commands unchanged.
 | --- | --- | --- | --- |
 | `-f`, `--rsh-filter` | expression | none | Filter with shorthand or jq. |
 | `--rsh-filter-lang` | `shorthand` or `jq` | auto | Force one parser. |
-| `-o`, `--rsh-output-format` | format | `auto` | `auto`, `json`, `yaml`, `cbor`, `table`, `ndjson`, `lines`, `gron`, `image`, or plugin formats. |
+| `-o`, `--rsh-output-format` | format | `auto` | `auto`, `json`, `yaml`, `cbor`, `table`, `ndjson`, `lines`, `gron`, `toon`, `image`, or plugin formats. |
 | `--rsh-print` | `auto` or letters | `auto` | Print parts: `H` request headers, `B` request body, `h` response status and headers, `b` rendered body, `p` pretty, `c` color. |
 | `--rsh-columns` | comma list | formatter default | Columns for `-o table`. |
 | `--rsh-sort-by` | column name | none | Sort table rows by a column. |

--- a/site/content/en/docs/reference/output-formats.md
+++ b/site/content/en/docs/reference/output-formats.md
@@ -137,10 +137,10 @@ collection of nested, irregular objects.
 | ndjson | 3,000 | 2,800 |
 | gron | 6,403 | 6,783 |
 
-On uniform record collections TOON is the most token-efficient text format, and
-the lead grows with row count. On nested or irregular data, compact JSON and
-NDJSON edge it out — TOON's per-line indentation outweighs the savings — so
-project to a uniform list first, or stay on JSON.
+On these uniform record collections, TOON is the most token-efficient built-in
+lossless text format, and the lead grows with row count. On nested or irregular
+data, compact JSON and NDJSON edge it out — TOON's per-line indentation
+outweighs the savings — so project to a uniform list first, or stay on JSON.
 
 Not shown: `table` is human-only and truncates long values (lossy), `lines`
 only handles scalar arrays, and `cbor` is binary rather than text.

--- a/site/content/en/docs/reference/output-formats.md
+++ b/site/content/en/docs/reference/output-formats.md
@@ -79,9 +79,10 @@ feeding API responses to LLM agents — for example when Restish is the tool
 surface an agent calls instead of an MCP server — where every response token
 has a cost.
 
-TOON's savings come from uniform arrays of objects. Such an array collapses
-into a table that declares its field names once and then streams one row per
-record, instead of repeating every key on every element:
+TOON's largest savings come from uniform arrays of flat objects whose values are
+primitives. Such an array collapses into a table that declares its field names
+once and then streams one row per record, instead of repeating every key on
+every element:
 
 ```bash
 restish api.rest.sh/images -o toon
@@ -137,10 +138,11 @@ collection of nested, irregular objects.
 | ndjson | 3,000 | 2,800 |
 | gron | 6,403 | 6,783 |
 
-On these uniform record collections, TOON is the most token-efficient built-in
-lossless text format, and the lead grows with row count. On nested or irregular
-data, compact JSON and NDJSON edge it out — TOON's per-line indentation
-outweighs the savings — so project to a uniform list first, or stay on JSON.
+On these uniform, primitive-valued record collections, TOON is the most
+token-efficient built-in lossless text format, and the lead grows with row
+count. On nested or irregular data, compact JSON and NDJSON edge it out —
+TOON's per-line indentation outweighs the savings — so project to a flat,
+primitive-valued list first, or stay on JSON.
 
 Not shown: `table` is human-only and truncates long values (lossy), `lines`
 only handles scalar arrays, and `cbor` is binary rather than text.

--- a/site/content/en/docs/reference/output-formats.md
+++ b/site/content/en/docs/reference/output-formats.md
@@ -23,6 +23,7 @@ Document formats produce one coherent result:
 | `yaml` | One YAML document. |
 | `cbor` | One CBOR document. |
 | `gron` | Greppable path/value assignments. |
+| `toon` | Token-dense encoding for feeding responses to LLM agents. |
 | `table` | Terminal table output for records or object collections. |
 | `image` | Terminal image rendering for image responses. |
 
@@ -69,6 +70,86 @@ Tables are for terminal inspection, not stable machine parsing:
 restish api.rest.sh/images -o table --rsh-columns name,format,self
 restish api.rest.sh/images -o table --rsh-sort-by name
 ```
+
+## TOON For Agents
+
+[TOON](https://github.com/toon-format/spec) (Token-Oriented Object Notation) is
+a compact, indentation-based encoding of the JSON data model. It is built for
+feeding API responses to LLM agents — for example when Restish is the tool
+surface an agent calls instead of an MCP server — where every response token
+has a cost.
+
+TOON's savings come from uniform arrays of objects. Such an array collapses
+into a table that declares its field names once and then streams one row per
+record, instead of repeating every key on every element:
+
+```bash
+restish api.rest.sh/images -o toon
+```
+
+```text
+[5]{format,name,self}:
+  jpeg,Dragonfly macro,/images/jpeg
+  webp,Origami under blacklight,/images/webp
+  gif,Andy Warhol mural in Miami,/images/gif
+  png,Station in Prague,/images/png
+  heic,Chihuly glass in boats,/images/heic
+```
+
+Pair `-o toon` with a filter that projects the response down to the records and
+fields you care about. Filtering drops unneeded fields entirely and usually
+saves more tokens than re-encoding alone, and projecting to a uniform list is
+what keeps the tabular form:
+
+```bash
+restish api.rest.sh/images -f '.[] | {name, format}' -o toon
+```
+
+```text
+[5]{format,name}:
+  jpeg,Dragonfly macro
+  webp,Origami under blacklight
+  gif,Andy Warhol mural in Miami
+  png,Station in Prague
+  heic,Chihuly glass in boats
+```
+
+For paginated list endpoints, add `--rsh-collect` so every page is gathered into
+one array and rendered as a single table. Without it, each page's items render
+as separate documents and the tabular savings are lost:
+
+```bash
+restish api.rest.sh/images --rsh-collect -o toon
+```
+
+### How TOON compares
+
+Tokens for the same data rendered in each format, counted with `o200k_base`
+(GPT-4o-class). "Uniform 100" is a 100-row record collection; "Nested 40" is a
+collection of nested, irregular objects.
+
+| Format | Uniform 100 | Nested 40 |
+| --- | --: | --: |
+| **toon** | **1,689** | **3,343** |
+| json (compact) | 2,903 | 2,762 |
+| json (pretty) | 5,002 | 4,842 |
+| yaml | 3,700 | 3,360 |
+| ndjson | 3,000 | 2,800 |
+| gron | 6,403 | 6,783 |
+
+On uniform record collections TOON is the most token-efficient text format, and
+the lead grows with row count. On nested or irregular data, compact JSON and
+NDJSON edge it out — TOON's per-line indentation outweighs the savings — so
+project to a uniform list first, or stay on JSON.
+
+Not shown: `table` is human-only and truncates long values (lossy), `lines`
+only handles scalar arrays, and `cbor` is binary rather than text.
+
+Other tradeoffs:
+
+- TOON is output-only. Restish does not accept TOON request bodies.
+- Token savings only pay off if your model parses TOON as reliably as JSON.
+  Validate against your own model and data before relying on it.
 
 ## Images
 


### PR DESCRIPTION
## Summary

Adds an opt-in, output-only `-o toon` formatter that renders response bodies as
[Token-Oriented Object Notation (TOON, spec v3.3)](https://github.com/toon-format/spec) —
a compact, indentation-based encoding of the JSON data model designed to reduce
token usage when API responses are fed to LLM agents (e.g. when Restish is the
tool surface an agent calls in place of an MCP server).

It's additive and zero-risk to existing behavior: a new value for
`-o/--rsh-output-format`, never a default. The encoder is hand-rolled in
`internal/output` (**no new dependency**) and implements both `Formatter` and
`ValueFormatter`, so it composes with `-f` filtering and paginated/streamed
values.

## Why not just `-o table`?

`table` and `toon` both tabularize uniform records, but for opposite consumers.
`table` is human-only ("not stable machine parsing"), **truncates** long values
(~40 chars), flattens nested data, and loses type fidelity (`null` vs `"null"`,
`3` vs `"3"` render identically). `toon` is a lossless, type-preserving,
machine-parseable serialization that handles arbitrary nesting — at 38–50% fewer
tokens than `table` on uniform data.

## Benchmark (honest, all formats)

Tokens via `tiktoken o200k_base` (GPT-4o-class), rendering each fixture through
the real Restish formatters.

**Fixtures**
- **Uniform 5** — real `api.rest.sh/images`: 5 flat records of 3 string fields.
- **Uniform 100** — 100 synthetic user records, mixed scalar types (int/str/bool).
- **Nested 40** — 40 nested, non-uniform objects (sub-objects + variable arrays); not tabular-eligible.
- **String-heavy** — real `sedric-labs` deployments response; each dominated by a ~1.5 KB embedded prompt string.

| Format | Uniform 5 | Uniform 100 | Nested 40 | String-heavy |
| --- | --: | --: | --: | --: |
| **toon** | **71** | **1,689** | **3,343** | **2,048** |
| json (compact) | 96 | 2,903 | 2,762 | 1,978 |
| json (pretty, `-o json`) | 155 | 5,002 | 4,842 | 2,184 |
| yaml | 108 | 3,700 | 3,360 | 2,009 |
| ndjson | 98 | 3,000 | 2,800 | 2,191 |
| gron | 196 | 6,403 | 6,783 | 2,560 |
| table ¹ | 141 | 2,743 | 1,556 | 686 |
| lines ² | n/a | n/a | n/a | n/a |
| cbor ³ | 288 B | 8,311 B | 6,359 B | 8,121 B |

**TOON token savings vs each text format** (negative = TOON uses more):

| vs | Uniform 5 | Uniform 100 | Nested 40 | String-heavy |
| --- | --: | --: | --: | --: |
| json (compact) | +26% | +42% | −21% | −4% |
| json (pretty) | +54% | +66% | +31% | +6% |
| yaml | +34% | +54% | +1% | −2% |
| ndjson | +28% | +44% | −19% | +7% |
| gron | +64% | +74% | +51% | +20% |
| table ¹ | +50% | +38% | −115% | −199% |

¹ `table` truncates long values + flattens nesting — its low nested/string counts are **dropped data**, not efficiency; also human-only and loses type fidelity.
² `lines` only renders arrays of scalars.
³ `cbor` is binary (bytes shown), not LLM text.

**Takeaways (no cherry-picking):**
- On uniform record collections — the REST list-endpoint shape — TOON is the most token-efficient text format, and the win **grows with row count** (+26% → +42% vs compact JSON from 5 to 100 rows; holds at +42% at 500 rows).
- It beats **pretty JSON, YAML, and gron on every shape tested**.
- On nested/irregular or string-dominated payloads, **compact JSON and NDJSON are slightly smaller** — TOON's per-line indentation outweighs the brace/quote savings. That's why it's opt-in and the docs steer users to project to a uniform list first.

## Usage

```bash
restish api.rest.sh/images -o toon                       # full response
restish api.rest.sh/images -f '.[] | {name, format}' -o toon   # project, then encode
restish api.rest.sh/images --rsh-collect -o toon          # one table across all pages
```

## Notes

- **Output only.** Restish does not accept TOON request bodies (out of scope; agents emit JSON bodies fine).
- **Hand-rolled vs vendored:** the only Go TOON lib (`toon-format/toon-go`) is MIT but untagged/single-author/~9 commits — too immature for this surface. The encoder is small, owned in-repo, and pinned to spec v3.3 with golden-style tests.
- Includes a small fix: adding a format made the unknown-`-o` "did you mean?" suggestion ambiguous (`jsoon` ↔ json/toon), which dropped the hint; now it picks the strictly nearest name.

## Tests / verification

- New encoder tests (objects, inline arrays, tabular, expanded-list, empties, quoting, number canonicalization, key quoting, body-only, writer errors) + a regression test for the suggestion change.
- `go test ./...` and `go test -tags=integration ./...` pass; `gofmt`/`go vet` clean.
- Verified live against `api.rest.sh` and a real internal API.

See `docs/design/041-toon-output-format.md` for the full design, decision record, and benchmark methodology.
