### PR TITLE
docs: add OpenAPI CLI blog post

### DIFF
--- a/.agents/skills/rsh-docs/SKILL.md
+++ b/.agents/skills/rsh-docs/SKILL.md
@@ -168,6 +168,19 @@ Avoid making blog posts the only source for exact commands, migration steps, or
 security-sensitive behavior; link to durable docs and update those docs when the
 post reveals a gap.
 
+### Blog Improvement
+
+Whenever you write a new blog post or modify an existing one, spin off a sub-agent to do a review of the changes and suggest improvements, which you should then apply. The review should check for:
+
+1. Clarity: Is the post easy to understand? Are there any ambiguous statements or jargon that could be clarified?
+2. Engagement: Does the post have a compelling hook? Does it maintain the reader's interest throughout?
+3. Accuracy: Are all technical details correct? Are there any factual errors or misleading statements?
+   1. Commands should prefer shorthand in examples over jq or plain JSON when possible.
+   2. Do not use `get` or `post` in examples when the auto mode is clear (e.g., `restish api.rest.sh/example` instead of `restish get api.rest.sh/example`).
+   3. Do not add options for no reason. E.g. `--rsh-no-paginate` when not talking explicitly about pagination, or `--rsh-columns` when the default output is fine. This complicates commands and makes it harder for readers. Another good example is `-o lines` unless it significantly improves readability of the output.
+4. Structure: Is the post well-organized? Does it have a logical flow from introduction to conclusion? Do the headings make sense (and are they short enough to not wrap for common screen widths)?
+5. Do all the command examples actually make sense? Are they good examples, or could they be improved to better illustrate the point? Are the examples in the right place in the post or should they be moved?
+
 ## Plugin Docs
 
 Always separate operator docs from author docs. Operators need install/configure/run/verify/debug. Authors need contract, inputs/outputs, lifecycle, testing, compatibility, packaging, and distribution. Do not make operators read authoring internals to use a plugin.

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1286,6 +1286,117 @@ body.td-home .td-navbar__search .td-search-input {
   color: var(--restish-card-title);
 }
 
+.restish-anatomy {
+  --anatomy-bin-color: #2563eb;
+  --anatomy-api-color: #0f766e;
+  --anatomy-op-color: #b45309;
+  --anatomy-option-color: #7c3aed;
+  --anatomy-arg-color: #be123c;
+  --anatomy-body-color: #15803d;
+  --anatomy-command-bg: #f8fafc;
+  --anatomy-command-border: rgba(15, 23, 42, 0.12);
+
+  margin: 1.5rem 0;
+  overflow: hidden;
+  border: 1px solid rgba(99, 102, 241, 0.28);
+  border-radius: 8px;
+  background: var(--restish-card-bg-top);
+}
+
+.restish-anatomy__command {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--anatomy-command-border);
+  background: var(--anatomy-command-bg);
+  color: var(--restish-card-title);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  white-space: pre;
+}
+
+.restish-anatomy__command code {
+  color: inherit;
+}
+
+.restish-anatomy__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.restish-anatomy__item {
+  min-width: 0;
+  padding: 0.15rem 0 0.15rem 0.75rem;
+  border-left: 0.3rem solid var(--anatomy-color);
+}
+
+.restish-anatomy__label {
+  display: block;
+  color: var(--anatomy-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.restish-anatomy__item code {
+  overflow-wrap: anywhere;
+}
+
+.restish-anatomy__item > code {
+  display: inline-block;
+  max-width: 100%;
+  color: var(--anatomy-color);
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.restish-anatomy__from {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--restish-card-title);
+  font-weight: 700;
+}
+
+.restish-anatomy__note {
+  display: block;
+  margin-top: 0.1rem;
+}
+
+.anatomy-bin {
+  --anatomy-color: var(--anatomy-bin-color);
+}
+
+.anatomy-api {
+  --anatomy-color: var(--anatomy-api-color);
+}
+
+.anatomy-op {
+  --anatomy-color: var(--anatomy-op-color);
+}
+
+.anatomy-option {
+  --anatomy-color: var(--anatomy-option-color);
+}
+
+.anatomy-arg {
+  --anatomy-color: var(--anatomy-arg-color);
+}
+
+.anatomy-body {
+  --anatomy-color: var(--anatomy-body-color);
+}
+
+.restish-anatomy__command .anatomy-bin,
+.restish-anatomy__command .anatomy-api,
+.restish-anatomy__command .anatomy-op,
+.restish-anatomy__command .anatomy-option,
+.restish-anatomy__command .anatomy-arg,
+.restish-anatomy__command .anatomy-body {
+  color: var(--anatomy-color);
+}
+
 .restish-blog-cta {
   display: grid;
   gap: 1.2rem;
@@ -1400,6 +1511,49 @@ a.restish-blog-rail-card {
   color: var(--restish-link-color);
 }
 
+.restish-blog-post-nav {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.restish-blog-post-nav__link {
+  display: block;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--restish-card-border);
+  color: var(--restish-card-text);
+  text-decoration: none;
+}
+
+.restish-blog-post-nav__link:first-of-type {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.restish-blog-post-nav__link span,
+.restish-blog-post-nav__link time {
+  display: block;
+  color: var(--restish-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.restish-blog-post-nav__link b {
+  display: block;
+  margin: 0.18rem 0;
+  color: var(--restish-link-color);
+  font-size: 0.9rem;
+  line-height: 1.25;
+}
+
+.restish-blog-post-nav__link:hover b,
+.restish-blog-post-nav__link:focus b {
+  color: var(--restish-nav-hover);
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+}
+
 [data-bs-theme="dark"] .restish-blog,
 [data-bs-theme="dark"] .restish-blog .td-main {
   background: var(--bs-body-bg);
@@ -1411,6 +1565,17 @@ a.restish-blog-rail-card {
 
 [data-bs-theme="dark"] .restish-blog-callout {
   background: rgba(45, 212, 191, 0.1);
+}
+
+[data-bs-theme="dark"] .restish-anatomy {
+  --anatomy-bin-color: #93c5fd;
+  --anatomy-api-color: #5eead4;
+  --anatomy-op-color: #fbbf24;
+  --anatomy-option-color: #c4b5fd;
+  --anatomy-arg-color: #fda4af;
+  --anatomy-body-color: #86efac;
+  --anatomy-command-bg: #111827;
+  --anatomy-command-border: rgba(148, 163, 184, 0.18);
 }
 
 [data-bs-theme="dark"] .restish-blog-rail-card {

--- a/site/content/en/blog/turn-an-openapi-spec-into-a-cli-without-generating-code.md
+++ b/site/content/en/blog/turn-an-openapi-spec-into-a-cli-without-generating-code.md
@@ -1,0 +1,397 @@
+---
+title: "Turn an OpenAPI Spec Into a CLI Without Generating Code"
+linkTitle: "Turn an OpenAPI Spec Into a CLI Without Generating Code"
+date: 2026-06-08
+author: "Daniel Taylor"
+description: OpenAPI can be more than SDK input or Swagger UI data. Restish loads API descriptions at runtime and turns them into shell-native commands with profiles, auth, output, pagination, and MCP-ready extension points.
+canonical_url: "https://rest.sh/blog/turn-an-openapi-spec-into-a-cli-without-generating-code/"
+categories:
+  - OpenAPI
+tags:
+  - openapi
+  - cli
+  - rest
+  - devtools
+---
+
+OpenAPI is usually treated as an input to something else. Generate an SDK. Render
+Swagger UI. Publish reference docs. Feed a contract test. All of those are good
+jobs for a spec.
+
+But there is another useful job hiding in the same document: teach the terminal
+how to work with the API.
+
+That does not have to mean generating a new repository, choosing a language
+runtime, publishing a package, and keeping a client binary in sync with every
+operation change. A CLI can load an OpenAPI description at runtime, cache what it
+needs, and turn repeated API work into commands without making users rebuild a
+client.
+
+That is the core bet behind Restish. It can still make a one-off HTTP request,
+but once an API publishes OpenAPI, Restish can turn that API into a small
+shell-native command group.
+
+<div class="restish-blog-callout">
+  <strong>Try it as you read.</strong> Runnable examples below use the browser
+  preview against the public <code>api.rest.sh</code> API. Local setup commands
+  are shown as fenced shell snippets because they write Restish config on your
+  machine.
+</div>
+
+## Start With Plain HTTP
+
+A good API CLI still needs the universal escape hatch: send a request to a URL.
+Restish does not require setup before it is useful.
+
+{{< restish-example >}}
+restish api.rest.sh/auth/bearer -H 'Authorization: Bearer docs-token'
+{{< /restish-example >}}
+
+That path matters because API work often starts messy. You paste a URL from a
+bug report, check a response header, inspect an error body, or try one endpoint
+before you know whether the API deserves local setup.
+
+That is useful, but it is not the whole job. The moment you call the same API
+repeatedly, the URL, auth, parameters, output shape, and pagination rules start
+becoming a little client you keep reconstructing by hand.
+
+OpenAPI already knows a lot of that.
+
+## Register The API Once
+
+When an API publishes an OpenAPI document, connect it to Restish:
+
+```bash
+restish api connect example api.rest.sh
+restish example --help
+```
+
+Restish discovers the spec, stores the API registration, and caches the
+description. The API name becomes a command group. After that, generated
+operations are available under `restish example ...`.
+
+The browser preview used in these docs has a built-in `example` mapping, so you
+can try the generated-command shape without writing local config:
+
+{{< restish-example >}}
+restish example get-auth-bearer
+{{< /restish-example >}}
+
+That command is not a wrapper around a handwritten `curl` string. It comes from
+the API description. Restish knows the operation, parameters, path, response
+shape, and profile context, then runs the request through the same pipeline used
+by ordinary URL requests.
+
+## What The Spec Becomes
+
+OpenAPI has many fields that look like documentation metadata until a CLI starts
+using them as interface design.
+
+`operationId` becomes a command name:
+
+```yaml
+paths:
+  /items/{item-id}:
+    get:
+      operationId: getItem
+      summary: Get one item
+```
+
+Restish turns that into:
+
+```bash
+restish myapi get-item alpha
+```
+
+Path parameters become positional arguments. Optional query, header, and cookie
+parameters become flags. Summaries and descriptions become help text. Schemas
+describe request bodies and parameter types. Servers influence where operations
+are sent. Security requirements tell Restish which credentials an operation can
+use.
+
+Here is the anatomy of a generated command:
+
+<div class="restish-anatomy">
+  <pre class="restish-anatomy__command"><code><span class="anatomy-bin">restish</span> <span class="anatomy-api">inventory</span> <span class="anatomy-op">update-item</span> <span class="anatomy-option">--dry-run</span> <span class="anatomy-arg">item-123</span> <span class="anatomy-body">'name: Travel mug, enabled: true'</span></code></pre>
+  <div class="restish-anatomy__grid">
+    <div class="restish-anatomy__item anatomy-bin">
+      <span class="restish-anatomy__label">Binary</span>
+      <code>restish</code>
+      <span class="restish-anatomy__from">Restish itself</span>
+      <span class="restish-anatomy__note">The universal entry point.</span>
+    </div>
+    <div class="restish-anatomy__item anatomy-api">
+      <span class="restish-anatomy__label">API</span>
+      <code>inventory</code>
+      <span class="restish-anatomy__from">Chosen during <code>api connect</code></span>
+      <span class="restish-anatomy__note">Local operator vocabulary, not an OpenAPI field.</span>
+    </div>
+    <div class="restish-anatomy__item anatomy-op">
+      <span class="restish-anatomy__label">Operation</span>
+      <code>update-item</code>
+      <span class="restish-anatomy__from"><code>operationId: updateItem</code></span>
+      <span class="restish-anatomy__note">The operation ID becomes the command name.</span>
+    </div>
+    <div class="restish-anatomy__item anatomy-option">
+      <span class="restish-anatomy__label">Option</span>
+      <code>--dry-run</code>
+      <span class="restish-anatomy__from">Optional query parameter <code>dry_run</code></span>
+      <span class="restish-anatomy__note">Optional parameters become flags.</span>
+    </div>
+    <div class="restish-anatomy__item anatomy-arg">
+      <span class="restish-anatomy__label">Argument</span>
+      <code>item-123</code>
+      <span class="restish-anatomy__from">Required path parameter <code>item-id</code></span>
+      <span class="restish-anatomy__note">Required path parameters become positional arguments.</span>
+    </div>
+    <div class="restish-anatomy__item anatomy-body">
+      <span class="restish-anatomy__label">Body</span>
+      <code>'name: Travel mug, enabled: true'</code>
+      <span class="restish-anatomy__from">JSON request body schema</span>
+      <span class="restish-anatomy__note">Body input can come from shorthand, stdin, or a file.</span>
+    </div>
+  </div>
+</div>
+
+The corresponding OpenAPI operation might look like this:
+
+```yaml
+paths:
+  /items/{item-id}:
+    patch:
+      operationId: updateItem
+      summary: Update one item
+      parameters:
+        - name: item-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: dry_run
+          in: query
+          schema:
+            type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                enabled:
+                  type: boolean
+```
+
+That means spec quality becomes CLI quality. Stable operation IDs, clear
+parameter names, accurate schemas, and honest auth metadata are not only good
+for docs. They make the generated command easier to discover, complete, and run.
+
+When a spec needs CLI-specific polish, Restish supports targeted extensions:
+
+```yaml
+x-cli-name: list-items
+x-cli-aliases: [items]
+x-cli-description: List items with optional filtering.
+```
+
+Those extensions should stay small. OpenAPI remains the source of truth for the
+API. Restish-specific hints are for command vocabulary, hiding confusing
+operations, auth setup hints, and other terminal UX details that the base spec
+cannot express cleanly.
+
+## Why Runtime Helps
+
+Generated SDKs make sense inside applications. A service written in Go,
+TypeScript, Python, or Java usually wants typed calls, versioned dependencies,
+and application-local error handling. That is a different job.
+
+A terminal workflow has different constraints:
+
+- users want the newest operation without waiting for a released client
+- commands need to compose with files, pipes, `jq`, `grep`, and CI scripts
+- auth and environment selection belong in local profiles
+- output has to be helpful for humans and boring for scripts
+- debugging often starts before anyone knows which language a real integration
+  will use
+
+Runtime generation fits that shape. You connect an API once, then sync the spec
+when it changes:
+
+```bash
+restish api sync example
+restish example --help
+```
+
+There is still caching. Restish should not fetch and parse a large spec for
+every shell completion or every request. But the cached artifact is local
+operational state, not a generated client project that must be reviewed,
+published, installed, and eventually forgotten.
+
+This also keeps API examples honest. Documentation can say:
+
+```bash
+restish example get-image jpeg > dragonfly.jpg
+```
+
+That example is both readable to a person and connected to the live API shape
+after sync. If the API publishes a better command name, updated schema, or new
+auth metadata, the CLI can pick it up from the spec instead of waiting for a new
+handwritten wrapper.
+
+## Output Is A Contract
+
+Turning OpenAPI into commands only helps if the result behaves like a good CLI.
+The generated command should not dump surprising diagnostics into a script, add
+color to piped output, or corrupt a downloaded file because the tool tried to be
+helpful.
+
+Restish v2 treats output as a product contract:
+
+- `stdout` carries the selected response data
+- `stderr` carries diagnostics, warnings, progress, and verbose traces
+- terminal output can be readable by default
+- redirected unfiltered responses preserve body bytes
+- explicit filters and formats produce structured output for the next program
+
+For example, ask for one field from every paginated item:
+
+{{< restish-example >}}
+restish example list-images -f body.self
+{{< /restish-example >}}
+
+The same rule applies to generated OpenAPI commands and plain URL requests. The
+API-aware layer should add names, help, auth, and request shaping. It should not
+break the shell contract underneath.
+
+## Auth Belongs With Profiles
+
+OpenAPI command generation becomes much more useful when credentials are not
+pasted into every command.
+
+Restish keeps repeated auth in profiles. A profile can hold API keys, bearer
+tokens, OAuth configuration, mTLS settings, external tool auth, base URLs,
+headers, query defaults, and OpenAPI credential bindings.
+
+The practical difference is that this:
+
+```bash
+restish github list-issues --state open
+```
+
+can carry the right base URL, token source, TLS config, and operation-specific
+credential choice without turning every docs example into a wall of headers.
+
+OpenAPI security matters here. Some operations are public. Some allow several
+auth alternatives. Some require a credential that should only be used for a
+subset of operations. Restish v2 treats operation security as request execution
+metadata, not as one global header pasted onto every generated call.
+
+That is where a runtime CLI can feel more like a local tool than a copied HTTP
+example. Profiles remember the environment. The spec explains the operation.
+The command stays small enough to type.
+
+## The Same Source Can Feed Agents
+
+OpenAPI-to-CLI is also a useful bridge to agent tools.
+
+For humans, Restish turns OpenAPI operations into terminal commands. For MCP
+clients, the `restish-mcp` plugin can expose registered operations as tools:
+
+```bash
+restish mcp serve example
+```
+
+That does not mean every endpoint should be exposed to every model, user, or
+profile. Restish keeps MCP conservative by default: read-oriented tools are
+shown first, write tools require explicit opt-in, and operations can be
+allowlisted or hidden.
+
+The important part is that both interfaces use the same source of truth. The
+OpenAPI document describes the API. Restish profiles carry local auth and
+environment choices. The request pipeline owns TLS, retries, timeouts,
+normalization, filtering, and output behavior.
+
+Humans use the CLI. Agents use MCP. The API should not need a separate pile of
+handwritten glue for each one.
+
+There is also a lighter-weight path when an agent is calling Restish through an
+ordinary command instead of MCP: render the response as TOON.
+[TOON](https://github.com/toon-format/spec) is a token-dense text encoding for
+JSON-shaped data, and Restish now supports it with `-o toon`:
+
+{{< restish-example >}}
+restish api.rest.sh/images -f 'body.{name, format}' -o toon
+{{< /restish-example >}}
+
+That is not a replacement for filtering. The biggest savings still come from
+projecting the response down to the records and fields the agent needs, then
+using TOON when the remaining shape is a uniform list. Restish treats TOON as
+output-only, so JSON remains the format to use for request bodies and for
+workflows where the consumer expects standard JSON. The
+[output formats reference](/docs/reference/output-formats/#toon-for-agents)
+covers the tradeoffs.
+
+## CLI-Friendly Specs
+
+If you publish an API and want it to work well in tools like Restish, start with
+the ordinary OpenAPI basics:
+
+- publish the spec at a predictable URL such as `/openapi.json`
+- use stable, human-readable `operationId` values
+- write summaries that make sense as command help
+- give parameters clear names and accurate schemas
+- describe request and response bodies honestly
+- model auth per operation, including public operations
+- provide examples for tricky request shapes
+- expose pagination links or enough metadata for clients to proceed safely
+
+Then test the terminal shape:
+
+```bash
+restish api connect myapi https://api.example.test
+restish myapi --help
+restish doctor api myapi
+```
+
+If the generated commands are awkward, the fix is often useful beyond Restish.
+Better operation IDs improve docs anchors. Better schemas improve SDKs. Better
+security metadata improves Swagger UI, contract tests, and agent tools.
+
+That is the quiet advantage of OpenAPI as a shared interface contract. A spec
+that can teach a terminal usually teaches other tools better too.
+
+## Try It Locally
+
+Install Restish:
+
+```bash
+brew install restish
+restish --version
+```
+
+Or with Go:
+
+```bash
+go install github.com/rest-sh/restish/v2/cmd/restish@latest
+restish --help
+```
+
+Connect the public example API:
+
+```bash
+restish api connect example api.rest.sh
+restish example --help
+restish example list-images
+```
+
+Useful next stops:
+
+- [Connect to an API](/docs/getting-started/connect-to-an-api/) covers setup, explicit spec URLs, sync, and project config.
+- [OpenAPI Reference](/docs/reference/openapi-cli-integration/) explains command naming, parameters, extensions, and generated help.
+- [Output Guide](/docs/guides/output/) covers formats, filters, redirects, and script-friendly output.
+- [Authentication Guide](/docs/guides/authentication/) covers profiles and repeated credentials.
+- [Serve APIs Over MCP](/docs/plugins/mcp/) shows how registered APIs become MCP tools.
+
+OpenAPI is not only for generated SDKs and browser docs. If the spec already
+knows the API, the terminal should be able to learn from it too.

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -40,6 +40,38 @@
           {{ . }}
         </div>
       {{ end -}}
+      {{ $pages := .CurrentSection.RegularPages.ByDate.Reverse -}}
+      {{ $newerPost := false -}}
+      {{ $olderPost := false -}}
+      {{ range $index, $page := $pages -}}
+        {{ if eq $page.RelPermalink $.RelPermalink -}}
+          {{ if gt $index 0 -}}
+            {{ $newerPost = index $pages (sub $index 1) -}}
+          {{ end -}}
+          {{ if lt (add $index 1) (len $pages) -}}
+            {{ $olderPost = index $pages (add $index 1) -}}
+          {{ end -}}
+        {{ end -}}
+      {{ end -}}
+      {{ if or $newerPost $olderPost -}}
+        <nav class="restish-blog-rail-card restish-blog-post-nav" aria-label="Adjacent blog posts">
+          <strong>More posts</strong>
+          {{ with $newerPost -}}
+            <a class="restish-blog-post-nav__link" href="{{ .RelPermalink }}">
+              <span>Newer post</span>
+              <b>{{ .LinkTitle | default .Title }}</b>
+              <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format ($.Site.Params.time_format_blog | default "Jan 2, 2006") }}</time>
+            </a>
+          {{ end -}}
+          {{ with $olderPost -}}
+            <a class="restish-blog-post-nav__link" href="{{ .RelPermalink }}">
+              <span>Older post</span>
+              <b>{{ .LinkTitle | default .Title }}</b>
+              <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format ($.Site.Params.time_format_blog | default "Jan 2, 2006") }}</time>
+            </a>
+          {{ end -}}
+        </nav>
+      {{ end -}}
     </aside>
   </div>
 </article>

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "social-images": "node scripts/generate-social-images.mjs",
+    "test": "node scripts/test-restish-playground.mjs",
     "dev": "npm run social-images && hugo server",
     "build": "npm run social-images && hugo"
   },

--- a/site/scripts/test-restish-playground.mjs
+++ b/site/scripts/test-restish-playground.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siteDir = path.resolve(__dirname, "..");
+const repoDir = path.resolve(siteDir, "..");
+
+const source = await readFile(path.join(siteDir, "static/js/restish-playground.js"), "utf8");
+const sandbox = {
+  AbortController,
+  URL,
+  URLSearchParams,
+  console,
+  document: {
+    readyState: "loading",
+    addEventListener() {},
+    createElement() {
+      return {};
+    },
+    querySelectorAll() {
+      return [];
+    }
+  },
+  fetch() {
+    throw new Error("fetch should not be called by playground unit tests");
+  },
+  navigator: {},
+  window: {
+    __RESTISH_PLAYGROUND_TEST__: true,
+    addEventListener() {},
+    clearTimeout,
+    isSecureContext: false,
+    requestAnimationFrame(callback) {
+      callback();
+    },
+    setTimeout
+  },
+  MutationObserver: class {
+    observe() {}
+  }
+};
+
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: "restish-playground.js" });
+
+const api = sandbox.window.__restishPlaygroundTest;
+assert.ok(api, "playground test API should be exposed");
+
+const toonPlan = api.parseCommand("restish get https://api.rest.sh/items -o toon");
+assert.equal(toonPlan.flags.outputFormat, "toon");
+assert.equal(
+  api.render({
+    proto: "HTTP/2.0",
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: { items: [{ id: 1, name: "Ada" }] }
+  }, toonPlan, null),
+  "items[1]{id,name}:\n  1,Ada\n"
+);
+
+const fixtureDir = path.join(repoDir, "internal/output/testdata/toon/encode");
+let checked = 0;
+for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith(".json")).sort()) {
+  const fixture = JSON.parse(await readFile(path.join(fixtureDir, file), "utf8"));
+  for (const testCase of fixture.tests) {
+    if (testCase.shouldError || !usesDefaultTOONOptions(testCase.options || {})) {
+      continue;
+    }
+    checked += 1;
+    assert.equal(
+      api.encodeTOONDocument(testCase.input),
+      testCase.expected,
+      `${file}: ${testCase.name}`
+    );
+  }
+}
+
+assert.ok(checked > 0, "TOON fixture suite should include default-option cases");
+console.log(`restish-playground: ${checked} TOON encode fixtures passed`);
+
+function usesDefaultTOONOptions(options) {
+  return Object.entries(options).every(([key, value]) => {
+    if (key === "delimiter") return value === ",";
+    if (key === "indent") return value === 2;
+    if (key === "keyFolding") return value === "off";
+    return false;
+  });
+}

--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -22,7 +22,7 @@
     ["--rsh-retry", "retry"],
     ["--rsh-retry-max-wait", "retryMaxWait"]
   ]);
-  const supportedOutputFormats = new Set(["auto", "json", "yaml", "ndjson", "lines", "table", "image", "gron", "csv"]);
+  const supportedOutputFormats = new Set(["auto", "json", "yaml", "ndjson", "lines", "table", "image", "gron", "csv", "toon"]);
   const boolFlags = new Map([
     ["-v", "verbose"],
     ["-vv", "verbose"],
@@ -1626,6 +1626,9 @@
     if (flags.outputFormat === "csv") {
       return csvOutput(value, flags.columns);
     }
+    if (flags.outputFormat === "toon") {
+      return toonOutput(value);
+    }
     if (explicitFilter) {
       return renderValue(value, flags);
     }
@@ -1927,6 +1930,9 @@
     if (flags.outputFormat === "csv") {
       return csvOutput(value, flags.columns);
     }
+    if (flags.outputFormat === "toon") {
+      return toonOutput(value);
+    }
     return readableFilteredOutput(value);
   }
 
@@ -2046,6 +2052,241 @@
     }
     return text;
   }
+
+  function toonOutput(value) {
+    return encodeTOONDocument(value) + "\n";
+  }
+
+  function encodeTOONDocument(value) {
+    return encodeTOONRoot(value).replace(/\n+$/, "");
+  }
+
+  function encodeTOONRoot(value) {
+    if (isTOONObject(value)) {
+      return encodeTOONObject(0, value);
+    }
+    if (Array.isArray(value)) {
+      if (!value.length) {
+        return "[]\n";
+      }
+      return encodeTOONArray(0, "", value, { allowTabular: true });
+    }
+    return encodeTOONScalar(value) + "\n";
+  }
+
+  function encodeTOONObject(depth, obj) {
+    return toonObjectFields(obj).map((field) => encodeTOONField(depth, field.key, field.value)).join("");
+  }
+
+  function encodeTOONField(depth, key, value) {
+    const keyToken = encodeTOONKey(key);
+    if (isTOONObject(value)) {
+      return `${toonIndent(depth)}${keyToken}:\n${encodeTOONObject(depth + 1, value)}`;
+    }
+    if (Array.isArray(value)) {
+      return encodeTOONArray(depth, keyToken, value, { allowTabular: true });
+    }
+    return `${toonIndent(depth)}${keyToken}: ${encodeTOONScalar(value)}\n`;
+  }
+
+  function encodeTOONArray(depth, keyToken, arr, context) {
+    const indent = toonIndent(depth);
+    if (!arr.length) {
+      if (keyToken) {
+        return `${indent}${keyToken}: []\n`;
+      }
+      return context.emptyArrayHeader ? `${indent}[0]:\n` : `${indent}[]\n`;
+    }
+
+    if (arr.every(isTOONPrimitive)) {
+      return `${indent}${keyToken}[${arr.length}]: ${arr.map(encodeTOONScalar).join(",")}\n`;
+    }
+
+    if (context.allowTabular) {
+      const fields = toonTabularFields(arr);
+      if (fields) {
+        let out = `${indent}${keyToken}[${arr.length}]{${fields.map(encodeTOONKey).join(",")}}:\n`;
+        for (const item of arr) {
+          out += `${toonIndent(depth + 1)}${fields.map((field) => encodeTOONScalar(item[field])).join(",")}\n`;
+        }
+        return out;
+      }
+    }
+
+    let out = `${indent}${keyToken}[${arr.length}]:\n`;
+    for (const item of arr) {
+      out += encodeTOONListItem(depth + 1, item);
+    }
+    return out;
+  }
+
+  function encodeTOONListItem(depth, item) {
+    if (isTOONObject(item)) {
+      const fields = toonObjectFields(item);
+      if (!fields.length) {
+        return `${toonIndent(depth)}-\n`;
+      }
+      return toonDashItem(depth, encodeTOONObject(depth + 1, item));
+    }
+    if (Array.isArray(item)) {
+      return toonDashArrayItem(depth, encodeTOONArray(depth + 1, "", item, {
+        allowTabular: false,
+        emptyArrayHeader: true
+      }));
+    }
+    return `${toonIndent(depth)}- ${encodeTOONScalar(item)}\n`;
+  }
+
+  function toonTabularFields(arr) {
+    let fields = null;
+    for (const item of arr) {
+      if (!isTOONObject(item)) {
+        return null;
+      }
+      const itemFields = toonObjectFields(item);
+      if (!itemFields.length || itemFields.some((field) => !isTOONPrimitive(field.value))) {
+        return null;
+      }
+      if (!fields) {
+        fields = itemFields.map((field) => field.key);
+        continue;
+      }
+      if (itemFields.length !== fields.length || fields.some((field) => !Object.prototype.hasOwnProperty.call(item, field))) {
+        return null;
+      }
+    }
+    return fields;
+  }
+
+  function isTOONObject(value) {
+    return value && typeof value === "object" && !Array.isArray(value);
+  }
+
+  function isTOONPrimitive(value) {
+    return !isTOONObject(value) && !Array.isArray(value);
+  }
+
+  function toonObjectFields(obj) {
+    return Object.keys(obj).map((key) => ({ key, value: obj[key] }));
+  }
+
+  function encodeTOONScalar(value) {
+    if (value === null || value === undefined) {
+      return "null";
+    }
+    if (typeof value === "boolean") {
+      return value ? "true" : "false";
+    }
+    if (typeof value === "number") {
+      return encodeTOONNumber(value);
+    }
+    return encodeTOONString(String(value));
+  }
+
+  function encodeTOONNumber(value) {
+    if (!Number.isFinite(value)) {
+      return "null";
+    }
+    if (Object.is(value, -0)) {
+      return "0";
+    }
+    return String(value);
+  }
+
+  function encodeTOONString(value) {
+    return toonStringNeedsQuote(value) ? quoteTOONString(value) : value;
+  }
+
+  function encodeTOONKey(key) {
+    return /^[A-Za-z_][A-Za-z0-9_.]*$/.test(key) ? key : quoteTOONString(key);
+  }
+
+  function toonStringNeedsQuote(value) {
+    if (value === "" || value === "true" || value === "false" || value === "null") {
+      return true;
+    }
+    if (value[0] === "-") {
+      return true;
+    }
+    if (value.trim() !== value) {
+      return true;
+    }
+    if (/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(value)) {
+      return true;
+    }
+    if (/[:"\\[\]{},]/.test(value)) {
+      return true;
+    }
+    for (const ch of value) {
+      if (ch.codePointAt(0) <= 0x1f) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function quoteTOONString(value) {
+    let out = "\"";
+    for (const ch of value) {
+      const code = ch.codePointAt(0);
+      if (ch === "\\") {
+        out += "\\\\";
+      } else if (ch === "\"") {
+        out += "\\\"";
+      } else if (ch === "\n") {
+        out += "\\n";
+      } else if (ch === "\r") {
+        out += "\\r";
+      } else if (ch === "\t") {
+        out += "\\t";
+      } else if (code <= 0x1f) {
+        out += `\\u${code.toString(16).padStart(4, "0")}`;
+      } else {
+        out += ch;
+      }
+    }
+    return out + "\"";
+  }
+
+  function toonDashItem(depth, content) {
+    const strip = toonIndentUnit.length * (depth + 1);
+    return `${toonIndent(depth)}- ${content.slice(strip)}`;
+  }
+
+  function toonDashArrayItem(depth, content) {
+    const firstLineStrip = toonIndentUnit.length * (depth + 1);
+    const lines = toonLines(content);
+    let out = `${toonIndent(depth)}- `;
+    lines.forEach((line, index) => {
+      if (index === 0) {
+        out += line.slice(firstLineStrip);
+      } else if (line.startsWith(toonIndentUnit)) {
+        out += line.slice(toonIndentUnit.length);
+      } else {
+        out += line;
+      }
+    });
+    return out;
+  }
+
+  function toonLines(content) {
+    const lines = content.split("\n");
+    const out = [];
+    lines.forEach((line, index) => {
+      if (index < lines.length - 1) {
+        out.push(line + "\n");
+      } else if (line) {
+        out.push(line);
+      }
+    });
+    return out;
+  }
+
+  function toonIndent(depth) {
+    return toonIndentUnit.repeat(depth);
+  }
+
+  const toonIndentUnit = "  ";
 
   function gronOutput(value) {
     const lines = [];
@@ -2569,6 +2810,15 @@
 
   function initAllPlaygrounds() {
     document.querySelectorAll("[data-restish-playground]").forEach(initPlayground);
+  }
+
+  if (window.__RESTISH_PLAYGROUND_TEST__) {
+    window.__restishPlaygroundTest = {
+      encodeTOONDocument,
+      parseCommand,
+      render,
+      toonOutput
+    };
   }
 
   if (document.readyState === "loading") {

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -1,0 +1,47 @@
+# Restish
+
+> Restish is a shell-native CLI for interacting with REST-ish HTTP APIs. It supports direct HTTP requests, OpenAPI-generated commands, profiles, authentication, content negotiation, pagination, filtering, output formatting, caching, retries, and plugins.
+
+Use these docs to understand how to install Restish, connect it to APIs, make requests, configure authentication, and use generated OpenAPI commands. Prefer current docs under `/docs/` over archived v1 docs under `/v1/`.
+
+## Start Here
+
+- [Tour](https://rest.sh/docs/getting-started/tour/): A practical walkthrough of Restish's main CLI workflows.
+- [Install](https://rest.sh/docs/getting-started/install/): Installation options and first setup.
+- [Connect to an API](https://rest.sh/docs/getting-started/connect-to-an-api/): How Restish discovers and uses API descriptions.
+- [Set Up Profiles](https://rest.sh/docs/getting-started/set-up-profiles/): Configure named API environments.
+
+## Core Guides
+
+- [Requests](https://rest.sh/docs/guides/requests/): Make HTTP requests and API-aware commands.
+- [API setup and discovery](https://rest.sh/docs/guides/api-setup-and-discovery/): Load OpenAPI specs and generate commands.
+- [Authentication](https://rest.sh/docs/guides/authentication/): Configure auth for APIs and profiles.
+- [Input and shorthand](https://rest.sh/docs/guides/input/): Send request bodies, files, forms, and shorthand data.
+- [Output](https://rest.sh/docs/guides/output/): Understand response rendering and formats.
+- [Filtering](https://rest.sh/docs/guides/filtering/): Select and transform response data.
+- [Pagination](https://rest.sh/docs/guides/pagination/): Traverse paginated APIs.
+- [Streaming](https://rest.sh/docs/guides/streaming/): Work with streaming responses.
+
+## Reference
+
+- [Commands](https://rest.sh/docs/reference/commands/): Command reference.
+- [Global Flags](https://rest.sh/docs/reference/global-flags/): Shared CLI flags.
+- [OpenAPI CLI Integration](https://rest.sh/docs/reference/openapi-cli-integration/): Generated command behavior.
+- [Config](https://rest.sh/docs/reference/config/): Configuration files and fields.
+- [Output Formats](https://rest.sh/docs/reference/output-formats/): Supported output formats.
+- [Shorthand](https://rest.sh/docs/reference/shorthand/): Input shorthand syntax.
+- [Example API](https://rest.sh/docs/reference/example-api/): Public examples used throughout the docs.
+
+## Plugins
+
+- [Install and Use Plugins](https://rest.sh/docs/plugins/install-and-use/): Operator guide for Restish plugins.
+- [MCP Plugin](https://rest.sh/docs/plugins/mcp/): Serve API commands over Model Context Protocol.
+- [Command Plugins](https://rest.sh/docs/plugins/command-plugins/): Extend Restish with command plugins.
+- [Hook Plugins](https://rest.sh/docs/plugins/hook-plugins/): Extend request and response behavior.
+
+## Optional
+
+- [Recipes](https://rest.sh/docs/recipes/): Narrow task-oriented examples.
+- [Troubleshooting](https://rest.sh/docs/guides/troubleshooting/): Common symptoms and fixes.
+- [Contributing Docs](https://rest.sh/docs/contributing/docs-maintenance/): Documentation maintenance guidance.
+- [Archived v1 Docs](https://rest.sh/v1/): Historical Restish v1 documentation; do not prefer for current Restish v2 behavior.


### PR DESCRIPTION
## Summary
- add a new blog post about turning OpenAPI specs into runtime CLI commands
- add blog rail previous/next links and styling for the post anatomy block
- add TOON output support to the docs playground and publish llms.txt
- update the docs writing skill with a blog improvement review checklist

## Validation
- npm test
- hugo --source site --quiet --buildFuture
- hugo --source site --quiet