### PR TITLE
docs: add OpenAPI CLI blog post and interactive guides

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -707,6 +707,52 @@ body.td-home .td-navbar__search .td-search-input {
   outline: 0;
 }
 
+.restish-playground__completions {
+  display: grid;
+  grid-template-columns: 2.25rem minmax(0, 1fr);
+  align-items: start;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.24);
+  background: #030712;
+  color: #cbd5e1;
+  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.restish-playground__completions[hidden] {
+  display: none;
+}
+
+.restish-playground__completion-prompt {
+  color: var(--restish-amber);
+  font-weight: 800;
+  text-align: center;
+}
+
+.restish-playground__completion-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.7rem;
+  min-width: 0;
+  padding-right: 0.875rem;
+}
+
+.restish-playground__completion-item,
+.restish-playground__completion-more {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.restish-playground__completion-item {
+  color: #f8fafc;
+}
+
+.restish-playground__completion-more {
+  color: #94a3b8;
+}
+
 .restish-playground__output {
   min-height: 5.25rem;
   max-height: 28rem;
@@ -1287,15 +1333,17 @@ body.td-home .td-navbar__search .td-search-input {
 }
 
 .restish-anatomy {
-  --anatomy-bin-color: #2563eb;
+  --anatomy-bin-color: #334155;
   --anatomy-api-color: #0f766e;
   --anatomy-op-color: #b45309;
-  --anatomy-option-color: #7c3aed;
-  --anatomy-arg-color: #be123c;
-  --anatomy-body-color: #15803d;
+  --anatomy-option-color: #8b5cf6;
+  --anatomy-arg-color: #d9369e;
+  --anatomy-body-color: #0284c7;
+  --anatomy-active-color: var(--anatomy-bin-color);
   --anatomy-command-bg: #f8fafc;
   --anatomy-command-border: rgba(15, 23, 42, 0.12);
 
+  position: relative;
   margin: 1.5rem 0;
   overflow: hidden;
   border: 1px solid rgba(99, 102, 241, 0.28);
@@ -1303,7 +1351,35 @@ body.td-home .td-navbar__search .td-search-input {
   background: var(--restish-card-bg-top);
 }
 
+.restish-anatomy__connector {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  overflow: visible;
+  pointer-events: none;
+  transition: opacity 160ms ease;
+}
+
+.restish-anatomy__connector path {
+  fill: none;
+  stroke: var(--anatomy-active-color);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 8 10;
+  filter: drop-shadow(0 5px 8px rgba(15, 23, 42, 0.2));
+}
+
+.restish-anatomy[data-connector-active="true"] .restish-anatomy__connector {
+  opacity: 0.86;
+}
+
 .restish-anatomy__command {
+  position: relative;
+  z-index: 2;
   margin: 0;
   padding: 1rem;
   overflow-x: auto;
@@ -1320,6 +1396,8 @@ body.td-home .td-navbar__search .td-search-input {
 }
 
 .restish-anatomy__grid {
+  position: relative;
+  z-index: 2;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
   gap: 0.75rem;
@@ -1330,6 +1408,11 @@ body.td-home .td-navbar__search .td-search-input {
   min-width: 0;
   padding: 0.15rem 0 0.15rem 0.75rem;
   border-left: 0.3rem solid var(--anatomy-color);
+  border-radius: 0 8px 8px 0;
+  transition:
+    background 160ms ease,
+    opacity 160ms ease,
+    transform 160ms ease;
 }
 
 .restish-anatomy__label {
@@ -1364,6 +1447,35 @@ body.td-home .td-navbar__search .td-search-input {
   margin-top: 0.1rem;
 }
 
+[data-anatomy-part] {
+  transition:
+    opacity 160ms ease,
+    outline-color 160ms ease,
+    text-shadow 160ms ease;
+}
+
+[data-anatomy-part]:focus {
+  outline: 2px solid var(--anatomy-color);
+  outline-offset: 0.18rem;
+}
+
+.restish-anatomy[data-active-anatomy] [data-anatomy-part] {
+  opacity: 0.42;
+}
+
+.restish-anatomy[data-active-anatomy] [data-anatomy-active] {
+  opacity: 1;
+}
+
+.restish-anatomy__command [data-anatomy-active] {
+  text-shadow: 0 0 0.55rem color-mix(in srgb, var(--anatomy-color) 50%, transparent);
+}
+
+.restish-anatomy__item[data-anatomy-active] {
+  background: color-mix(in srgb, var(--anatomy-color) 11%, transparent);
+  transform: translateX(0.18rem);
+}
+
 .anatomy-bin {
   --anatomy-color: var(--anatomy-bin-color);
 }
@@ -1395,6 +1507,11 @@ body.td-home .td-navbar__search .td-search-input {
 .restish-anatomy__command .anatomy-arg,
 .restish-anatomy__command .anatomy-body {
   color: var(--anatomy-color);
+}
+
+.restish-anatomy__command [data-anatomy-part],
+.restish-anatomy__item[data-anatomy-part] {
+  cursor: pointer;
 }
 
 .restish-blog-cta {
@@ -1568,14 +1685,25 @@ a.restish-blog-rail-card {
 }
 
 [data-bs-theme="dark"] .restish-anatomy {
-  --anatomy-bin-color: #93c5fd;
+  --anatomy-bin-color: #cbd5e1;
   --anatomy-api-color: #5eead4;
   --anatomy-op-color: #fbbf24;
   --anatomy-option-color: #c4b5fd;
-  --anatomy-arg-color: #fda4af;
-  --anatomy-body-color: #86efac;
+  --anatomy-arg-color: #ff9adb;
+  --anatomy-body-color: #38bdf8;
   --anatomy-command-bg: #111827;
   --anatomy-command-border: rgba(148, 163, 184, 0.18);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .restish-anatomy__connector {
+    display: none;
+  }
+
+  .restish-anatomy__item,
+  [data-anatomy-part] {
+    transition: none;
+  }
 }
 
 [data-bs-theme="dark"] .restish-blog-rail-card {

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -831,6 +831,489 @@ body.td-home .td-navbar__search .td-search-input {
   color: #fecaca;
 }
 
+.restish-docs-tool {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 1px solid var(--restish-card-border);
+  border-radius: 8px;
+  background: var(--restish-card-bg-top);
+  box-shadow: var(--restish-card-shadow);
+}
+
+.restish-docs-tool__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.55rem;
+  padding: 0.15rem 0 0.25rem;
+}
+
+.restish-docs-tool__header > div {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.restish-docs-tool__header h3 {
+  margin: 0;
+  padding-left: 0;
+  border-left: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0;
+}
+
+.restish-docs-tool__header p {
+  margin: 0;
+  color: var(--restish-card-text);
+}
+
+.restish-docs-tool__header > div + p {
+  margin-top: 0.2rem;
+}
+
+.restish-docs-tool__eyebrow {
+  margin: 0;
+  color: var(--restish-nav-hover) !important;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.restish-docs-tool__samples,
+.restish-output-pipeline__actions,
+.restish-docs-tool__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.restish-docs-tool button,
+.restish-output-pipeline__steps button {
+  min-height: 2.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--restish-ink);
+  font-weight: 700;
+  line-height: 1.2;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.restish-docs-tool button:hover,
+.restish-docs-tool button:focus {
+  border-color: rgba(15, 118, 110, 0.45);
+  background: rgba(45, 212, 191, 0.12);
+  transform: translateY(-1px);
+}
+
+.restish-docs-tool [data-active] {
+  border-color: rgba(217, 54, 158, 0.5);
+  background: rgba(255, 77, 189, 0.14);
+  color: #9d174d;
+}
+
+.restish-output-pipeline__command {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  min-width: 0;
+  padding: 0.8rem 0.9rem;
+  overflow-x: auto;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background: #0f172a;
+  color: #f8fafc;
+}
+
+.restish-output-pipeline__command span {
+  color: var(--restish-amber);
+}
+
+.td-content .restish-output-pipeline__command code,
+.restish-output-pipeline__command code {
+  border: 0;
+  background: transparent;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.restish-output-pipeline__steps {
+  --pipeline-arrow-color: rgba(15, 23, 42, 0.28);
+  --pipeline-active-arrow-color: rgba(15, 118, 110, 0.62);
+
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+  width: 100%;
+  max-width: 38rem;
+  min-width: 0;
+  margin: 0 auto;
+  padding: 0.15rem 0 0.25rem 3rem;
+  overflow: visible;
+  counter-reset: restish-output-step;
+}
+
+.restish-output-pipeline__steps::before {
+  position: absolute;
+  top: 1.4rem;
+  bottom: 1.4rem;
+  left: 1.25rem;
+  width: 2px;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(15, 118, 110, 0.18),
+    rgba(15, 118, 110, 0.34),
+    rgba(245, 158, 11, 0.26)
+  );
+  content: "";
+}
+
+.restish-output-pipeline__steps button {
+  counter-increment: restish-output-step;
+  position: relative;
+  z-index: 2;
+  min-height: 5.15rem;
+  padding: 0.82rem 1rem 0.9rem;
+  text-align: left;
+}
+
+.restish-output-pipeline__steps button::before {
+  position: absolute;
+  top: 50%;
+  left: -2.77rem;
+  display: grid;
+  width: 2.05rem;
+  height: 2.05rem;
+  place-items: center;
+  border: 2px solid rgba(15, 118, 110, 0.28);
+  border-radius: 999px;
+  background: var(--restish-card-bg-top);
+  color: #0f766e;
+  content: counter(restish-output-step);
+  font-size: 0.76rem;
+  font-weight: 900;
+  transform: translateY(-50%);
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.restish-output-pipeline__steps button::after {
+  position: absolute;
+  bottom: -0.82rem;
+  left: -2.08rem;
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid var(--pipeline-arrow-color);
+  border-bottom: 2px solid var(--pipeline-arrow-color);
+  content: "";
+  transform: rotate(45deg);
+}
+
+.restish-output-pipeline__steps button:last-child::after {
+  content: none;
+}
+
+.restish-output-pipeline__steps button span,
+.restish-output-pipeline__steps button small {
+  display: block;
+}
+
+.restish-output-pipeline__steps button span {
+  color: var(--restish-card-title);
+  font-size: 0.9rem;
+}
+
+.restish-output-pipeline__steps button small {
+  margin-top: 0.32rem;
+  color: var(--restish-card-text);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.restish-output-pipeline__steps button[data-active] {
+  border-color: rgba(15, 118, 110, 0.45);
+  background: rgba(45, 212, 191, 0.13);
+  color: #0f766e;
+  animation: restish-pipeline-pop 220ms ease-out both;
+  animation-delay: calc(var(--step-index, 0) * 28ms);
+}
+
+.restish-output-pipeline__steps button[data-active] span {
+  color: #0f766e;
+}
+
+.restish-output-pipeline__steps button[data-active] small {
+  color: #115e59;
+}
+
+.restish-output-pipeline__steps button[data-active-edge]::after {
+  border-color: var(--pipeline-active-arrow-color);
+}
+
+.restish-output-pipeline__steps button[data-active]::before {
+  border-color: rgba(15, 118, 110, 0.78);
+  background: #0f766e;
+  color: #ecfeff;
+  box-shadow: 0 0 0 0.22rem rgba(45, 212, 191, 0.16);
+}
+
+.restish-output-pipeline__detail {
+  min-height: 3.5rem;
+  padding: 0.85rem 1rem;
+  border-left: 0.3rem solid var(--restish-amber);
+  border-radius: 0 8px 8px 0;
+  background: rgba(251, 191, 36, 0.12);
+  color: var(--restish-card-text);
+}
+
+.restish-docs-tool__label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--restish-card-title);
+  font-weight: 800;
+}
+
+.restish-docs-tool textarea,
+.restish-docs-tool input[type="text"] {
+  width: 100%;
+  min-width: 0;
+  padding: 0.7rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--restish-ink);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.94rem;
+}
+
+.restish-docs-tool textarea {
+  resize: vertical;
+}
+
+.restish-code-editor {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  border-radius: 8px;
+  background: var(--restish-code-surface);
+}
+
+.restish-code-editor pre {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--restish-code-text);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.94rem;
+  line-height: 1.45;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.td-content .restish-code-editor pre {
+  padding: 0;
+}
+
+.restish-code-editor pre code {
+  display: block;
+  padding: 0.7rem 0.75rem;
+  color: inherit;
+}
+
+.restish-code-editor textarea,
+.restish-code-editor input[type="text"] {
+  position: relative;
+  z-index: 2;
+  border: 0;
+  background: transparent;
+  color: transparent;
+  caret-color: var(--restish-code-text);
+  outline: 0;
+  resize: vertical;
+}
+
+.restish-code-editor textarea::selection,
+.restish-code-editor input[type="text"]::selection {
+  background: rgba(45, 212, 191, 0.26);
+  color: transparent;
+}
+
+.restish-code-editor--single {
+  min-height: 2.45rem;
+}
+
+.restish-code-editor--single pre {
+  white-space: pre;
+}
+
+.restish-code-editor--single pre code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+
+.restish-code-editor--single input[type="text"] {
+  height: 2.45rem;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.restish-docs-tool textarea.restish-docs-tool__code-input {
+  min-height: 18rem;
+  border-color: rgba(148, 163, 184, 0.22);
+  background: var(--restish-code-surface);
+  color: var(--restish-code-text);
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.restish-code-editor textarea.restish-docs-tool__code-input {
+  border: 0;
+  background: transparent;
+  color: transparent;
+}
+
+.restish-docs-tool__toolbar {
+  justify-content: space-between;
+}
+
+.restish-docs-tool__toolbar span {
+  min-height: 1.6rem;
+  color: var(--restish-card-text);
+  font-weight: 700;
+}
+
+.restish-docs-tool__toolbar span[data-mode="ok"] {
+  color: #0f766e;
+}
+
+.restish-docs-tool__toolbar span[data-mode="error"] {
+  color: #be123c;
+}
+
+.td-content pre.restish-docs-tool__output,
+.restish-docs-tool__output {
+  min-height: 8rem;
+  max-height: 28rem;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background: var(--restish-code-surface);
+  color: var(--restish-code-text);
+}
+
+.restish-docs-tool__output code {
+  color: inherit;
+}
+
+.restish-query-lab__panes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.restish-query-lab__panes section {
+  display: grid;
+  grid-template-rows: auto minmax(18rem, 1fr);
+  min-width: 0;
+  gap: 0.45rem;
+}
+
+.restish-query-lab__panes h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0;
+}
+
+.restish-query-lab .restish-docs-tool__output {
+  height: 100%;
+  min-height: 18rem;
+}
+
+.restish-query-lab .restish-docs-tool__code-input {
+  height: 100%;
+}
+
+.restish-query-lab .restish-code-editor--json {
+  height: 100%;
+  min-height: 18rem;
+  background: var(--restish-code-surface);
+}
+
+.restish-query-lab .restish-code-editor--json pre {
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+.restish-token-key {
+  color: #5fafd7;
+  font-weight: 800;
+}
+
+.restish-token-string {
+  color: #afd787;
+}
+
+.restish-token-number {
+  color: #d78700;
+}
+
+.restish-token-bool,
+.restish-token-null {
+  color: #f43f5e;
+  font-weight: 800;
+}
+
+.restish-token-operator {
+  color: #d7af5f;
+  font-weight: 900;
+}
+
+.restish-token-punctuation {
+  color: #d7af5f;
+}
+
+.restish-token-href {
+  color: #d6ffb7;
+  font-style: italic;
+}
+
+.restish-token-date {
+  color: #af87d7;
+}
+
+@keyframes restish-pipeline-pop {
+  0% {
+    transform: translateY(0.18rem);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
 .restish-submit-map {
   margin: 1.25rem 0;
   padding: 1rem;
@@ -1038,6 +1521,137 @@ body.td-home .td-navbar__search .td-search-input {
 [data-bs-theme="dark"] .restish-playground__state {
   border-color: rgba(148, 163, 184, 0.22);
   background: rgba(2, 6, 23, 0.74);
+}
+
+[data-bs-theme="dark"] .restish-docs-tool button,
+[data-bs-theme="dark"] .restish-output-pipeline__steps button {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: #0b1120;
+  color: #f8fafc;
+}
+
+[data-bs-theme="dark"] .restish-docs-tool [data-active] {
+  border-color: rgba(255, 114, 202, 0.5);
+  background: rgba(255, 77, 189, 0.16);
+  color: #ff9adb;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active] {
+  border-color: rgba(94, 234, 212, 0.48);
+  background: rgba(45, 212, 191, 0.14);
+  color: #5eead4;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button::after {
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button span {
+  color: #f8fafc;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button small {
+  color: #cbd5e1;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps::before {
+  background: linear-gradient(
+    180deg,
+    rgba(94, 234, 212, 0.2),
+    rgba(94, 234, 212, 0.32),
+    rgba(251, 191, 36, 0.24)
+  );
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button::before {
+  border-color: rgba(94, 234, 212, 0.28);
+  background: #0b1120;
+  color: #99f6e4;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active] span {
+  color: #5eead4;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active] small {
+  color: #99f6e4;
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active]::before {
+  border-color: rgba(94, 234, 212, 0.78);
+  background: #0f766e;
+  color: #ecfeff;
+  box-shadow: 0 0 0 0.22rem rgba(45, 212, 191, 0.18);
+}
+
+[data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active-edge]::after {
+  border-color: rgba(94, 234, 212, 0.72);
+}
+
+[data-bs-theme="dark"] .restish-docs-tool textarea,
+[data-bs-theme="dark"] .restish-docs-tool input[type="text"] {
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(2, 6, 23, 0.72);
+  color: #f8fafc;
+}
+
+[data-bs-theme="dark"] .restish-code-editor {
+  border-color: rgba(148, 163, 184, 0.34);
+  background: rgba(2, 6, 23, 0.72);
+}
+
+[data-bs-theme="dark"] .restish-code-editor textarea,
+[data-bs-theme="dark"] .restish-code-editor input[type="text"],
+[data-bs-theme="dark"] .restish-code-editor textarea.restish-docs-tool__code-input {
+  border: 0;
+  background: transparent;
+  color: transparent;
+  caret-color: #f8fafc;
+}
+
+[data-bs-theme="dark"] .restish-code-editor pre {
+  color: #f8fafc;
+}
+
+[data-bs-theme="dark"] .restish-token-key {
+  color: #5fafd7;
+}
+
+[data-bs-theme="dark"] .restish-token-string {
+  color: #afd787;
+}
+
+[data-bs-theme="dark"] .restish-token-number {
+  color: #d78700;
+}
+
+[data-bs-theme="dark"] .restish-token-bool,
+[data-bs-theme="dark"] .restish-token-null {
+  color: #f43f5e;
+}
+
+[data-bs-theme="dark"] .restish-token-operator {
+  color: #d7af5f;
+}
+
+[data-bs-theme="dark"] .restish-token-punctuation {
+  color: #d7af5f;
+}
+
+[data-bs-theme="dark"] .restish-token-href {
+  color: #d6ffb7;
+}
+
+[data-bs-theme="dark"] .restish-token-date {
+  color: #af87d7;
+}
+
+[data-bs-theme="dark"] .restish-docs-tool__toolbar span[data-mode="ok"] {
+  color: #5eead4;
+}
+
+[data-bs-theme="dark"] .restish-docs-tool__toolbar span[data-mode="error"] {
+  color: #fda4af;
 }
 
 [data-bs-theme="dark"] .td-content :not(pre) > code {
@@ -1696,6 +2310,10 @@ a.restish-blog-rail-card {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .restish-output-pipeline__steps button[data-active] {
+    animation: none;
+  }
+
   .restish-anatomy__connector {
     display: none;
   }
@@ -1721,6 +2339,23 @@ a.restish-blog-rail-card {
 }
 
 @media (max-width: 575.98px) {
+  .restish-output-pipeline__steps {
+    width: 100%;
+    gap: 0.9rem;
+  }
+
+  .restish-query-lab__panes {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .restish-docs-tool__toolbar {
+    align-items: stretch;
+  }
+
+  .restish-docs-tool__toolbar button {
+    width: 100%;
+  }
+
   .restish-playground__bar {
     align-items: flex-start;
     flex-direction: column;

--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -1198,6 +1198,13 @@ body.td-home .td-navbar__search .td-search-input {
   justify-content: space-between;
 }
 
+.restish-docs-tool__toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
 .restish-docs-tool__toolbar span {
   min-height: 1.6rem;
   color: var(--restish-card-text);
@@ -1266,6 +1273,104 @@ body.td-home .td-navbar__search .td-search-input {
 .restish-query-lab .restish-code-editor--json pre {
   font-size: 0.86rem;
   line-height: 1.45;
+}
+
+.restish-filter-trace {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(15, 118, 110, 0.24);
+  border-radius: 8px;
+  background: rgba(45, 212, 191, 0.08);
+}
+
+.restish-filter-trace[hidden] {
+  display: none;
+}
+
+.restish-filter-trace__top,
+.restish-filter-trace__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.restish-filter-trace__top {
+  justify-content: space-between;
+}
+
+.restish-filter-trace h4,
+.restish-filter-trace h5,
+.restish-filter-trace p {
+  margin: 0;
+}
+
+.restish-filter-trace h4 {
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.restish-filter-trace h5 {
+  color: var(--restish-card-title);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.restish-filter-trace__top p,
+.restish-filter-trace__detail {
+  color: var(--restish-card-text);
+  font-size: 0.9rem;
+}
+
+.restish-filter-trace__tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.42rem;
+}
+
+.restish-filter-trace__tokens button {
+  min-height: 2rem;
+  padding: 0.35rem 0.55rem;
+  font-family: var(--bs-font-monospace);
+  font-size: 0.82rem;
+}
+
+.restish-filter-trace__stage {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.restish-filter-trace__stage section {
+  display: grid;
+  min-width: 0;
+  gap: 0.35rem;
+}
+
+.td-content .restish-filter-trace__stage pre,
+.restish-filter-trace__stage pre {
+  min-height: 9rem;
+  max-height: 18rem;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 8px;
+  background: var(--restish-code-surface);
+  color: var(--restish-code-text);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.restish-filter-trace__stage code {
+  color: inherit;
+}
+
+.restish-filter-trace__detail {
+  padding-left: 0.85rem;
+  border-left: 0.22rem solid var(--restish-amber);
 }
 
 .restish-token-key {
@@ -1586,6 +1691,17 @@ body.td-home .td-navbar__search .td-search-input {
 
 [data-bs-theme="dark"] .restish-output-pipeline__steps button[data-active-edge]::after {
   border-color: rgba(94, 234, 212, 0.72);
+}
+
+[data-bs-theme="dark"] .restish-filter-trace {
+  border-color: rgba(94, 234, 212, 0.24);
+  background: rgba(45, 212, 191, 0.08);
+}
+
+[data-bs-theme="dark"] .restish-filter-trace__stage pre {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.72);
+  color: #f8fafc;
 }
 
 [data-bs-theme="dark"] .restish-docs-tool textarea,
@@ -2352,8 +2468,13 @@ a.restish-blog-rail-card {
     align-items: stretch;
   }
 
+  .restish-docs-tool__toolbar-actions,
   .restish-docs-tool__toolbar button {
     width: 100%;
+  }
+
+  .restish-filter-trace__stage {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .restish-playground__bar {

--- a/site/content/en/blog/turn-an-openapi-spec-into-a-cli-without-generating-code.md
+++ b/site/content/en/blog/turn-an-openapi-spec-into-a-cli-without-generating-code.md
@@ -5,6 +5,8 @@ date: 2026-06-08
 author: "Daniel Taylor"
 description: OpenAPI can be more than SDK input or Swagger UI data. Restish loads API descriptions at runtime and turns them into shell-native commands with profiles, auth, output, pagination, and MCP-ready extension points.
 canonical_url: "https://rest.sh/blog/turn-an-openapi-spec-into-a-cli-without-generating-code/"
+extra_js:
+  - js/restish-anatomy.js
 categories:
   - OpenAPI
 tags:
@@ -109,42 +111,47 @@ describe request bodies and parameter types. Servers influence where operations
 are sent. Security requirements tell Restish which credentials an operation can
 use.
 
+### Anatomy of Generated Commands
+
 Here is the anatomy of a generated command:
 
-<div class="restish-anatomy">
-  <pre class="restish-anatomy__command"><code><span class="anatomy-bin">restish</span> <span class="anatomy-api">inventory</span> <span class="anatomy-op">update-item</span> <span class="anatomy-option">--dry-run</span> <span class="anatomy-arg">item-123</span> <span class="anatomy-body">'name: Travel mug, enabled: true'</span></code></pre>
+<div class="restish-anatomy" data-restish-anatomy>
+  <svg class="restish-anatomy__connector" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+    <path data-restish-anatomy-string d="" />
+  </svg>
+  <pre class="restish-anatomy__command"><code><span class="anatomy-bin" data-anatomy-part="bin" tabindex="0">restish</span> <span class="anatomy-api" data-anatomy-part="api" tabindex="0">inventory</span> <span class="anatomy-op" data-anatomy-part="op" tabindex="0">update-item</span> <span class="anatomy-option" data-anatomy-part="option" tabindex="0">--dry-run</span> <span class="anatomy-arg" data-anatomy-part="arg" tabindex="0">item-123</span> <span class="anatomy-body" data-anatomy-part="body" tabindex="0">'name: Travel mug, enabled: true'</span></code></pre>
   <div class="restish-anatomy__grid">
-    <div class="restish-anatomy__item anatomy-bin">
+    <div class="restish-anatomy__item anatomy-bin" data-anatomy-part="bin" tabindex="0">
       <span class="restish-anatomy__label">Binary</span>
       <code>restish</code>
       <span class="restish-anatomy__from">Restish itself</span>
       <span class="restish-anatomy__note">The universal entry point.</span>
     </div>
-    <div class="restish-anatomy__item anatomy-api">
+    <div class="restish-anatomy__item anatomy-api" data-anatomy-part="api" tabindex="0">
       <span class="restish-anatomy__label">API</span>
       <code>inventory</code>
       <span class="restish-anatomy__from">Chosen during <code>api connect</code></span>
       <span class="restish-anatomy__note">Local operator vocabulary, not an OpenAPI field.</span>
     </div>
-    <div class="restish-anatomy__item anatomy-op">
+    <div class="restish-anatomy__item anatomy-op" data-anatomy-part="op" tabindex="0">
       <span class="restish-anatomy__label">Operation</span>
       <code>update-item</code>
       <span class="restish-anatomy__from"><code>operationId: updateItem</code></span>
       <span class="restish-anatomy__note">The operation ID becomes the command name.</span>
     </div>
-    <div class="restish-anatomy__item anatomy-option">
+    <div class="restish-anatomy__item anatomy-option" data-anatomy-part="option" tabindex="0">
       <span class="restish-anatomy__label">Option</span>
       <code>--dry-run</code>
       <span class="restish-anatomy__from">Optional query parameter <code>dry_run</code></span>
       <span class="restish-anatomy__note">Optional parameters become flags.</span>
     </div>
-    <div class="restish-anatomy__item anatomy-arg">
+    <div class="restish-anatomy__item anatomy-arg" data-anatomy-part="arg" tabindex="0">
       <span class="restish-anatomy__label">Argument</span>
       <code>item-123</code>
       <span class="restish-anatomy__from">Required path parameter <code>item-id</code></span>
       <span class="restish-anatomy__note">Required path parameters become positional arguments.</span>
     </div>
-    <div class="restish-anatomy__item anatomy-body">
+    <div class="restish-anatomy__item anatomy-body" data-anatomy-part="body" tabindex="0">
       <span class="restish-anatomy__label">Body</span>
       <code>'name: Travel mug, enabled: true'</code>
       <span class="restish-anatomy__from">JSON request body schema</span>

--- a/site/content/en/docs/guides/filtering.md
+++ b/site/content/en/docs/guides/filtering.md
@@ -5,16 +5,21 @@ weight: 45
 description: Select headers, links, and body fields with shorthand queries or jq filters.
 aliases:
   - /docs/recipes/filter-response-fields/
+extra_js:
+  - js/restish-docs-interactions.js
 ---
 
 Filtering trims a normalized Restish response before formatting. Use shorthand
 for direct paths and projections; use jq for richer transforms.
 
+{{< restish-query-runner >}}
+
 ## Filter Roots
 
 - `proto` for the response protocol string
 - `status` for the numeric HTTP status
-- `headers` for response headers
+- `headers` for the first value of each response header
+- `headers_all` for repeated response headers such as `Set-Cookie`
 - `links` for normalized hypermedia links
 - `body` for decoded response body
 
@@ -23,6 +28,7 @@ restish api.rest.sh/ -f headers.Content-Type
 {{< /restish-example >}}
 
 ```bash
+restish api.rest.sh/ -f 'headers_all."Set-Cookie"[0]'
 restish api.rest.sh/images -f links.next
 restish api.rest.sh/example -f body.basics.profiles
 ```

--- a/site/content/en/docs/guides/input.md
+++ b/site/content/en/docs/guides/input.md
@@ -6,11 +6,15 @@ description: Build structured request bodies with shorthand, stdin, forms, multi
 aliases:
   - /docs/recipes/patch-piped-json-with-shorthand/
   - /docs/recipes/send-a-form-login-request/
+extra_js:
+  - js/restish-docs-interactions.js
 ---
 
 Restish shorthand lets you create structured request bodies directly on the
 command line. JSON is the default request encoding, but the same body model can
 be encoded as YAML, form data, multipart, CBOR, and other registered types.
+
+{{< restish-shorthand-body >}}
 
 ## Object Input
 
@@ -23,7 +27,7 @@ The `/post` endpoint echoes the parsed body so you can confirm the result.
 ## Nested Objects And Arrays
 
 {{< restish-example >}}
-restish post api.rest.sh/post 'user.name: Alice, user.roles[]: admin, user.roles[]: editor, active: true'
+restish post api.rest.sh/post 'user.name: Alice, user.roles: [admin, editor], active: true'
 {{< /restish-example >}}
 
 Use quotes when your shell would otherwise treat brackets or spaces specially:

--- a/site/content/en/docs/guides/output.md
+++ b/site/content/en/docs/guides/output.md
@@ -6,6 +6,8 @@ description: Understand how Restish decodes, normalizes, filters, and renders re
 aliases:
   - /docs/guides/output/
   - /docs/recipes/show-only-response-headers/
+extra_js:
+  - js/restish-docs-interactions.js
 ---
 
 Restish output is built around one rule: stdout carries the selected HTTP
@@ -14,15 +16,7 @@ verbose traces.
 
 ## Processing Model
 
-```mermaid
-flowchart LR
-  A[HTTP response] --> B[Decompress]
-  B --> C[Decode by Content-Type]
-  C --> D[Normalize status, headers, links, body]
-  D --> E[Paginate or stream]
-  E --> F[Filter]
-  F --> G[Format]
-```
+{{< restish-output-pipeline >}}
 
 ## Choose A Format
 
@@ -68,11 +62,11 @@ shell-friendly scalar values.
 
 ## Document vs Record Output
 
-Use document output when the next program expects one complete value. Make the
-format explicit in scripts and redirects:
+Use document output when the next program expects one complete value. Make
+collection explicit when pagination should become one redirected document:
 
 ```bash
-restish api.rest.sh/images --rsh-collect -o json > images.json
+restish api.rest.sh/images --rsh-collect > images.json
 ```
 
 Use record output when you want one item per line:
@@ -139,7 +133,7 @@ Control exactly what stdout contains with `--rsh-print`:
 
 ```bash
 restish api.rest.sh/images --rsh-print hbpc
-restish api.rest.sh/images -o json > images.json
+restish api.rest.sh/images --rsh-collect > images.json
 restish api.rest.sh/images --rsh-print b > images.compact.json
 restish post api.rest.sh/post 'name: Alice' --rsh-print HBhbp
 ```

--- a/site/content/en/docs/reference/query-syntax.md
+++ b/site/content/en/docs/reference/query-syntax.md
@@ -17,13 +17,14 @@ Most filters start from one of these normalized roots:
 | --- | --- |
 | `status` | Numeric HTTP status code. |
 | `headers` | First value for each response header. |
-| `headers_all` | Complete header map for repeated values. Use jq syntax such as `.headers_all["Set-Cookie"]` when you need it. |
+| `headers_all` | Complete header map for repeated values. Use quoted shorthand such as `headers_all."Set-Cookie"[0]` or jq syntax such as `.headers_all["Set-Cookie"]` when you need every value. |
 | `links` | Normalized hypermedia links. |
 | `body` | Decoded response body. |
 | `proto` | HTTP protocol string such as `HTTP/2.0`. |
 
 ```bash
 restish api.rest.sh/ -f headers.Content-Type
+restish api.rest.sh/ -f 'headers_all."Set-Cookie"[0]'
 restish api.rest.sh/images -f links.next
 restish api.rest.sh/example -f body.basics.profiles
 ```

--- a/site/layouts/_partials/hooks/body-end.html
+++ b/site/layouts/_partials/hooks/body-end.html
@@ -2,6 +2,11 @@
 {{/* Automatically cache-bust the playground script when its file contents change. */}}
 {{ $playgroundVersion := readFile "static/js/restish-playground.js" | md5 }}
 <script src='{{ "js/restish-playground.js" | relURL }}?v={{ $playgroundVersion }}'></script>
+{{ range .Params.extra_js -}}
+  {{ $scriptPath := . }}
+  {{ $scriptVersion := readFile (printf "static/%s" $scriptPath) | md5 }}
+  <script src='{{ $scriptPath | relURL }}?v={{ $scriptVersion }}'></script>
+{{ end -}}
 <script>
   (function () {
     if (window.location.pathname === "/" && window.location.hash.indexOf("#/") === 0) {

--- a/site/layouts/_partials/hooks/body-end.html
+++ b/site/layouts/_partials/hooks/body-end.html
@@ -4,6 +4,9 @@
 <script src='{{ "js/restish-playground.js" | relURL }}?v={{ $playgroundVersion }}'></script>
 {{ range .Params.extra_js -}}
   {{ $scriptPath := . }}
+  {{ if or (not (strings.HasPrefix $scriptPath "js/")) (strings.Contains $scriptPath "..") -}}
+    {{ errorf "extra_js path %q must be relative to site/static/js/ and must not contain parent traversal" $scriptPath }}
+  {{ end -}}
   {{ $scriptVersion := readFile (printf "static/%s" $scriptPath) | md5 }}
   <script src='{{ $scriptPath | relURL }}?v={{ $scriptVersion }}'></script>
 {{ end -}}

--- a/site/layouts/blog/baseof.html
+++ b/site/layouts/blog/baseof.html
@@ -20,10 +20,5 @@
       {{ partial "footer.html" . }}
     </div>
     {{ partial "scripts.html" . }}
-    {{ range .Params.extra_js -}}
-      {{ $scriptPath := . }}
-      {{ $scriptVersion := readFile (printf "static/%s" $scriptPath) | md5 }}
-      <script src='{{ $scriptPath | relURL }}?v={{ $scriptVersion }}'></script>
-    {{ end -}}
   </body>
 </html>

--- a/site/layouts/blog/baseof.html
+++ b/site/layouts/blog/baseof.html
@@ -20,5 +20,10 @@
       {{ partial "footer.html" . }}
     </div>
     {{ partial "scripts.html" . }}
+    {{ range .Params.extra_js -}}
+      {{ $scriptPath := . }}
+      {{ $scriptVersion := readFile (printf "static/%s" $scriptPath) | md5 }}
+      <script src='{{ $scriptPath | relURL }}?v={{ $scriptVersion }}'></script>
+    {{ end -}}
   </body>
 </html>

--- a/site/layouts/docs/baseof.html
+++ b/site/layouts/docs/baseof.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js"
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main" {{- partialCached "td/scrollspy-attr.txt" . .Section | safeHTMLAttr }}>
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="td-sidebar-toc">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+            {{ partial "version-banner.html" . }}
+            {{ if not (.Param "ui.breadcrumb_disable") -}}
+              {{ partial "breadcrumb.html" . -}}
+            {{ end -}}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/site/layouts/shortcodes/restish-example.html
+++ b/site/layouts/shortcodes/restish-example.html
@@ -27,9 +27,10 @@
     <span class="restish-playground__prompt" aria-hidden="true">$</span>
     <div class="restish-playground__command-wrap">
       <div class="restish-playground__command-highlight" aria-hidden="true"><code class="language-bash" data-restish-command-highlight>{{ $command }}</code></div>
-      <input id="{{ $id }}-command" class="restish-playground__command" type="text" spellcheck="false" autocomplete="off" autocapitalize="off" value="{{ $command }}" data-restish-command>
+      <input id="{{ $id }}-command" class="restish-playground__command" type="text" spellcheck="false" autocomplete="off" autocapitalize="off" value="{{ $command }}" aria-controls="{{ $id }}-completions" data-restish-command>
     </div>
   </div>
+  <div id="{{ $id }}-completions" class="restish-playground__completions" data-restish-completions aria-live="polite" hidden></div>
   <pre id="{{ $id }}-output" class="restish-playground__output" aria-live="polite" hidden><code class="language-readable" data-restish-output></code></pre>
   <noscript>
     <p class="restish-playground__noscript">Enable JavaScript to run this example in the browser.</p>

--- a/site/layouts/shortcodes/restish-output-pipeline.html
+++ b/site/layouts/shortcodes/restish-output-pipeline.html
@@ -1,0 +1,31 @@
+<div class="restish-docs-tool restish-output-pipeline" data-restish-output-pipeline>
+  <div class="restish-docs-tool__header">
+    <div>
+      <p class="restish-docs-tool__eyebrow">Interactive model</p>
+      <h3>Trace How Output Is Built</h3>
+    </div>
+    <p>Pick a command shape to see which parts of the response pipeline become active.</p>
+  </div>
+  <div class="restish-output-pipeline__actions" role="list" aria-label="Output command examples">
+    <button type="button" data-output-action="auto">Terminal view</button>
+    <button type="button" data-output-action="headers">Headers only</button>
+    <button type="button" data-output-action="jsonfile">Filtered JSON file</button>
+    <button type="button" data-output-action="pages">Paginated table</button>
+    <button type="button" data-output-action="stream">Event stream</button>
+    <button type="button" data-output-action="redirect">Raw download</button>
+  </div>
+  <div class="restish-output-pipeline__command" aria-live="polite">
+    <span aria-hidden="true">$</span>
+    <code data-output-command>restish api.rest.sh/types</code>
+  </div>
+  <div class="restish-output-pipeline__steps" aria-label="Response processing pipeline">
+    <button type="button" data-output-step="response"><span>HTTP response</span><small>Status, headers, compressed or raw body bytes</small></button>
+    <button type="button" data-output-step="decompress"><span>Decompress</span><small>Content-Encoding: deflate, gzip, brotli &rarr; uncompressed body bytes</small></button>
+    <button type="button" data-output-step="decode"><span>Unmarshal body</span><small>JSON, YAML, CBOR, text &rarr; Go structs, maps, slices, or strings</small></button>
+    <button type="button" data-output-step="normalize"><span>Normalize</span><small>Status, headers, processed hypermedia links, body</small></button>
+    <button type="button" data-output-step="paginate"><span>Paginate or stream</span><small>Follow Link headers or emit event records as they arrive</small></button>
+    <button type="button" data-output-step="filter"><span>Filter</span><small>-f selectors and shortcuts &rarr; the fields or records you asked for</small></button>
+    <button type="button" data-output-step="format"><span>Format output</span><small>auto, table, JSON, TOON, lines, or raw bytes for the next tool</small></button>
+  </div>
+  <div class="restish-output-pipeline__detail" data-output-detail aria-live="polite"></div>
+</div>

--- a/site/layouts/shortcodes/restish-query-runner.html
+++ b/site/layouts/shortcodes/restish-query-runner.html
@@ -1,0 +1,42 @@
+<div class="restish-docs-tool restish-query-lab" data-restish-query-runner>
+  <div class="restish-docs-tool__header">
+    <div>
+      <p class="restish-docs-tool__eyebrow">Try filters</p>
+      <h3>Run A Shorthand Query</h3>
+    </div>
+    <p>Test shorthand filters against editable response JSON.</p>
+  </div>
+  <div class="restish-docs-tool__samples" aria-label="Shorthand query examples">
+    <button type="button" data-sample="body.account.{name, active, created_at, tags}">Account Summary</button>
+    <button type="button" data-sample='body.items[format == "jpeg"].{name, owner: owner.name, size_bytes}'>JPEG Owner</button>
+    <button type="button" data-sample="body.items[name.lower contains dragonfly].links.self">Case Search</button>
+    <button type="button" data-sample='body.events[type == deploy].changes.name'>Deploy Changes</button>
+    <button type="button" data-sample="body..download|[@ contains jpeg]">URL Contains</button>
+    <button type="button" data-sample='headers."Content-Type"'>Header</button>
+    <button type="button" data-sample='headers_all."Set-Cookie"[0]'>Repeated Header</button>
+  </div>
+  <label class="restish-docs-tool__label">
+    Filter
+    <div class="restish-code-editor restish-code-editor--single" data-highlight-editor data-highlight-mode="filter">
+      <pre aria-hidden="true"><code data-highlight-mirror></code></pre>
+      <input data-query-input type="text" spellcheck="false" value="body.account.{name, active, created_at, tags}">
+    </div>
+  </label>
+  <div class="restish-query-lab__panes">
+    <section>
+      <h4>Response JSON</h4>
+      <div class="restish-code-editor restish-code-editor--json" data-highlight-editor data-highlight-mode="json">
+        <pre aria-hidden="true"><code data-highlight-mirror></code></pre>
+        <textarea class="restish-docs-tool__code-input" data-query-source rows="18" spellcheck="false"></textarea>
+      </div>
+    </section>
+    <section>
+      <h4>Selected Value</h4>
+      <pre class="restish-docs-tool__output"><code data-query-output></code></pre>
+    </section>
+  </div>
+  <div class="restish-docs-tool__toolbar">
+    <span data-query-status>Ready</span>
+    <button type="button" data-share-example>Copy share link</button>
+  </div>
+</div>

--- a/site/layouts/shortcodes/restish-query-runner.html
+++ b/site/layouts/shortcodes/restish-query-runner.html
@@ -37,6 +37,34 @@
   </div>
   <div class="restish-docs-tool__toolbar">
     <span data-query-status>Ready</span>
-    <button type="button" data-share-example>Copy share link</button>
+    <div class="restish-docs-tool__toolbar-actions">
+      <button type="button" data-toggle-trace aria-expanded="false">Trace filter</button>
+      <button type="button" data-share-example>Copy share link</button>
+    </div>
+  </div>
+  <div class="restish-filter-trace" data-filter-trace hidden>
+    <div class="restish-filter-trace__top">
+      <div>
+        <h4>Filter Trace</h4>
+        <p data-trace-summary>Step through how Restish satisfies this shorthand filter.</p>
+      </div>
+      <div class="restish-filter-trace__controls">
+        <button type="button" data-trace-prev aria-label="Previous trace step">Prev</button>
+        <button type="button" data-trace-play>Play</button>
+        <button type="button" data-trace-next aria-label="Next trace step">Next</button>
+      </div>
+    </div>
+    <div class="restish-filter-trace__tokens" data-trace-tokens aria-label="Filter trace tokens"></div>
+    <div class="restish-filter-trace__stage" data-trace-stage>
+      <section>
+        <h5>Before</h5>
+        <pre><code data-trace-before></code></pre>
+      </section>
+      <section>
+        <h5>After</h5>
+        <pre><code data-trace-after></code></pre>
+      </section>
+    </div>
+    <p class="restish-filter-trace__detail" data-trace-detail></p>
   </div>
 </div>

--- a/site/layouts/shortcodes/restish-shorthand-body.html
+++ b/site/layouts/shortcodes/restish-shorthand-body.html
@@ -1,0 +1,28 @@
+<div class="restish-docs-tool restish-shorthand-lab" data-restish-shorthand-body>
+  <div class="restish-docs-tool__header">
+    <div>
+      <p class="restish-docs-tool__eyebrow">Try shorthand</p>
+      <h3>Build A Request Body</h3>
+    </div>
+    <p>Edit the shorthand and see the JSON body Restish would send.</p>
+  </div>
+  <div class="restish-docs-tool__samples" aria-label="Shorthand body examples">
+    <button type="button" data-sample="user{name: Ada Lovelace, email: ada@example.com}, active: true, joined_at: 2026-06-08">Profile</button>
+    <button type="button" data-sample="order.id: ord-123,&#10;items: [&#10;  {sku: mug-01, qty: 2, price: 14.5},&#10;  {sku: tee-02, qty: 1, price: 28},&#10;],&#10;rush: false">Cart Items</button>
+    <button type="button" data-sample="metadata{&#10;  tags: [docs, cli, beta],&#10;  flags{dry_run: true, notify: false}&#10;},&#10;score: 98.6">Nested Literals</button>
+    <button type="button" data-sample='enabled: "true",&#10;missing: "null",&#10;blank: "",&#10;note: "keep exact strings"'>Quoted Strings</button>
+    <button type="button" data-sample='{&#10;  "name": "Ada Lovelace",&#10;  "tags": ["docs", "json"],&#10;  "active": true&#10;}'>Plain JSON</button>
+  </div>
+  <label class="restish-docs-tool__label">
+    Shorthand
+    <div class="restish-code-editor" data-highlight-editor data-highlight-mode="shorthand">
+      <pre aria-hidden="true"><code data-highlight-mirror></code></pre>
+      <textarea data-shorthand-input data-auto-size rows="2" spellcheck="false">user{name: Ada Lovelace, email: ada@example.com}, active: true, joined_at: 2026-06-08</textarea>
+    </div>
+  </label>
+  <div class="restish-docs-tool__toolbar">
+    <span data-shorthand-status>Ready</span>
+    <button type="button" data-share-example>Copy share link</button>
+  </div>
+  <pre class="restish-docs-tool__output"><code data-shorthand-output></code></pre>
+</div>

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "social-images": "node scripts/generate-social-images.mjs",
-    "test": "node scripts/test-restish-playground.mjs",
+    "test": "node scripts/test-restish-playground.mjs && node scripts/test-restish-docs-interactions.mjs",
     "dev": "npm run social-images && hugo server",
     "build": "npm run social-images && hugo"
   },

--- a/site/scripts/test-restish-docs-interactions.mjs
+++ b/site/scripts/test-restish-docs-interactions.mjs
@@ -171,6 +171,28 @@ assert.deepEqual(
   "query selection maps projection across array items"
 );
 
+{
+  const trace = api.buildFilterTrace(api.querySample, 'body.items[format == "jpeg"].{name, owner: owner.name, size_bytes}');
+  assert.deepEqual(
+    normalize(trace.steps.map((step) => step.token)),
+    ["body", ".items", "[format == jpeg]", "{name, owner: owner.name, size_bytes}"],
+    "filter trace exposes path, selection, and projection tokens"
+  );
+  assert.equal(trace.steps[1].title, "Select items", "filter trace names ordinary field selection");
+  assert.equal(trace.steps[2].title, "Filter 3 items", "filter trace counts selected array items");
+  assert.deepEqual(
+    normalize(trace.value),
+    [
+      {
+        name: "Dragonfly JPEG",
+        owner: "Ada",
+        size_bytes: 184523
+      }
+    ],
+    "filter trace final value matches filter result"
+  );
+}
+
 assert.deepEqual(
   normalize(api.applyShorthandFilter(api.querySample, "body.items[public == true].name")),
   ["Dragonfly JPEG", "CLI Screenshot"],
@@ -191,6 +213,18 @@ assert.deepEqual(
   "query nested arrays after selection"
 );
 
+{
+  const trace = api.buildFilterTrace(api.querySample, "body.events[type == deploy].changes.name");
+  assert.equal(trace.steps.at(-1).title, "Map name over each item", "filter trace explains array mapping");
+  assert.deepEqual(
+    normalize(trace.value),
+    [
+      ["output guide", "TOON renderer"]
+    ],
+    "filter trace handles nested arrays after selection"
+  );
+}
+
 assert.deepEqual(
   normalize(api.applyShorthandFilter(api.querySample, "body..download")),
   [
@@ -206,6 +240,21 @@ assert.deepEqual(
   ["https://api.rest.sh/images/jpeg?download=1"],
   "recursive shorthand query can filter current values"
 );
+
+{
+  const trace = api.buildFilterTrace(api.querySample, "body..download|[@ contains jpeg]");
+  assert.deepEqual(
+    normalize(trace.steps.map((step) => step.token)),
+    ["body", "..download", "|", "[@ contains jpeg]"],
+    "filter trace shows pipe as a collection boundary"
+  );
+  assert.equal(trace.steps[2].title, "Pipe the current result", "filter trace explains pipe boundary");
+  assert.deepEqual(
+    normalize(trace.value),
+    ["https://api.rest.sh/images/jpeg?download=1"],
+    "filter trace final value matches piped filter result"
+  );
+}
 
 assert.equal(
   api.applyShorthandFilter(api.querySample, 'headers."Content-Type"'),

--- a/site/scripts/test-restish-docs-interactions.mjs
+++ b/site/scripts/test-restish-docs-interactions.mjs
@@ -1,0 +1,293 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siteDir = path.resolve(__dirname, "..");
+
+const source = await readFile(path.join(siteDir, "static/js/restish-docs-interactions.js"), "utf8");
+const sandbox = {
+  URL,
+  URLSearchParams,
+  console,
+  document: {
+    readyState: "loading",
+    addEventListener() {},
+    createElement() {
+      return {
+        setAttribute() {},
+        select() {},
+        style: {}
+      };
+    },
+    querySelectorAll() {
+      return [];
+    },
+    body: {
+      appendChild() {},
+      removeChild() {}
+    },
+    execCommand() {
+      return true;
+    }
+  },
+  navigator: {},
+  window: {
+    __RESTISH_DOCS_INTERACTIONS_TEST__: true,
+    addEventListener() {},
+    isSecureContext: false,
+    location: {
+      href: "https://rest.sh/docs/guides/input/",
+      hash: ""
+    },
+    setTimeout
+  }
+};
+
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: "restish-docs-interactions.js" });
+
+const api = sandbox.window.__restishDocsInteractionsTest;
+assert.ok(api, "docs interactions test API should be exposed");
+
+function normalize(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+assert.deepEqual(
+  normalize(api.parseShorthand("user.name: Ada, tags[]: cli, tags[]: docs, enabled: true, count: 3")),
+  {
+    user: { name: "Ada" },
+    tags: ["cli", "docs"],
+    enabled: true,
+    count: 3
+  },
+  "shorthand body parser handles nested fields, arrays, booleans, and numbers"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand("user{name: Ada Lovelace, email: ada@example.com}, active: true, joined_at: 2026-06-08")),
+  {
+    user: {
+      name: "Ada Lovelace",
+      email: "ada@example.com"
+    },
+    active: true,
+    joined_at: "2026-06-08"
+  },
+  "shorthand body parser supports compact object assignment"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand(`metadata{
+  tags: [docs, cli, beta],
+  flags{dry_run: true, notify: false}
+},
+score: 98.6`)),
+  {
+    metadata: {
+      tags: ["docs", "cli", "beta"],
+      flags: {
+        dry_run: true,
+        notify: false
+      }
+    },
+    score: 98.6
+  },
+  "shorthand body parser supports nested compact object assignment"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand(`order.id: ord-123,
+items: [
+  {sku: mug-01, qty: 2, price: 14.5},
+  {sku: tee-02, qty: 1, price: 28},
+],
+rush: false`)),
+  {
+    order: {
+      id: "ord-123"
+    },
+    items: [
+      { sku: "mug-01", qty: 2, price: 14.5 },
+      { sku: "tee-02", qty: 1, price: 28 }
+    ],
+    rush: false
+  },
+  "shorthand body parser supports formatted arrays with a trailing comma"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand(`{
+  "name": "Ada Lovelace",
+  "tags": ["docs", "json"],
+  "active": true
+}`)),
+  {
+    name: "Ada Lovelace",
+    tags: ["docs", "json"],
+    active: true
+  },
+  "shorthand body parser accepts plain JSON"
+);
+
+assert.ok(
+  api.highlightValue("order.id: ord-123", "shorthand").includes('<span class="restish-token-key">order</span><span class="restish-token-punctuation">.</span><span class="restish-token-key">id</span>'),
+  "shorthand highlighter treats dotted paths as one key"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand('enabled: "true", missing: "null", blank: ""')),
+  {
+    enabled: "true",
+    missing: "null",
+    blank: ""
+  },
+  "quoted shorthand scalars remain strings"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body.account.{name, active, created_at, tags}")),
+  {
+    name: "Restish Docs",
+    active: true,
+    created_at: "2026-06-08T09:30:00Z",
+    tags: ["docs", "cli", "api"]
+  },
+  "query projection"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, 'body.items[format == "jpeg"].{name, owner: owner.name, size_bytes}')),
+  [
+    {
+      name: "Dragonfly JPEG",
+      owner: "Ada",
+      size_bytes: 184523
+    }
+  ],
+  "query selection maps projection across array items"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body.items[public == true].name")),
+  ["Dragonfly JPEG", "CLI Screenshot"],
+  "query boolean selection across array fields"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body.items[name.lower contains dragonfly].links.self")),
+  ["https://api.rest.sh/images/jpeg"],
+  "query selection supports contains with lower modifier"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body.events[type == deploy].changes.name")),
+  [
+    ["output guide", "TOON renderer"]
+  ],
+  "query nested arrays after selection"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body..download")),
+  [
+    "https://api.rest.sh/images/jpeg?download=1",
+    "https://api.rest.sh/images/svg?download=1",
+    "https://api.rest.sh/images/png?download=1"
+  ],
+  "recursive shorthand query"
+);
+
+assert.deepEqual(
+  normalize(api.applyShorthandFilter(api.querySample, "body..download|[@ contains jpeg]")),
+  ["https://api.rest.sh/images/jpeg?download=1"],
+  "recursive shorthand query can filter current values"
+);
+
+assert.equal(
+  api.applyShorthandFilter(api.querySample, 'headers."Content-Type"'),
+  "application/json",
+  "quoted field segment query"
+);
+
+assert.equal(
+  api.applyShorthandFilter(api.querySample, 'headers_all."Set-Cookie"[0]'),
+  "session=docs; Path=/; HttpOnly",
+  "headers_all root supports repeated headers"
+);
+
+assert.ok(
+  api.highlightValue("body..download|[@ contains jpeg]", "filter").includes('<span class="restish-token-operator">contains</span>'),
+  "filter highlighter marks contains as query syntax"
+);
+
+assert.deepEqual(
+  normalize(api.parseQuerySource('{"items":[{"id":1,"name":"Ada"}]}')),
+  {
+    body: {
+      items: [{ id: 1, name: "Ada" }]
+    },
+    headers: {},
+    headers_all: {},
+    links: {},
+    proto: "",
+    status: 0
+  },
+  "plain JSON body gets wrapped as a normalized body"
+);
+
+assert.equal(
+  api.applyShorthandFilter(api.parseQuerySource('{"items":[{"id":1,"name":"Ada"}]}'), "body.items[0].name"),
+  "Ada",
+  "filters run against pasted plain JSON bodies"
+);
+
+const encodedSample = api.encodeShorthand(api.querySample);
+assert.ok(encodedSample.includes('headers:{"Content-Type":application/json'), "share encoding groups multi-key header objects");
+assert.ok(encodedSample.includes("links:{self:https://api.rest.sh/example,next:https://api.rest.sh/example?page=2"), "share encoding groups multi-key link objects");
+assert.ok(encodedSample.includes("account:{id:acct_docs,name:Restish Docs"), "share encoding preserves nested account objects");
+assert.ok(encodedSample.includes("tags:[docs,cli,api]"), "share encoding groups arrays without repeated paths");
+assert.ok(encodedSample.includes("items:[{id:101,name:Dragonfly JPEG"), "share encoding preserves arrays of objects");
+assert.equal(encodedSample.includes("tags[]"), false, "share encoding does not repeat array paths");
+
+assert.deepEqual(
+  normalize(api.parseShorthand(encodedSample)),
+  normalize(api.querySample),
+  "share shorthand round trips the normalized sample response"
+);
+
+assert.equal(
+  api.encodeShorthand({ body: { items: [{ id: 1, name: "Ada" }] } }),
+  "body.items:[{id:1,name:Ada}]",
+  "share encoding shortens single-key object chains"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand('body:{basics:{profiles:[github,docs]}}')),
+  { body: { basics: { profiles: ["github", "docs"] } } },
+  "nested shorthand object and array literals parse"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand("body:{name:API Technologies}")),
+  { body: { name: "API Technologies" } },
+  "bare literal strings may contain spaces"
+);
+
+assert.deepEqual(
+  normalize(api.parseShorthand('"meta:field": "value:with:colon"')),
+  { "meta:field": "value:with:colon" },
+  "quoted keys and values can contain colons"
+);
+
+assert.equal(
+  api.parseQuerySource('{"status":201,"body":{"id":"new"}}').status,
+  201,
+  "normalized responses stay normalized"
+);
+
+assert.equal(api.outputActions.redirect.active.includes("format"), false, "raw redirect skips formatting");
+console.log("restish-docs-interactions: parser and query fixtures passed");

--- a/site/scripts/test-restish-playground.mjs
+++ b/site/scripts/test-restish-playground.mjs
@@ -50,6 +50,76 @@ vm.runInContext(source, sandbox, { filename: "restish-playground.js" });
 const api = sandbox.window.__restishPlaygroundTest;
 assert.ok(api, "playground test API should be exposed");
 
+function complete(input) {
+  return JSON.parse(JSON.stringify(api.completeCommand(input, input.length)));
+}
+
+assert.deepEqual(
+  complete("restish ex"),
+  {
+    value: "restish example ",
+    cursor: "restish example ".length,
+    matches: ["example"],
+    applied: true
+  },
+  "root command completion"
+);
+
+assert.deepEqual(
+  complete("restish example li"),
+  {
+    value: "restish example list-",
+    cursor: "restish example list-".length,
+    matches: ["list-books", "list-images", "list-items"],
+    applied: true
+  },
+  "shared prefix completion for generated operations"
+);
+
+assert.deepEqual(
+  complete("restish example list-im"),
+  {
+    value: "restish example list-images ",
+    cursor: "restish example list-images ".length,
+    matches: ["list-images"],
+    applied: true
+  },
+  "single generated operation completion"
+);
+
+assert.deepEqual(
+  complete("restish example get-image "),
+  {
+    value: "restish example get-image ",
+    cursor: "restish example get-image ".length,
+    matches: ["gif", "heic", "jpeg", "png", "webp"],
+    applied: false
+  },
+  "generated path parameter suggestions"
+);
+
+assert.deepEqual(
+  complete("restish api.rest.sh/images -o j"),
+  {
+    value: "restish api.rest.sh/images -o json ",
+    cursor: "restish api.rest.sh/images -o json ".length,
+    matches: ["json"],
+    applied: true
+  },
+  "output format value completion"
+);
+
+assert.deepEqual(
+  complete("restish api.rest.sh/im"),
+  {
+    value: "restish api.rest.sh/images",
+    cursor: "restish api.rest.sh/images".length,
+    matches: ["api.rest.sh/images", "api.rest.sh/images/jpeg"],
+    applied: true
+  },
+  "URL-ish docs path completion"
+);
+
 const toonPlan = api.parseCommand("restish get https://api.rest.sh/items -o toon");
 assert.equal(toonPlan.flags.outputFormat, "toon");
 assert.equal(

--- a/site/scripts/test-restish-playground.mjs
+++ b/site/scripts/test-restish-playground.mjs
@@ -109,6 +109,14 @@ assert.deepEqual(
   "output format value completion"
 );
 
+const printCompletion = complete("restish api.rest.sh/images --rsh-print H");
+assert.ok(printCompletion.matches.includes("HBhbp"), "print transcript completion should include HBhbp");
+assert.equal(
+  printCompletion.matches.includes("Hhbp"),
+  false,
+  "print transcript completion should not include the invalid Hhbp spec"
+);
+
 assert.deepEqual(
   complete("restish api.rest.sh/im"),
   {
@@ -118,6 +126,17 @@ assert.deepEqual(
     applied: true
   },
   "URL-ish docs path completion"
+);
+
+assert.equal(
+  api.shouldApplyCompletionKey({ key: "Tab", shiftKey: false }),
+  true,
+  "plain Tab should apply completions"
+);
+assert.equal(
+  api.shouldApplyCompletionKey({ key: "Tab", shiftKey: true }),
+  false,
+  "Shift+Tab should keep the browser focus traversal behavior"
 );
 
 const toonPlan = api.parseCommand("restish get https://api.rest.sh/items -o toon");

--- a/site/static/js/restish-anatomy.js
+++ b/site/static/js/restish-anatomy.js
@@ -1,0 +1,268 @@
+(function () {
+  "use strict";
+
+  function initAnatomyBlock(block) {
+    if (block.dataset.restishAnatomyReady === "true") {
+      return;
+    }
+    block.dataset.restishAnatomyReady = "true";
+
+    const targets = Array.from(block.querySelectorAll("[data-anatomy-part]"));
+    const connectorPath = block.querySelector("[data-restish-anatomy-string]");
+    const connectorEnabled = connectorPath && !prefersReducedMotion() && !usesCoarsePointer();
+    let activePart = "";
+    let activeToken = null;
+    let activeCard = null;
+    let startPoint = null;
+    let endPoint = null;
+    let pointerPoint = null;
+    let previousPointerPoint = null;
+    let pointerControls = "";
+    let pointerImpulse = 0;
+    let stringOffset = 0;
+    let stringVelocity = 0;
+    let previousFrame = 0;
+    let animationFrame = 0;
+
+    function activate(part, source) {
+      if (!part) {
+        clear();
+        return;
+      }
+
+      activePart = part;
+      activeToken = findAnatomyPart(block, part, ".restish-anatomy__command");
+      activeCard = findAnatomyPart(block, part, ".restish-anatomy__grid");
+      block.dataset.activeAnatomy = part;
+      targets.forEach(function (target) {
+        target.toggleAttribute("data-anatomy-active", target.dataset.anatomyPart === part);
+      });
+
+      const activeColor = window.getComputedStyle(source).getPropertyValue("--anatomy-color").trim();
+      if (activeColor) {
+        block.style.setProperty("--anatomy-active-color", activeColor);
+      }
+
+      if (!connectorEnabled || !activeToken || !activeCard) {
+        block.dataset.connectorActive = "false";
+        return;
+      }
+
+      previousFrame = 0;
+      pointerControls = source.classList.contains("restish-anatomy__item") ? "card" : "token";
+      stringVelocity += pointerControls === "card" ? -13 : 13;
+      updateConnectorAnchors();
+      block.dataset.connectorActive = "true";
+      drawConnector();
+      if (!animationFrame) {
+        animationFrame = window.requestAnimationFrame(animateConnector);
+      }
+    }
+
+    function clear() {
+      activePart = "";
+      activeToken = null;
+      activeCard = null;
+      startPoint = null;
+      endPoint = null;
+      pointerPoint = null;
+      previousPointerPoint = null;
+      pointerControls = "";
+      pointerImpulse = 0;
+      previousFrame = 0;
+      stringOffset = 0;
+      stringVelocity = 0;
+      delete block.dataset.activeAnatomy;
+      block.dataset.connectorActive = "false";
+      targets.forEach(function (target) {
+        target.removeAttribute("data-anatomy-active");
+      });
+      if (connectorPath) {
+        connectorPath.setAttribute("d", "");
+      }
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+        animationFrame = 0;
+      }
+    }
+
+    function updateConnectorAnchors() {
+      if (!activeToken || !activeCard || !connectorPath) {
+        return;
+      }
+      const rect = block.getBoundingClientRect();
+      const tokenRect = activeToken.getBoundingClientRect();
+      const cardRect = activeCard.getBoundingClientRect();
+      const svg = connectorPath.ownerSVGElement;
+      svg.setAttribute("viewBox", `0 0 ${rect.width} ${rect.height}`);
+      startPoint = {
+        x: tokenRect.left + tokenRect.width / 2 - rect.left,
+        y: tokenRect.bottom - rect.top + 3
+      };
+      endPoint = {
+        x: cardRect.left + cardRect.width / 2 - rect.left,
+        y: cardRect.top - rect.top - 3
+      };
+    }
+
+    function updatePointer(event) {
+      if (!connectorEnabled || !activePart) {
+        return;
+      }
+      const rect = block.getBoundingClientRect();
+      const nextPoint = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top
+      };
+      previousPointerPoint = pointerPoint;
+      pointerPoint = nextPoint;
+      updateConnectorAnchors();
+      addPointerImpulse();
+      drawConnector();
+      if (!animationFrame) {
+        previousFrame = 0;
+        animationFrame = window.requestAnimationFrame(animateConnector);
+      }
+    }
+
+    function currentStartPoint() {
+      return pointerControls === "token" && pointerPoint ? pointerPoint : startPoint;
+    }
+
+    function currentEndPoint() {
+      return pointerControls === "card" && pointerPoint ? pointerPoint : endPoint;
+    }
+
+    function addPointerImpulse() {
+      if (!previousPointerPoint || !startPoint || !endPoint) {
+        return;
+      }
+      const from = currentStartPoint();
+      const to = currentEndPoint();
+      if (!from || !to) {
+        return;
+      }
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const length = Math.max(Math.hypot(dx, dy), 1);
+      const normalX = -dy / length;
+      const normalY = dx / length;
+      const moveX = pointerPoint.x - previousPointerPoint.x;
+      const moveY = pointerPoint.y - previousPointerPoint.y;
+      const perpendicularMovement = moveX * normalX + moveY * normalY;
+      const movement = Math.hypot(moveX, moveY);
+      if (movement < 0.2) {
+        return;
+      }
+      const direction = pointerControls === "card" ? -1 : 1;
+      const impulse = clamp(perpendicularMovement * 0.62 * direction, -18, 18);
+      pointerImpulse = clamp(pointerImpulse + impulse, -30, 30);
+      stringVelocity = clamp(stringVelocity + impulse * 0.95, -28, 28);
+    }
+
+    function drawConnector() {
+      if (!startPoint || !endPoint || !connectorPath) {
+        return;
+      }
+      const from = currentStartPoint();
+      const to = currentEndPoint();
+      if (!from || !to) {
+        return;
+      }
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const length = Math.max(Math.hypot(dx, dy), 1);
+      const normalX = -dy / length;
+      const normalY = dx / length;
+      const bend = stringOffset + pointerImpulse;
+      const controlX = (from.x + to.x) / 2 + normalX * bend;
+      const controlY = (from.y + to.y) / 2 + normalY * bend;
+      connectorPath.setAttribute(
+        "d",
+        `M ${from.x.toFixed(1)} ${from.y.toFixed(1)} Q ${controlX.toFixed(1)} ${controlY.toFixed(1)} ${to.x.toFixed(1)} ${to.y.toFixed(1)}`
+      );
+    }
+
+    function animateConnector(timestamp) {
+      animationFrame = 0;
+      if (!activePart || !startPoint || !endPoint || !connectorPath) {
+        return;
+      }
+
+      if (!previousFrame) {
+        previousFrame = timestamp;
+      }
+      const delta = Math.min((timestamp - previousFrame) / 16.67, 2);
+      previousFrame = timestamp;
+
+      stringVelocity += (0 - stringOffset) * 0.18 * delta;
+      stringVelocity *= Math.pow(0.79, delta);
+      stringOffset += stringVelocity * delta;
+      pointerImpulse *= Math.pow(0.72, delta);
+      drawConnector();
+
+      if (Math.abs(stringVelocity) > 0.035 || Math.abs(stringOffset) > 0.12 || Math.abs(pointerImpulse) > 0.12) {
+        animationFrame = window.requestAnimationFrame(animateConnector);
+      } else {
+        stringOffset = 0;
+        stringVelocity = 0;
+        pointerImpulse = 0;
+        drawConnector();
+      }
+    }
+
+    targets.forEach(function (target) {
+      target.addEventListener("mouseenter", function () {
+        activate(target.dataset.anatomyPart, target);
+      });
+      target.addEventListener("focus", function () {
+        activate(target.dataset.anatomyPart, target);
+      });
+      target.addEventListener("mousemove", updatePointer);
+    });
+
+    block.addEventListener("mouseleave", clear);
+    block.addEventListener("focusout", function (event) {
+      if (!block.contains(event.relatedTarget)) {
+        clear();
+      }
+    });
+    window.addEventListener("resize", function () {
+      if (activePart) {
+        updateConnectorAnchors();
+      }
+    });
+  }
+
+  function findAnatomyPart(block, part, scopeSelector) {
+    const scope = block.querySelector(scopeSelector);
+    if (!scope) {
+      return null;
+    }
+    return Array.from(scope.querySelectorAll("[data-anatomy-part]")).find(function (item) {
+      return item.dataset.anatomyPart === part;
+    }) || null;
+  }
+
+  function prefersReducedMotion() {
+    return Boolean(window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  }
+
+  function usesCoarsePointer() {
+    return Boolean(window.matchMedia && window.matchMedia("(hover: none), (pointer: coarse)").matches);
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function initAllAnatomyBlocks() {
+    document.querySelectorAll("[data-restish-anatomy]").forEach(initAnatomyBlock);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAllAnatomyBlocks);
+  } else {
+    initAllAnatomyBlocks();
+  }
+})();

--- a/site/static/js/restish-docs-interactions.js
+++ b/site/static/js/restish-docs-interactions.js
@@ -247,10 +247,23 @@
     const source = root.querySelector("[data-query-source]");
     const output = root.querySelector("[data-query-output]");
     const status = root.querySelector("[data-query-status]");
+    const traceRoot = root.querySelector("[data-filter-trace]");
+    const traceToggle = root.querySelector("[data-toggle-trace]");
+    const traceSummary = root.querySelector("[data-trace-summary]");
+    const traceTokens = root.querySelector("[data-trace-tokens]");
+    const traceBefore = root.querySelector("[data-trace-before]");
+    const traceAfter = root.querySelector("[data-trace-after]");
+    const traceDetail = root.querySelector("[data-trace-detail]");
+    const tracePrev = root.querySelector("[data-trace-prev]");
+    const traceNext = root.querySelector("[data-trace-next]");
+    const tracePlay = root.querySelector("[data-trace-play]");
     const refreshHighlights = setupHighlightEditors(root);
     if (!input || !output) {
       return;
     }
+    let traceSteps = [];
+    let traceIndex = 0;
+    let traceTimer = 0;
 
     const shared = readSharedValue("shorthand-filter");
     if (shared) {
@@ -272,9 +285,74 @@
         const value = applyShorthandFilter(sourceValue, input.value);
         setHighlightedCode(output, JSON.stringify(value, null, 2), "json");
         setStatus(status, "Filter matched", "ok");
+        updateTrace(sourceValue);
       } catch (error) {
         setHighlightedCode(output, error.message, "");
         setStatus(status, "No match", "error");
+        updateTrace(null, error);
+      }
+    }
+
+    function updateTrace(sourceValue, error) {
+      stopTracePlayback();
+      if (!traceRoot || traceRoot.hidden) {
+        return;
+      }
+      if (error || !sourceValue) {
+        traceSteps = [];
+        renderTraceError(error ? error.message : "Fix the response JSON before tracing.");
+        return;
+      }
+      try {
+        const trace = buildFilterTrace(sourceValue, input.value);
+        traceSteps = trace.steps;
+        traceIndex = Math.min(traceIndex, Math.max(0, traceSteps.length - 1));
+        renderTraceStep();
+      } catch (traceError) {
+        traceSteps = [];
+        renderTraceError(traceError.message);
+      }
+    }
+
+    function renderTraceError(message) {
+      if (traceSummary) {
+        traceSummary.textContent = message;
+      }
+      if (traceTokens) {
+        traceTokens.textContent = "";
+      }
+      setHighlightedCode(traceBefore, "", "");
+      setHighlightedCode(traceAfter, "", "");
+      if (traceDetail) {
+        traceDetail.textContent = "";
+      }
+    }
+
+    function renderTraceStep() {
+      if (!traceSteps.length) {
+        renderTraceError("This filter has no traceable steps yet.");
+        return;
+      }
+      const step = traceSteps[traceIndex];
+      if (traceSummary) {
+        traceSummary.textContent = `Step ${traceIndex + 1} of ${traceSteps.length}: ${step.title}`;
+      }
+      if (traceTokens) {
+        traceTokens.innerHTML = traceSteps.map(function (item, index) {
+          const active = index === traceIndex ? " data-active" : "";
+          return `<button type="button" data-trace-step="${index}"${active}>${escapeHTML(item.token)}</button>`;
+        }).join("");
+      }
+      setHighlightedCode(traceBefore, JSON.stringify(step.before, null, 2), "json");
+      setHighlightedCode(traceAfter, JSON.stringify(step.after, null, 2), "json");
+      if (traceDetail) {
+        traceDetail.textContent = step.detail;
+      }
+      if (tracePrev) {
+        tracePrev.disabled = traceIndex === 0;
+      }
+      if (traceNext) {
+        traceNext.disabled = traceIndex === traceSteps.length - 1;
       }
     }
 
@@ -298,11 +376,79 @@
         }
       });
     }
+    if (traceToggle && traceRoot) {
+      traceToggle.addEventListener("click", function () {
+        traceRoot.hidden = !traceRoot.hidden;
+        traceToggle.setAttribute("aria-expanded", String(!traceRoot.hidden));
+        traceToggle.textContent = traceRoot.hidden ? "Trace filter" : "Hide trace";
+        traceIndex = 0;
+        try {
+          updateTrace(parseQuerySource(source ? source.value : ""));
+        } catch (error) {
+          updateTrace(null, error);
+        }
+      });
+    }
+    if (traceTokens) {
+      traceTokens.addEventListener("click", function (event) {
+        const button = event.target.closest("[data-trace-step]");
+        if (!button) {
+          return;
+        }
+        stopTracePlayback();
+        traceIndex = Number(button.dataset.traceStep || "0");
+        renderTraceStep();
+      });
+    }
+    if (tracePrev) {
+      tracePrev.addEventListener("click", function () {
+        stopTracePlayback();
+        traceIndex = Math.max(0, traceIndex - 1);
+        renderTraceStep();
+      });
+    }
+    if (traceNext) {
+      traceNext.addEventListener("click", function () {
+        stopTracePlayback();
+        traceIndex = Math.min(traceSteps.length - 1, traceIndex + 1);
+        renderTraceStep();
+      });
+    }
+    if (tracePlay) {
+      tracePlay.addEventListener("click", function () {
+        if (traceTimer) {
+          stopTracePlayback();
+          return;
+        }
+        if (!traceSteps.length) {
+          return;
+        }
+        tracePlay.textContent = "Pause";
+        traceTimer = window.setInterval(function () {
+          if (traceIndex >= traceSteps.length - 1) {
+            stopTracePlayback();
+            return;
+          }
+          traceIndex += 1;
+          renderTraceStep();
+        }, 950);
+      });
+    }
     input.addEventListener("input", render);
     if (source) {
       source.addEventListener("input", render);
     }
     render();
+
+    function stopTracePlayback() {
+      if (traceTimer) {
+        window.clearInterval(traceTimer);
+        traceTimer = 0;
+      }
+      if (tracePlay) {
+        tracePlay.textContent = "Play";
+      }
+    }
   }
 
   function setupHighlightEditors(root) {
@@ -978,6 +1124,160 @@
     }
   }
 
+  function buildFilterTrace(doc, filter) {
+    const parts = splitTopLevel(filter, "|").map((item) => item.trim()).filter(Boolean);
+    const steps = [];
+    let current = doc;
+    if (!parts.length) {
+      steps.push({
+        token: "input",
+        title: "Use the input value",
+        detail: "An empty filter returns the normalized response unchanged.",
+        before: doc,
+        after: doc
+      });
+      return { steps, value: doc };
+    }
+    parts.forEach(function (part, index) {
+      if (index > 0) {
+        steps.push({
+          token: "|",
+          title: "Pipe the current result",
+          detail: "A pipe stops path mapping, collects the current result, and runs the next expression against that value.",
+          before: current,
+          after: current
+        });
+      }
+      const traced = traceExpression(current, part);
+      steps.push(...traced.steps);
+      current = traced.value;
+    });
+    return { steps, value: current };
+  }
+
+  function traceExpression(value, expr) {
+    if (expr.startsWith("{") && expr.endsWith("}")) {
+      const after = project(value, expr.slice(1, -1));
+      return {
+        value: after,
+        steps: [traceStep(`{${expr.slice(1, -1)}}`, "Project selected fields", "Projection builds a new object from the current value.", value, after)]
+      };
+    }
+    if (expr.startsWith("..")) {
+      const field = expr.slice(2);
+      const after = recursiveFind(value, field);
+      return {
+        value: after,
+        steps: [traceStep(`..${field}`, `Find every ${field}`, "Recursive search walks below the current value and collects every matching field.", value, after)]
+      };
+    }
+
+    const projection = expr.match(/^(.*)\.\{(.+)\}$/);
+    if (projection) {
+      const traced = tracePath(value, projection[1]);
+      const before = traced.value;
+      const after = project(before, projection[2]);
+      traced.steps.push(traceStep(`{${projection[2]}}`, "Project selected fields", "Projection runs against the current value. If it is an array, each item gets the same projection.", before, after));
+      traced.value = after;
+      return traced;
+    }
+
+    const recursive = expr.match(/^(.*)\.\.([A-Za-z0-9_-]+)$/);
+    if (recursive) {
+      const traced = tracePath(value, recursive[1]);
+      const before = traced.value;
+      const after = recursiveFind(before, recursive[2]);
+      traced.steps.push(traceStep(`..${recursive[2]}`, `Find every ${recursive[2]}`, "Recursive search walks below the current value and collects every matching field.", before, after));
+      traced.value = after;
+      return traced;
+    }
+
+    return tracePath(value, expr);
+  }
+
+  function tracePath(value, path) {
+    if (!path) {
+      return { steps: [], value };
+    }
+    const tokens = pathTokens(path);
+    const steps = [];
+    let current = value;
+    tokens.forEach(function (token, index) {
+      const before = current;
+      const after = applyPathToken(before, token);
+      steps.push(tracePathStep(token, index, before, after));
+      current = after;
+      if (current === undefined) {
+        throw new Error(`No value matched \`${path}\`.`);
+      }
+    });
+    return { steps, value: current };
+  }
+
+  function applyPathToken(value, token) {
+    if (token.type === "field") {
+      return readField(value, token.value);
+    }
+    if (token.type === "index") {
+      return readIndex(value, token.value);
+    }
+    if (token.type === "slice") {
+      return readSlice(value, token.start, token.end);
+    }
+    if (token.type === "select") {
+      return selectItems(value, token.field, token.operator, token.value);
+    }
+    return value;
+  }
+
+  function tracePathStep(token, index, before, after) {
+    if (token.type === "field") {
+      const title = Array.isArray(before) ? `Map ${token.value} over each item` : `Select ${token.value}`;
+      const detail = Array.isArray(before)
+        ? `The current value is an array, so Restish applies .${token.value} to each item and keeps the matched values.`
+        : `Restish reads the ${token.value} field from the current value.`;
+      return traceStep(pathTokenLabel(token, index), title, detail, before, after);
+    }
+    if (token.type === "select") {
+      const kept = Array.isArray(after) ? after.length : 0;
+      const total = Array.isArray(before) ? before.length : 0;
+      return traceStep(pathTokenLabel(token, index), `Filter ${total} items`, `Selection keeps ${kept} of ${total} items where ${token.field} ${selectionOperatorLabel(token.operator)} ${formatTraceScalar(token.value)}.`, before, after);
+    }
+    if (token.type === "index") {
+      return traceStep(pathTokenLabel(token, index), `Pick index ${token.value}`, "Bracket indexes select one item from the current array.", before, after);
+    }
+    return traceStep(pathTokenLabel(token, index), "Take a slice", "Slice brackets select a range from the current array.", before, after);
+  }
+
+  function traceStep(token, title, detail, before, after) {
+    return { token, title, detail, before, after };
+  }
+
+  function pathTokenLabel(token, index) {
+    if (token.type === "field") {
+      return `${index === 0 ? "" : "."}${formatPathField(token.value)}`;
+    }
+    if (token.type === "index") {
+      return `[${token.value}]`;
+    }
+    if (token.type === "slice") {
+      return `[${token.start}:${token.end === undefined ? "" : token.end}]`;
+    }
+    return `[${token.field} ${selectionOperatorLabel(token.operator)} ${formatTraceScalar(token.value)}]`;
+  }
+
+  function selectionOperatorLabel(operator) {
+    return operator === "contains" ? "contains" : "==";
+  }
+
+  function formatPathField(field) {
+    return /^[A-Za-z_][A-Za-z0-9_-]*$/.test(field) ? field : JSON.stringify(field);
+  }
+
+  function formatTraceScalar(value) {
+    return typeof value === "string" && /\s/.test(value) ? JSON.stringify(value) : String(value);
+  }
+
   function applyShorthandFilter(doc, filter) {
     const parts = splitTopLevel(filter, "|").map((item) => item.trim()).filter(Boolean);
     if (!parts.length) {
@@ -1367,6 +1667,7 @@
   if (window.__RESTISH_DOCS_INTERACTIONS_TEST__) {
     window.__restishDocsInteractionsTest = {
       applyShorthandFilter,
+      buildFilterTrace,
       outputActions,
       encodeShorthand,
       highlightValue,

--- a/site/static/js/restish-docs-interactions.js
+++ b/site/static/js/restish-docs-interactions.js
@@ -1,0 +1,1384 @@
+(function () {
+  "use strict";
+
+  const outputActions = {
+    auto: {
+      command: "restish api.rest.sh/types",
+      active: ["response", "decompress", "decode", "normalize", "format"],
+      detail: "A normal terminal request receives bytes, decodes the body, normalizes the exchange, and chooses a human-friendly format. There is no paging or stream handling when the response is one document."
+    },
+    headers: {
+      command: "restish api.rest.sh/ --rsh-headers",
+      active: ["response", "normalize", "format"],
+      detail: "Header output uses response metadata. Restish can skip body decompression and unmarshalling because the command only asks for normalized headers."
+    },
+    jsonfile: {
+      command: "restish api.rest.sh/example -f body.skills > skills.json",
+      active: ["response", "decompress", "decode", "normalize", "filter", "format"],
+      detail: "For scripts, Restish can filter the normalized response and redirect the rendered JSON to a file. This path does not page or stream because the example endpoint returns one document."
+    },
+    pages: {
+      command: "restish api.rest.sh/images",
+      active: ["response", "decompress", "decode", "normalize", "paginate", "format"],
+      detail: "Paginated collection endpoints add a page step after normalization. Restish follows pagination links and formats the resulting records for the terminal."
+    },
+    stream: {
+      command: "restish api.rest.sh/events -o ndjson",
+      active: ["response", "decompress", "decode", "normalize", "paginate", "format"],
+      detail: "Streams reuse the same stage as pagination, but records arrive over time. NDJSON lets each event be decoded, normalized, and emitted without waiting for a final document."
+    },
+    redirect: {
+      command: "restish api.rest.sh/images/jpeg > dragonfly.jpg",
+      active: ["response", "decompress"],
+      detail: "Unfiltered redirects preserve response body bytes after HTTP content-encoding decompression. Restish skips decoding, filtering, and formatting."
+    }
+  };
+
+  const querySample = {
+    proto: "HTTP/2.0",
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Request-ID": "req_7mQp42",
+      "X-RateLimit-Remaining": "42"
+    },
+    headers_all: {
+      "Content-Type": ["application/json"],
+      "Set-Cookie": [
+        "session=docs; Path=/; HttpOnly",
+        "theme=dark; Path=/"
+      ]
+    },
+    links: {
+      self: "https://api.rest.sh/example",
+      next: "https://api.rest.sh/example?page=2",
+      help: "https://rest.sh/docs/guides/filtering/"
+    },
+    body: {
+      account: {
+        id: "acct_docs",
+        name: "Restish Docs",
+        active: true,
+        created_at: "2026-06-08T09:30:00Z",
+        tags: ["docs", "cli", "api"],
+        plan: {
+          name: "team",
+          seats: 5,
+          trial: false
+        }
+      },
+      items: [
+        {
+          id: 101,
+          name: "Dragonfly JPEG",
+          format: "jpeg",
+          size_bytes: 184523,
+          public: true,
+          created_at: "2026-06-01",
+          labels: ["image", "demo", "public"],
+          owner: {
+            id: "usr_ada",
+            name: "Ada"
+          },
+          links: {
+            self: "https://api.rest.sh/images/jpeg",
+            download: "https://api.rest.sh/images/jpeg?download=1"
+          },
+          metrics: {
+            views: 1280,
+            latency_ms: 24.6
+          }
+        },
+        {
+          id: 102,
+          name: "OpenAPI Diagram",
+          format: "svg",
+          size_bytes: 9280,
+          public: false,
+          created_at: "2026-05-18",
+          labels: ["diagram", "internal"],
+          owner: {
+            id: "usr_grace",
+            name: "Grace"
+          },
+          links: {
+            self: "https://api.rest.sh/images/svg",
+            download: "https://api.rest.sh/images/svg?download=1"
+          },
+          metrics: {
+            views: 312,
+            latency_ms: 11.8
+          }
+        },
+        {
+          id: 103,
+          name: "CLI Screenshot",
+          format: "png",
+          size_bytes: 64211,
+          public: true,
+          created_at: "2026-04-27",
+          labels: ["screenshot", "docs"],
+          owner: {
+            id: "usr_ada",
+            name: "Ada"
+          },
+          links: {
+            self: "https://api.rest.sh/images/png",
+            download: "https://api.rest.sh/images/png?download=1"
+          },
+          metrics: {
+            views: 845,
+            latency_ms: 18.2
+          }
+        }
+      ],
+      events: [
+        {
+          type: "deploy",
+          at: "2026-06-08T16:45:00Z",
+          actor: "daniel",
+          success: true,
+          changes: [
+            { name: "output guide", kind: "docs" },
+            { name: "TOON renderer", kind: "feature" }
+          ]
+        },
+        {
+          type: "audit",
+          at: "2026-06-07T19:12:00Z",
+          actor: "restish-bot",
+          success: true,
+          changes: [
+            { name: "link check", kind: "qa" }
+          ]
+        }
+      ],
+      totals: {
+        count: 3,
+        public_count: 2,
+        archived_count: 0,
+        next_review_at: "2026-07-01"
+      }
+    }
+  };
+
+  function initOutputPipeline(root) {
+    const command = root.querySelector("[data-output-command]");
+    const detail = root.querySelector("[data-output-detail]");
+    const actionButtons = Array.from(root.querySelectorAll("[data-output-action]"));
+    const stepButtons = Array.from(root.querySelectorAll("[data-output-step]"));
+
+    function activate(name) {
+      const action = outputActions[name] || outputActions.auto;
+      const active = new Set(action.active);
+      if (command) {
+        command.textContent = action.command;
+      }
+      if (detail) {
+        detail.textContent = action.detail;
+      }
+      actionButtons.forEach(function (button) {
+        button.toggleAttribute("data-active", button.dataset.outputAction === name);
+      });
+      stepButtons.forEach(function (button, index) {
+        const isActive = active.has(button.dataset.outputStep);
+        const next = stepButtons[index + 1];
+        const hasActiveEdge = Boolean(isActive && next && active.has(next.dataset.outputStep));
+        button.toggleAttribute("data-active", isActive);
+        button.toggleAttribute("data-active-edge", hasActiveEdge);
+        button.style.setProperty("--step-index", String(index));
+      });
+    }
+
+    actionButtons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        activate(button.dataset.outputAction);
+      });
+    });
+    activate("auto");
+  }
+
+  function initShorthandBody(root) {
+    const input = root.querySelector("[data-shorthand-input]");
+    const output = root.querySelector("[data-shorthand-output]");
+    const status = root.querySelector("[data-shorthand-status]");
+    const refreshHighlights = setupHighlightEditors(root);
+    if (!input || !output) {
+      return;
+    }
+
+    const shared = readSharedValue("shorthand-body");
+    if (shared) {
+      input.value = shared;
+    }
+
+    function render() {
+      refreshHighlights();
+      updateActiveSample(root, input.value);
+      try {
+        const value = parseShorthand(input.value);
+        setHighlightedCode(output, JSON.stringify(value, null, 2), "json");
+        setStatus(status, "Valid shorthand", "ok");
+      } catch (error) {
+        setHighlightedCode(output, error.message, "");
+        setStatus(status, "Needs attention", "error");
+      }
+    }
+
+    root.querySelectorAll("[data-sample]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        input.value = button.dataset.sample || "";
+        render();
+        input.focus();
+      });
+    });
+    const share = root.querySelector("[data-share-example]");
+    if (share) {
+      share.addEventListener("click", function () {
+        copyShareLink("shorthand-body", input.value, share, status);
+      });
+    }
+    input.addEventListener("input", render);
+    render();
+  }
+
+  function initQueryRunner(root) {
+    const input = root.querySelector("[data-query-input]");
+    const source = root.querySelector("[data-query-source]");
+    const output = root.querySelector("[data-query-output]");
+    const status = root.querySelector("[data-query-status]");
+    const refreshHighlights = setupHighlightEditors(root);
+    if (!input || !output) {
+      return;
+    }
+
+    const shared = readSharedValue("shorthand-filter");
+    if (shared) {
+      input.value = shared;
+    }
+    const sharedResponse = readSharedValue("response-shorthand");
+    const sharedJSONResponse = readSharedValue("response-json");
+    if (source) {
+      source.value = sharedResponse
+        ? JSON.stringify(parseShorthand(sharedResponse), null, 2)
+        : (sharedJSONResponse || JSON.stringify(querySample, null, 2));
+    }
+
+    function render() {
+      refreshHighlights();
+      updateActiveSample(root, input.value);
+      try {
+        const sourceValue = parseQuerySource(source ? source.value : "");
+        const value = applyShorthandFilter(sourceValue, input.value);
+        setHighlightedCode(output, JSON.stringify(value, null, 2), "json");
+        setStatus(status, "Filter matched", "ok");
+      } catch (error) {
+        setHighlightedCode(output, error.message, "");
+        setStatus(status, "No match", "error");
+      }
+    }
+
+    root.querySelectorAll("[data-sample]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        input.value = button.dataset.sample || "";
+        render();
+        input.focus();
+      });
+    });
+    const share = root.querySelector("[data-share-example]");
+    if (share) {
+      share.addEventListener("click", function () {
+        try {
+          copyShareLinkParams({
+            "response-shorthand": source ? encodeShorthand(parseQuerySource(source.value)) : "",
+            "shorthand-filter": input.value
+          }, share, status);
+        } catch (error) {
+          setStatus(status, "Fix response JSON before sharing", "error");
+        }
+      });
+    }
+    input.addEventListener("input", render);
+    if (source) {
+      source.addEventListener("input", render);
+    }
+    render();
+  }
+
+  function setupHighlightEditors(root) {
+    const editors = Array.from(root.querySelectorAll("[data-highlight-editor]"));
+    const refreshers = editors.map(function (editor) {
+      const field = editor.querySelector("textarea, input");
+      const mirror = editor.querySelector("[data-highlight-mirror]");
+      const mode = editor.dataset.highlightMode || "";
+      if (!field || !mirror) {
+        return function () {};
+      }
+
+      function refresh() {
+        autoSizeField(field);
+        mirror.innerHTML = highlightValue(field.value, mode);
+        if (field.tagName === "TEXTAREA" && !field.value.endsWith("\n")) {
+          mirror.insertAdjacentHTML("beforeend", "\n");
+        }
+      }
+
+      field.addEventListener("input", refresh);
+      field.addEventListener("scroll", function () {
+        mirror.parentElement.scrollTop = field.scrollTop;
+        mirror.parentElement.scrollLeft = field.scrollLeft;
+      });
+      refresh();
+      return refresh;
+    });
+    return function () {
+      refreshers.forEach(function (refresh) {
+        refresh();
+      });
+    };
+  }
+
+  function autoSizeField(field) {
+    if (field.tagName !== "TEXTAREA" || !field.hasAttribute("data-auto-size")) {
+      return;
+    }
+    const min = Number(field.dataset.autoSizeMin || "2");
+    const max = Number(field.dataset.autoSizeMax || "8");
+    const lineHeight = parseFloat(window.getComputedStyle(field).lineHeight) || 20;
+    const padding = 24;
+    field.style.height = "auto";
+    const maxHeight = (lineHeight * max) + padding;
+    const minHeight = (lineHeight * min) + padding;
+    const nextHeight = Math.max(minHeight, Math.min(field.scrollHeight, maxHeight));
+    field.style.height = `${nextHeight}px`;
+    field.style.overflowY = field.scrollHeight > maxHeight ? "auto" : "hidden";
+  }
+
+  function updateActiveSample(root, value) {
+    const normalized = (value || "").trim();
+    root.querySelectorAll("[data-sample]").forEach(function (button) {
+      button.toggleAttribute("data-active", (button.dataset.sample || "").trim() === normalized);
+    });
+  }
+
+  function setHighlightedCode(node, value, mode) {
+    if (!node) {
+      return;
+    }
+    if (mode) {
+      node.innerHTML = highlightValue(value, mode);
+    } else {
+      node.textContent = value;
+    }
+  }
+
+  function highlightValue(value, mode) {
+    if (mode === "json") {
+      return highlightJSON(value);
+    }
+    if (mode === "shorthand" || mode === "filter") {
+      return highlightLooseSyntax(value, mode);
+    }
+    return escapeHTML(value);
+  }
+
+  function highlightJSON(value) {
+    const input = String(value);
+    const pattern = /("(?:\\.|[^"\\])*"(?=\s*:)|"(?:\\.|[^"\\])*"|true|false|null|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|[{}\[\],:])/g;
+    let html = "";
+    let cursor = 0;
+    let match;
+    while ((match = pattern.exec(input)) !== null) {
+      html += escapeHTML(input.slice(cursor, match.index));
+      const token = match[0];
+      let cls = "restish-token-punctuation";
+      if (token.startsWith("\"")) {
+        cls = /^\s*:/.test(input.slice(pattern.lastIndex)) ? "restish-token-key" : jsonStringClass(token);
+      } else if (token === "true" || token === "false") {
+        cls = "restish-token-bool";
+      } else if (token === "null") {
+        cls = "restish-token-null";
+      } else if (/^-?\d/.test(token)) {
+        cls = "restish-token-number";
+      }
+      html += `<span class="${cls}">${escapeHTML(token)}</span>`;
+      cursor = match.index + token.length;
+    }
+    html += escapeHTML(input.slice(cursor));
+    return html;
+  }
+
+  function highlightLooseSyntax(value, mode) {
+    let html = "";
+    let index = 0;
+    while (index < value.length) {
+      const ch = value[index];
+      if (/\s/.test(ch)) {
+        html += escapeHTML(ch);
+        index += 1;
+        continue;
+      }
+      if (ch === "\"" || ch === "'") {
+        const start = index;
+        index += 1;
+        while (index < value.length) {
+          if (value[index] === ch && value[index - 1] !== "\\") {
+            index += 1;
+            break;
+          }
+          index += 1;
+        }
+        html += tokenSpan("string", value.slice(start, index));
+        continue;
+      }
+      if (value.slice(index, index + 2) === "==") {
+        html += tokenSpan("operator", "==");
+        index += 2;
+        continue;
+      }
+      if (mode === "filter" && value[index] === "@") {
+        html += tokenSpan("operator", "@");
+        index += 1;
+        continue;
+      }
+      if (mode === "shorthand") {
+        const keyPathEnd = shorthandKeyPathEnd(value, index);
+        if (keyPathEnd > index) {
+          html += highlightKeyPath(value.slice(index, keyPathEnd));
+          index = keyPathEnd;
+          continue;
+        }
+      }
+      if ("{}[](),:|.".includes(ch)) {
+        html += tokenSpan(ch === "|" ? "operator" : "punctuation", ch);
+        index += 1;
+        continue;
+      }
+      const start = index;
+      while (index < value.length && !/[\s{}\[\](),:|.]/.test(value[index])) {
+        index += 1;
+      }
+      const token = value.slice(start, index);
+      const next = nextNonSpace(value, index);
+      let cls = "string";
+      if (next === ":" || (mode === "shorthand" && next === "{") || (mode === "filter" && /^[A-Za-z_][A-Za-z0-9_-]*$/.test(token))) {
+        cls = "key";
+      }
+      if (token === "true" || token === "false") {
+        cls = "bool";
+      } else if (token === "null") {
+        cls = "null";
+      } else if (mode === "filter" && token === "contains") {
+        cls = "operator";
+      } else if (/^-?\d+(\.\d+)?$/.test(token)) {
+        cls = "number";
+      } else if (/^https?:\/\//.test(token)) {
+        cls = "href";
+      } else if (/^\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?$/.test(token)) {
+        cls = "date";
+      }
+      html += tokenSpan(cls, token);
+    }
+    return html;
+  }
+
+  function shorthandKeyPathEnd(value, start) {
+    let index = start;
+    let quote = "";
+    let bracketDepth = 0;
+    while (index < value.length) {
+      const ch = value[index];
+      if (quote) {
+        if (ch === quote && value[index - 1] !== "\\") {
+          quote = "";
+        }
+        index += 1;
+        continue;
+      }
+      if (ch === "\"" || ch === "'") {
+        quote = ch;
+        index += 1;
+        continue;
+      }
+      if (ch === "[") {
+        bracketDepth += 1;
+      } else if (ch === "]") {
+        bracketDepth = Math.max(0, bracketDepth - 1);
+      }
+      if (bracketDepth === 0 && (ch === ":" || ch === "{")) {
+        return index;
+      }
+      if (bracketDepth === 0 && /[\s,}\])|]/.test(ch)) {
+        return -1;
+      }
+      index += 1;
+    }
+    return -1;
+  }
+
+  function highlightKeyPath(path) {
+    let html = "";
+    let index = 0;
+    while (index < path.length) {
+      const ch = path[index];
+      if (ch === "." || ch === "[" || ch === "]") {
+        html += tokenSpan("punctuation", ch);
+        index += 1;
+        continue;
+      }
+      const start = index;
+      while (index < path.length && path[index] !== "." && path[index] !== "[" && path[index] !== "]") {
+        index += 1;
+      }
+      html += tokenSpan("key", path.slice(start, index));
+    }
+    return html;
+  }
+
+  function jsonStringClass(token) {
+    try {
+      const value = JSON.parse(token);
+      if (/^https?:\/\//.test(value)) {
+        return "restish-token-href";
+      }
+      if (/^\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?$/.test(value)) {
+        return "restish-token-date";
+      }
+    } catch (error) {
+      return "restish-token-string";
+    }
+    return "restish-token-string";
+  }
+
+  function nextNonSpace(value, index) {
+    let cursor = index;
+    while (/\s/.test(value[cursor] || "")) {
+      cursor += 1;
+    }
+    return value[cursor] || "";
+  }
+
+  function tokenSpan(kind, value) {
+    return `<span class="restish-token-${kind}">${escapeHTML(value)}</span>`;
+  }
+
+  function escapeHTML(value) {
+    return String(value).replace(/[&<>"']/g, function (ch) {
+      return {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "\"": "&quot;",
+        "'": "&#39;"
+      }[ch];
+    });
+  }
+
+  function parseQuerySource(input) {
+    const parsed = JSON.parse(input || "null");
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && (
+      Object.prototype.hasOwnProperty.call(parsed, "body") ||
+      Object.prototype.hasOwnProperty.call(parsed, "headers") ||
+      Object.prototype.hasOwnProperty.call(parsed, "headers_all") ||
+      Object.prototype.hasOwnProperty.call(parsed, "links") ||
+      Object.prototype.hasOwnProperty.call(parsed, "status") ||
+      Object.prototype.hasOwnProperty.call(parsed, "proto")
+    )) {
+      return parsed;
+    }
+    return {
+      body: parsed,
+      headers: {},
+      headers_all: {},
+      links: {},
+      proto: "",
+      status: 0
+    };
+  }
+
+  function parseShorthand(input) {
+    const trimmed = input.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      return parseLiteral(trimmed);
+    }
+    const result = {};
+    const fields = splitTopLevel(input, ",").map((item) => item.trim()).filter(Boolean);
+    for (const field of fields) {
+      const index = topLevelColonIndex(field);
+      if (index <= 0) {
+        const objectIndex = topLevelObjectFieldIndex(field);
+        if (objectIndex > 0) {
+          const path = field.slice(0, objectIndex).trim();
+          setPath(result, path, parseLiteral(field.slice(objectIndex).trim()));
+          continue;
+        }
+        throw new Error(`Could not parse \`${field}\`; expected key: value.`);
+      }
+      const path = field.slice(0, index).trim();
+      const raw = field.slice(index + 1).trim();
+      if (!path) {
+        throw new Error("Shorthand fields need a key before `:`.");
+      }
+      setPath(result, path, parseScalar(raw));
+    }
+    return result;
+  }
+
+  function topLevelColonIndex(input) {
+    let quote = "";
+    let depth = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      const ch = input[index];
+      if (quote) {
+        if (ch === quote && input[index - 1] !== "\\") {
+          quote = "";
+        }
+        continue;
+      }
+      if (ch === "'" || ch === "\"") {
+        quote = ch;
+        continue;
+      }
+      if (ch === "[" || ch === "{") {
+        depth += 1;
+      } else if (ch === "]" || ch === "}") {
+        depth = Math.max(0, depth - 1);
+      }
+      if (ch === ":" && depth === 0) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  function topLevelObjectFieldIndex(input) {
+    let quote = "";
+    let depth = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      const ch = input[index];
+      if (quote) {
+        if (ch === quote && input[index - 1] !== "\\") {
+          quote = "";
+        }
+        continue;
+      }
+      if (ch === "'" || ch === "\"") {
+        quote = ch;
+        continue;
+      }
+      if (ch === "[" && depth === 0) {
+        depth += 1;
+        continue;
+      }
+      if (ch === "]" && depth > 0) {
+        depth -= 1;
+        continue;
+      }
+      if (ch === "{" && depth === 0) {
+        const path = input.slice(0, index).trim();
+        const literal = input.slice(index).trim();
+        return path && literal.endsWith("}") ? index : -1;
+      }
+    }
+    return -1;
+  }
+
+  function setPath(target, path, value) {
+    const parts = assignmentPathSegments(path);
+    let current = target;
+    parts.forEach(function (part, index) {
+      const isLast = index === parts.length - 1;
+      const arrayMatch = part.match(/^(.+)\[(\d*)\]$/);
+      const isArray = Boolean(arrayMatch);
+      const key = arrayMatch ? arrayMatch[1] : part;
+      const arrayIndex = arrayMatch && arrayMatch[2] !== "" ? Number(arrayMatch[2]) : -1;
+      if (!key) {
+        throw new Error(`Invalid path segment in \`${path}\`.`);
+      }
+      if (isLast) {
+        if (isArray) {
+          if (!Array.isArray(current[key])) {
+            current[key] = [];
+          }
+          if (arrayIndex >= 0) {
+            current[key][arrayIndex] = value;
+          } else {
+            current[key].push(value);
+          }
+        } else {
+          current[key] = value;
+        }
+        return;
+      }
+      if (isArray) {
+        if (!Array.isArray(current[key])) {
+          current[key] = [];
+        }
+        const targetIndex = arrayIndex >= 0 ? arrayIndex : current[key].length - 1;
+        if (arrayIndex >= 0 && !current[key][targetIndex]) {
+          current[key][targetIndex] = {};
+        } else if (arrayIndex < 0 && (!current[key].length || typeof current[key][current[key].length - 1] !== "object")) {
+          current[key].push({});
+        }
+        current = current[key][arrayIndex >= 0 ? targetIndex : current[key].length - 1];
+        return;
+      }
+      if (!current[key] || typeof current[key] !== "object" || Array.isArray(current[key])) {
+        current[key] = {};
+      }
+      current = current[key];
+    });
+  }
+
+  function assignmentPathSegments(path) {
+    return splitPath(path).map(function (segment) {
+      const match = segment.match(/^(.+)(\[(?:\d*)\])$/);
+      if (!match) {
+        return unquotePathSegment(segment);
+      }
+      return unquotePathSegment(match[1]) + match[2];
+    }).filter(Boolean);
+  }
+
+  function parseScalar(raw) {
+    if (raw === "") {
+      return "";
+    }
+    if (raw.startsWith("[") || raw.startsWith("{")) {
+      return parseLiteral(raw);
+    }
+    if (raw.startsWith("\"") && raw.endsWith("\"")) {
+      return JSON.parse(raw);
+    }
+    if (raw.startsWith("'") && raw.endsWith("'")) {
+      return raw.slice(1, -1);
+    }
+    if (raw === "true") {
+      return true;
+    }
+    if (raw === "false") {
+      return false;
+    }
+    if (raw === "null") {
+      return null;
+    }
+    if (/^-?\d+(\.\d+)?$/.test(raw)) {
+      return Number(raw);
+    }
+    return raw;
+  }
+
+  function encodeShorthand(value) {
+    if (value && typeof value === "object") {
+      return Object.keys(value).map(function (key) {
+        return encodeField(encodePathSegment(key), value[key]);
+      }).join(",");
+    }
+    return `body:${encodeLiteral(value)}`;
+  }
+
+  function encodeField(path, value) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const keys = Object.keys(value);
+      if (keys.length === 1) {
+        const key = keys[0];
+        return encodeField(`${path}.${encodePathSegment(key)}`, value[key]);
+      }
+    }
+    return `${path}:${encodeLiteral(value)}`;
+  }
+
+  function encodeLiteral(value) {
+    if (Array.isArray(value)) {
+      return `[${value.map(encodeLiteral).join(",")}]`;
+    }
+    if (value && typeof value === "object") {
+      return `{${Object.keys(value).map(function (key) {
+        return `${encodePathSegment(key)}:${encodeLiteral(value[key])}`;
+      }).join(",")}}`;
+    }
+    return encodeScalar(value);
+  }
+
+  function encodeScalar(value) {
+    if (value === null) {
+      return "null";
+    }
+    if (typeof value === "boolean" || typeof value === "number") {
+      return String(value);
+    }
+    const stringValue = String(value);
+    if (canEncodeBareString(stringValue)) {
+      return stringValue;
+    }
+    return JSON.stringify(stringValue);
+  }
+
+  function encodePathSegment(segment) {
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(segment) ? segment : JSON.stringify(segment);
+  }
+
+  function canEncodeBareString(value) {
+    return value !== "" &&
+      value === value.trim() &&
+      value !== "true" &&
+      value !== "false" &&
+      value !== "null" &&
+      !/^-?\d+(\.\d+)?$/.test(value) &&
+      !/[,{}\[\]"']/.test(value);
+  }
+
+  function parseLiteral(input) {
+    const parser = {
+      index: 0,
+      input
+    };
+    const value = parseLiteralValue(parser);
+    skipLiteralSpace(parser);
+    if (parser.index !== input.length) {
+      throw new Error(`Unexpected shorthand literal near \`${input.slice(parser.index)}\`.`);
+    }
+    return value;
+  }
+
+  function parseLiteralValue(parser) {
+    skipLiteralSpace(parser);
+    const ch = parser.input[parser.index];
+    if (ch === "{") {
+      return parseLiteralObject(parser);
+    }
+    if (ch === "[") {
+      return parseLiteralArray(parser);
+    }
+    if (ch === "\"" || ch === "'") {
+      return parseLiteralQuoted(parser);
+    }
+    return parseLiteralBare(parser);
+  }
+
+  function parseLiteralObject(parser) {
+    const result = {};
+    parser.index += 1;
+    skipLiteralSpace(parser);
+    while (parser.index < parser.input.length && parser.input[parser.index] !== "}") {
+      const key = parseLiteralKey(parser);
+      skipLiteralSpace(parser);
+      if (parser.input[parser.index] === "{") {
+        result[key] = parseLiteralObject(parser);
+        skipLiteralSpace(parser);
+        if (parser.input[parser.index] === ",") {
+          parser.index += 1;
+          skipLiteralSpace(parser);
+          if (parser.input[parser.index] === "}") {
+            break;
+          }
+        } else if (parser.input[parser.index] !== "}") {
+          throw new Error("Expected `,` or `}` in shorthand object literal.");
+        }
+        continue;
+      }
+      if (parser.input[parser.index] !== ":") {
+        throw new Error("Expected `:` in shorthand object literal.");
+      }
+      parser.index += 1;
+      result[key] = parseLiteralValue(parser);
+      skipLiteralSpace(parser);
+      if (parser.input[parser.index] === ",") {
+        parser.index += 1;
+        skipLiteralSpace(parser);
+        if (parser.input[parser.index] === "}") {
+          break;
+        }
+      } else if (parser.input[parser.index] !== "}") {
+        throw new Error("Expected `,` or `}` in shorthand object literal.");
+      }
+    }
+    if (parser.input[parser.index] !== "}") {
+      throw new Error("Unclosed shorthand object literal.");
+    }
+    parser.index += 1;
+    return result;
+  }
+
+  function parseLiteralArray(parser) {
+    const result = [];
+    parser.index += 1;
+    skipLiteralSpace(parser);
+    while (parser.index < parser.input.length && parser.input[parser.index] !== "]") {
+      result.push(parseLiteralValue(parser));
+      skipLiteralSpace(parser);
+      if (parser.input[parser.index] === ",") {
+        parser.index += 1;
+        skipLiteralSpace(parser);
+        if (parser.input[parser.index] === "]") {
+          break;
+        }
+      } else if (parser.input[parser.index] !== "]") {
+        throw new Error("Expected `,` or `]` in shorthand array literal.");
+      }
+    }
+    if (parser.input[parser.index] !== "]") {
+      throw new Error("Unclosed shorthand array literal.");
+    }
+    parser.index += 1;
+    return result;
+  }
+
+  function parseLiteralKey(parser) {
+    skipLiteralSpace(parser);
+    const ch = parser.input[parser.index];
+    if (ch === "\"" || ch === "'") {
+      return parseLiteralQuoted(parser);
+    }
+    const start = parser.index;
+    while (parser.index < parser.input.length && !/[\s:{}]/.test(parser.input[parser.index])) {
+      parser.index += 1;
+    }
+    return parser.input.slice(start, parser.index);
+  }
+
+  function parseLiteralQuoted(parser) {
+    const quote = parser.input[parser.index];
+    if (quote === "\"") {
+      let end = parser.index + 1;
+      while (end < parser.input.length) {
+        if (parser.input[end] === "\"" && parser.input[end - 1] !== "\\") {
+          const raw = parser.input.slice(parser.index, end + 1);
+          parser.index = end + 1;
+          return JSON.parse(raw);
+        }
+        end += 1;
+      }
+      throw new Error("Unclosed quoted shorthand string.");
+    }
+    let value = "";
+    parser.index += 1;
+    while (parser.index < parser.input.length && parser.input[parser.index] !== "'") {
+      value += parser.input[parser.index];
+      parser.index += 1;
+    }
+    if (parser.input[parser.index] !== "'") {
+      throw new Error("Unclosed quoted shorthand string.");
+    }
+    parser.index += 1;
+    return value;
+  }
+
+  function parseLiteralBare(parser) {
+    const start = parser.index;
+    while (parser.index < parser.input.length && parser.input[parser.index] !== "," && parser.input[parser.index] !== "]" && parser.input[parser.index] !== "}") {
+      parser.index += 1;
+    }
+    return parseScalar(parser.input.slice(start, parser.index).trim());
+  }
+
+  function skipLiteralSpace(parser) {
+    while (/\s/.test(parser.input[parser.index] || "")) {
+      parser.index += 1;
+    }
+  }
+
+  function applyShorthandFilter(doc, filter) {
+    const parts = splitTopLevel(filter, "|").map((item) => item.trim()).filter(Boolean);
+    if (!parts.length) {
+      return doc;
+    }
+    return parts.reduce(function (value, part) {
+      return evaluateExpression(value, part);
+    }, doc);
+  }
+
+  function evaluateExpression(value, expr) {
+    if (expr.startsWith("{") && expr.endsWith("}")) {
+      return project(value, expr.slice(1, -1));
+    }
+    if (expr.startsWith("..")) {
+      return recursiveFind(value, expr.slice(2));
+    }
+
+    const projection = expr.match(/^(.*)\.\{(.+)\}$/);
+    if (projection) {
+      return project(evaluatePath(value, projection[1]), projection[2]);
+    }
+
+    const recursive = expr.match(/^(.*)\.\.([A-Za-z0-9_-]+)$/);
+    if (recursive) {
+      return recursiveFind(evaluatePath(value, recursive[1]), recursive[2]);
+    }
+
+    return evaluatePath(value, expr);
+  }
+
+  function evaluatePath(value, path) {
+    if (!path) {
+      return value;
+    }
+    let current = value;
+    const tokens = pathTokens(path);
+    for (const token of tokens) {
+      if (token.type === "field") {
+        current = readField(current, token.value);
+      } else if (token.type === "index") {
+        current = readIndex(current, token.value);
+      } else if (token.type === "slice") {
+        current = readSlice(current, token.start, token.end);
+      } else if (token.type === "select") {
+        current = selectItems(current, token.field, token.operator, token.value);
+      }
+      if (current === undefined) {
+        throw new Error(`No value matched \`${path}\`.`);
+      }
+    }
+    return current;
+  }
+
+  function pathTokens(path) {
+    const tokens = [];
+    const parts = splitPath(path);
+    for (const part of parts) {
+      let index = 0;
+      while (index < part.length) {
+        if (part[index] === "[") {
+          const end = part.indexOf("]", index);
+          if (end === -1) {
+            throw new Error(`Unclosed bracket in \`${path}\`.`);
+          }
+          tokens.push(bracketToken(part.slice(index + 1, end).trim()));
+          index = end + 1;
+          continue;
+        }
+        let end = index;
+        while (end < part.length && part[end] !== "[") {
+          end += 1;
+        }
+        tokens.push({ type: "field", value: unquotePathSegment(part.slice(index, end)) });
+        index = end;
+      }
+    }
+    return tokens;
+  }
+
+  function splitPath(path) {
+    const parts = [];
+    let current = "";
+    let quote = "";
+    let depth = 0;
+    for (let index = 0; index < path.length; index += 1) {
+      const ch = path[index];
+      if (quote) {
+        current += ch;
+        if (ch === quote && path[index - 1] !== "\\") {
+          quote = "";
+        }
+        continue;
+      }
+      if (ch === "'" || ch === "\"") {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+      if (ch === "[") {
+        depth += 1;
+      } else if (ch === "]") {
+        depth = Math.max(0, depth - 1);
+      }
+      if (ch === "." && depth === 0) {
+        if (current) {
+          parts.push(current);
+          current = "";
+        }
+        continue;
+      }
+      current += ch;
+    }
+    if (quote) {
+      throw new Error(`Unclosed quote in \`${path}\`.`);
+    }
+    if (depth !== 0) {
+      throw new Error(`Unclosed bracket in \`${path}\`.`);
+    }
+    if (current) {
+      parts.push(current);
+    }
+    return parts;
+  }
+
+  function unquotePathSegment(segment) {
+    if (segment.startsWith("\"") && segment.endsWith("\"")) {
+      return JSON.parse(segment);
+    }
+    if (segment.startsWith("'") && segment.endsWith("'")) {
+      return segment.slice(1, -1);
+    }
+    return segment;
+  }
+
+  function bracketToken(content) {
+    const slice = content.match(/^(-?\d*)\s*:\s*(-?\d*)$/);
+    if (slice) {
+      return {
+        type: "slice",
+        start: slice[1] === "" ? 0 : Number(slice[1]),
+        end: slice[2] === "" ? undefined : Number(slice[2])
+      };
+    }
+    if (/^-?\d+$/.test(content)) {
+      return { type: "index", value: Number(content) };
+    }
+    const contains = content.match(/^(@|[A-Za-z0-9_.-]+)\s+contains\s+(.+)$/);
+    if (contains) {
+      return { type: "select", field: contains[1], operator: "contains", value: parseScalar(contains[2].trim()) };
+    }
+    const equals = content.match(/^(@|[A-Za-z0-9_.-]+)\s*==\s*(.+)$/);
+    if (equals) {
+      return { type: "select", field: equals[1], operator: "equals", value: parseScalar(equals[2].trim()) };
+    }
+    throw new Error(`Unsupported selector \`[${content}]\` in this sample runner.`);
+  }
+
+  function readField(value, field) {
+    if (Array.isArray(value)) {
+      return value.map((item) => readField(item, field)).filter((item) => item !== undefined);
+    }
+    return value && value[field];
+  }
+
+  function readIndex(value, index) {
+    if (!Array.isArray(value)) {
+      throw new Error("Index selectors need an array.");
+    }
+    const resolved = index < 0 ? value.length + index : index;
+    return value[resolved];
+  }
+
+  function readSlice(value, start, end) {
+    if (!Array.isArray(value)) {
+      throw new Error("Slice selectors need an array.");
+    }
+    const resolvedStart = start < 0 ? value.length + start : start;
+    const resolvedEnd = end === undefined ? value.length : (end < 0 ? value.length + end + 1 : end + 1);
+    return value.slice(resolvedStart, resolvedEnd);
+  }
+
+  function selectItems(value, field, operator, expected) {
+    if (!Array.isArray(value)) {
+      throw new Error("Selection filters need an array.");
+    }
+    return value.filter(function (item) {
+      const selected = readSelectionField(item, field);
+      return selected.matched && selectionMatches(selected.value, selected.expected(expected), operator);
+    });
+  }
+
+  function readSelectionField(item, field) {
+    const modifier = ".lower";
+    const lower = field.endsWith(modifier);
+    const path = lower ? field.slice(0, -modifier.length) : field;
+    let value;
+    try {
+      value = path === "@" ? item : evaluatePath(item, path);
+    } catch (error) {
+      return {
+        matched: false,
+        value: undefined,
+        expected: function (expected) {
+          return expected;
+        }
+      };
+    }
+    return {
+      matched: value !== undefined,
+      value: lower ? lowerValue(value) : value,
+      expected: lower ? lowerValue : function (expected) {
+        return expected;
+      }
+    };
+  }
+
+  function selectionMatches(actual, expected, operator) {
+    if (Array.isArray(actual)) {
+      return actual.some(function (item) {
+        return selectionMatches(item, expected, operator);
+      });
+    }
+    if (operator === "contains") {
+      if (actual === null || actual === undefined) {
+        return false;
+      }
+      return String(actual).includes(String(expected));
+    }
+    return actual === expected;
+  }
+
+  function lowerValue(value) {
+    if (Array.isArray(value)) {
+      return value.map(lowerValue);
+    }
+    return typeof value === "string" ? value.toLowerCase() : value;
+  }
+
+  function project(value, spec) {
+    if (Array.isArray(value)) {
+      return value.map(function (item) {
+        return project(item, spec);
+      });
+    }
+    const fields = splitTopLevel(spec, ",").map((item) => item.trim()).filter(Boolean);
+    const target = {};
+    for (const field of fields) {
+      const alias = field.match(/^([A-Za-z0-9_-]+)\s*:\s*(.+)$/);
+      if (alias) {
+        target[alias[1]] = evaluateExpression(value, alias[2].trim());
+      } else {
+        target[field] = evaluatePath(value, field);
+      }
+    }
+    return target;
+  }
+
+  function recursiveFind(value, field) {
+    const found = [];
+    walk(value, function (item, key) {
+      if (key === field) {
+        found.push(item);
+      }
+    });
+    return found;
+  }
+
+  function walk(value, visit, key) {
+    if (value && typeof value === "object") {
+      if (key !== undefined) {
+        visit(value, key);
+      }
+      if (Array.isArray(value)) {
+        value.forEach(function (item) {
+          walk(item, visit);
+        });
+      } else {
+        Object.keys(value).forEach(function (childKey) {
+          walk(value[childKey], visit, childKey);
+        });
+      }
+      return;
+    }
+    if (key !== undefined) {
+      visit(value, key);
+    }
+  }
+
+  function splitTopLevel(input, separator) {
+    const parts = [];
+    let current = "";
+    let quote = "";
+    let depth = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      const ch = input[index];
+      if (quote) {
+        current += ch;
+        if (ch === quote && input[index - 1] !== "\\") {
+          quote = "";
+        }
+        continue;
+      }
+      if (ch === "'" || ch === "\"") {
+        quote = ch;
+        current += ch;
+        continue;
+      }
+      if (ch === "{" || ch === "[") {
+        depth += 1;
+      } else if (ch === "}" || ch === "]") {
+        depth = Math.max(0, depth - 1);
+      }
+      if (ch === separator && depth === 0) {
+        parts.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    parts.push(current);
+    return parts;
+  }
+
+  function readSharedValue(key) {
+    const params = new URLSearchParams((window.location.hash || "").replace(/^#/, ""));
+    return params.get(key);
+  }
+
+  function copyShareLink(key, value, button, status) {
+    copyShareLinkParams({ [key]: value }, button, status);
+  }
+
+  function copyShareLinkParams(values, button, status) {
+    const url = new URL(window.location.href);
+    const params = new URLSearchParams((url.hash || "").replace(/^#/, ""));
+    Object.keys(values).forEach(function (key) {
+      const value = values[key];
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+    });
+    url.hash = params.toString();
+    copyText(url.toString()).then(function () {
+      button.textContent = "Copied";
+      setStatus(status, "Share link copied", "ok");
+      window.setTimeout(function () {
+        button.textContent = "Copy share link";
+      }, 1600);
+    }).catch(function () {
+      setStatus(status, "Copy failed", "error");
+    });
+  }
+
+  function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(text);
+    }
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-1000px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return copied ? Promise.resolve() : Promise.reject(new Error("copy failed"));
+  }
+
+  function setStatus(node, text, mode) {
+    if (!node) {
+      return;
+    }
+    node.textContent = text;
+    node.dataset.mode = mode || "";
+  }
+
+  function init() {
+    document.querySelectorAll("[data-restish-output-pipeline]").forEach(initOutputPipeline);
+    document.querySelectorAll("[data-restish-shorthand-body]").forEach(initShorthandBody);
+    document.querySelectorAll("[data-restish-query-runner]").forEach(initQueryRunner);
+  }
+
+  if (window.__RESTISH_DOCS_INTERACTIONS_TEST__) {
+    window.__restishDocsInteractionsTest = {
+      applyShorthandFilter,
+      outputActions,
+      encodeShorthand,
+      highlightValue,
+      parseShorthand,
+      parseQuerySource,
+      querySample
+    };
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -132,6 +132,59 @@
     "put-method": { method: "PUT", path: "/put" },
     "put-types-example": { method: "PUT", path: "/types" }
   }));
+  const rootCompletions = [
+    "api",
+    "cache",
+    "config",
+    "delete",
+    "edit",
+    "example",
+    "get",
+    "head",
+    "links",
+    "options",
+    "patch",
+    "plugin",
+    "post",
+    "put",
+    "shell"
+  ];
+  const shellCompletions = ["completion", "setup"];
+  const shellCompletionCompletions = ["bash", "fish", "install", "powershell", "zsh"];
+  const apiCompletions = ["connect", "info", "list", "profiles", "set", "sync"];
+  const configCompletions = ["edit", "get", "path", "set"];
+  const cacheCompletions = ["clear", "dir", "list"];
+  const pluginCompletions = ["debug", "install", "list", "remove"];
+  const contentTypeCompletions = ["json", "form"];
+  const printCompletions = ["hbp", "hbpc", "h", "b", "Hhbp"];
+  const filterLangCompletions = ["restish", "jq"];
+  const imageFormatCompletions = ["jpeg", "png", "webp", "gif", "heic"];
+  const documentFormatCompletions = ["json", "yaml", "xml", "html", "text", "csv"];
+  const statusCodeCompletions = ["200", "201", "204", "301", "302", "400", "401", "403", "404", "409", "422", "429", "500", "503"];
+  const examplePathCompletions = [
+    "api.rest.sh/",
+    "api.rest.sh/auth/api-key-header",
+    "api.rest.sh/auth/api-key-query",
+    "api.rest.sh/books",
+    "api.rest.sh/books/restish-tour",
+    "api.rest.sh/cache",
+    "api.rest.sh/events",
+    "api.rest.sh/example",
+    "api.rest.sh/flaky",
+    "api.rest.sh/formats/json",
+    "api.rest.sh/headers",
+    "api.rest.sh/images",
+    "api.rest.sh/images/jpeg",
+    "api.rest.sh/items",
+    "api.rest.sh/items/docs-demo",
+    "api.rest.sh/logs",
+    "api.rest.sh/problem",
+    "api.rest.sh/status/200",
+    "api.rest.sh/types"
+  ];
+  const exampleAliasPathCompletions = examplePathCompletions
+    .filter((item) => item !== "api.rest.sh/")
+    .map((item) => `example/${item.slice("api.rest.sh/".length)}`);
 
   function shellWords(input) {
     const words = [];
@@ -182,6 +235,301 @@
       words.push(current);
     }
     return words;
+  }
+
+  function shellWordsPartial(input) {
+    const words = [];
+    let current = "";
+    let quote = "";
+    let escaped = false;
+    const text = input.replace(/\\\r?\n/g, " ");
+
+    for (const ch of text) {
+      if (escaped) {
+        current += ch;
+        escaped = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (quote) {
+        if (ch === quote) {
+          quote = "";
+        } else {
+          current += ch;
+        }
+        continue;
+      }
+      if (ch === "'" || ch === "\"") {
+        quote = ch;
+        continue;
+      }
+      if (/\s/.test(ch)) {
+        if (current) {
+          words.push(current);
+          current = "";
+        }
+        continue;
+      }
+      current += ch;
+    }
+
+    if (escaped) {
+      current += "\\";
+    }
+    if (current || !/\s$/.test(text)) {
+      words.push(current);
+    }
+    return words;
+  }
+
+  function completeCommand(input, cursor) {
+    const position = typeof cursor === "number" ? cursor : input.length;
+    const range = currentTokenRange(input, position);
+    if (/[`'"$\\]/.test(range.tokenBeforeCursor)) {
+      return { value: input, cursor: position, matches: [], applied: false };
+    }
+
+    const candidates = completionCandidates(input, position, range.tokenBeforeCursor);
+    const matches = uniqueSorted(candidates).filter((item) => item.toLowerCase().startsWith(range.tokenBeforeCursor.toLowerCase()));
+    if (!matches.length) {
+      return { value: input, cursor: position, matches: [], applied: false };
+    }
+
+    let replacement = "";
+    let applied = false;
+    if (matches.length === 1) {
+      replacement = completionInsertText(matches[0], true);
+      applied = replacement !== range.fullToken;
+    } else {
+      replacement = commonPrefix(matches);
+      applied = replacement.length > range.tokenBeforeCursor.length;
+    }
+
+    if (!applied) {
+      return { value: input, cursor: position, matches, applied: false };
+    }
+
+    const value = input.slice(0, range.start) + replacement + input.slice(range.end);
+    return {
+      value,
+      cursor: range.start + replacement.length,
+      matches,
+      applied: true
+    };
+  }
+
+  function currentTokenRange(input, cursor) {
+    let start = cursor;
+    while (start > 0 && !/\s/.test(input[start - 1])) {
+      start -= 1;
+    }
+    let end = cursor;
+    while (end < input.length && !/\s/.test(input[end])) {
+      end += 1;
+    }
+    return {
+      start,
+      end,
+      tokenBeforeCursor: input.slice(start, cursor),
+      fullToken: input.slice(start, end)
+    };
+  }
+
+  function completionCandidates(input, cursor, currentPrefix) {
+    const before = input.slice(0, cursor);
+    const endsAtBoundary = /\s$/.test(before);
+    const partialWords = shellWordsPartial(before);
+    const completedWords = endsAtBoundary ? partialWords : partialWords.slice(0, -1);
+    const tokenIndex = endsAtBoundary ? partialWords.length : Math.max(0, partialWords.length - 1);
+
+    if (tokenIndex === 0) {
+      return ["restish"];
+    }
+    if (completedWords[0] !== "restish") {
+      return [];
+    }
+
+    const inlineValue = inlineFlagValueCandidates(currentPrefix);
+    if (inlineValue) {
+      return inlineValue;
+    }
+
+    const previous = completedWords[completedWords.length - 1] || "";
+    const flagValues = valueCandidatesForFlag(previous);
+    if (flagValues) {
+      return flagValues;
+    }
+
+    if (currentPrefix.startsWith("-")) {
+      return flagCompletions(completedWords);
+    }
+
+    if (tokenIndex === 1) {
+      return rootCompletions.concat(requestTargetCompletions(completedWords, currentPrefix));
+    }
+
+    const first = completedWords[1];
+    if (first === "example") {
+      return exampleCommandCompletions(completedWords);
+    }
+    if (first === "shell") {
+      return nestedCompletions(completedWords, [shellCompletions, shellCompletionCompletions]);
+    }
+    if (first === "api") {
+      return nestedCompletions(completedWords, [apiCompletions]);
+    }
+    if (first === "config") {
+      return nestedCompletions(completedWords, [configCompletions]);
+    }
+    if (first === "cache") {
+      return nestedCompletions(completedWords, [cacheCompletions]);
+    }
+    if (first === "plugin") {
+      return nestedCompletions(completedWords, [pluginCompletions]);
+    }
+    if (first === "links") {
+      return linksCompletions(completedWords);
+    }
+    if (supportedVerbs.has(first) || first === "edit") {
+      return requestTargetCompletions(completedWords, currentPrefix);
+    }
+    if (looksLikeURL(first) || first.startsWith("example/")) {
+      return bodyOrFlagHintCompletions(currentPrefix);
+    }
+    return requestTargetCompletions(completedWords, currentPrefix);
+  }
+
+  function inlineFlagValueCandidates(currentPrefix) {
+    const match = currentPrefix.match(/^(--[^=]+=)(.*)$/);
+    if (!match) {
+      return null;
+    }
+    const flag = match[1].slice(0, -1);
+    const values = valueCandidatesForFlag(flag);
+    return values ? values.map((value) => match[1] + value) : null;
+  }
+
+  function valueCandidatesForFlag(flag) {
+    if (flag === "-o" || flag === "--rsh-output-format") {
+      return Array.from(supportedOutputFormats);
+    }
+    if (flag === "-c" || flag === "--rsh-content-type") {
+      return contentTypeCompletions;
+    }
+    if (flag === "--rsh-print") {
+      return printCompletions;
+    }
+    if (flag === "--rsh-filter-lang") {
+      return filterLangCompletions;
+    }
+    if (flag === "--format") {
+      return documentFormatCompletions.concat(imageFormatCompletions);
+    }
+    if (flag === "--status" || flag === "--status-code" || flag === "--status_code") {
+      return statusCodeCompletions;
+    }
+    if (flag === "--private") {
+      return ["true", "false"];
+    }
+    return null;
+  }
+
+  function flagCompletions(completedWords) {
+    const flags = Array.from(valueFlags.keys())
+      .concat(Array.from(boolFlags.keys()))
+      .concat(Array.from(generatedValueFlags.keys()))
+      .concat(Array.from(generatedBoolFlags.keys()));
+    if (completedWords[1] !== "example") {
+      return flags.filter((item) => !generatedValueFlags.has(item) && !generatedBoolFlags.has(item));
+    }
+    return flags;
+  }
+
+  function exampleCommandCompletions(completedWords) {
+    if (completedWords.length <= 2) {
+      return Array.from(exampleOperations.keys());
+    }
+    const op = completedWords[2];
+    if (op === "get-image") {
+      return imageFormatCompletions;
+    }
+    if (op === "get-format") {
+      return documentFormatCompletions.concat(imageFormatCompletions);
+    }
+    if (op === "get-status") {
+      return statusCodeCompletions;
+    }
+    if (op === "get-item" || op === "patch-item" || op === "delete-item") {
+      return ["docs-demo", "docs-second"];
+    }
+    if (op === "get-book" || op === "put-book" || op === "patch-book" || op === "delete-book") {
+      return ["restish-tour", "api-field-guide"];
+    }
+    return bodyOrFlagHintCompletions("");
+  }
+
+  function nestedCompletions(completedWords, levels) {
+    const depth = completedWords.length - 2;
+    return levels[depth] || [];
+  }
+
+  function linksCompletions(completedWords) {
+    if (completedWords.length <= 2) {
+      return requestTargetCompletions(completedWords, "");
+    }
+    return ["self", "next", "prev", "first", "last", "item"];
+  }
+
+  function requestTargetCompletions(completedWords, currentPrefix) {
+    if (currentPrefix.startsWith("example/")) {
+      return exampleAliasPathCompletions;
+    }
+    if (currentPrefix.startsWith("https://api.rest.sh/")) {
+      return examplePathCompletions.map((item) => item.replace(/^api\.rest\.sh/, "https://api.rest.sh"));
+    }
+    return examplePathCompletions;
+  }
+
+  function bodyOrFlagHintCompletions(currentPrefix) {
+    if (currentPrefix.startsWith("-")) {
+      return flagCompletions(["restish"]);
+    }
+    return ["name:", "title:", "tags[]:", "enabled:", "count:"];
+  }
+
+  function completionInsertText(value, singleMatch) {
+    if (!singleMatch) {
+      return value;
+    }
+    if (value.endsWith(":") || value.endsWith("=") || value.endsWith("/")) {
+      return value;
+    }
+    return value + " ";
+  }
+
+  function uniqueSorted(values) {
+    return Array.from(new Set(values.filter(Boolean))).sort((a, b) => a.localeCompare(b));
+  }
+
+  function commonPrefix(values) {
+    if (!values.length) {
+      return "";
+    }
+    let prefix = values[0];
+    for (const value of values.slice(1)) {
+      let index = 0;
+      while (index < prefix.length && index < value.length && prefix[index].toLowerCase() === value[index].toLowerCase()) {
+        index += 1;
+      }
+      prefix = prefix.slice(0, index);
+      if (!prefix) {
+        break;
+      }
+    }
+    return prefix;
   }
 
   function parseCommand(command) {
@@ -2592,6 +2940,7 @@
     root.dataset.restishReady = "true";
     const command = root.querySelector("[data-restish-command]");
     const commandHighlight = root.querySelector("[data-restish-command-highlight]");
+    const completions = root.querySelector("[data-restish-completions]");
     const output = root.querySelector("[data-restish-output]");
     const runButton = root.querySelector("[data-restish-run]");
     const copyButton = root.querySelector("[data-restish-copy]");
@@ -2693,6 +3042,58 @@
       }
     }
 
+    function hideCompletions() {
+      if (!completions) {
+        return;
+      }
+      completions.hidden = true;
+      completions.replaceChildren();
+    }
+
+    function showCompletions(matches) {
+      if (!completions) {
+        return;
+      }
+      completions.replaceChildren();
+      if (!matches || !matches.length) {
+        completions.hidden = true;
+        return;
+      }
+      const prompt = document.createElement("span");
+      prompt.className = "restish-playground__completion-prompt";
+      prompt.textContent = ">";
+      prompt.setAttribute("aria-hidden", "true");
+      completions.appendChild(prompt);
+      const list = document.createElement("span");
+      list.className = "restish-playground__completion-list";
+      for (const match of matches.slice(0, 18)) {
+        const item = document.createElement("span");
+        item.className = "restish-playground__completion-item";
+        item.textContent = match;
+        list.appendChild(item);
+      }
+      if (matches.length > 18) {
+        const more = document.createElement("span");
+        more.className = "restish-playground__completion-more";
+        more.textContent = `+${matches.length - 18}`;
+        list.appendChild(more);
+      }
+      completions.appendChild(list);
+      completions.hidden = false;
+    }
+
+    function applyCompletion() {
+      const result = completeCommand(command.value, command.selectionStart || 0);
+      if (result.applied) {
+        command.value = result.value;
+        command.setSelectionRange(result.cursor, result.cursor);
+        resetCommandScroll();
+        renderCommandHighlight();
+      }
+      showCompletions(result.matches);
+      setState(state, result.matches.length ? "Complete" : "No match", result.matches.length ? "ok" : "error");
+    }
+
     function enableCommandHighlight() {
       if (commandHighlightReady || !commandHighlight || !window.Prism) {
         return;
@@ -2721,6 +3122,7 @@
       if (runButton.disabled) {
         return;
       }
+      hideCompletions();
       let highlight = true;
       let language = "language-readable";
       try {
@@ -2786,6 +3188,8 @@
 
     command.addEventListener("keydown", function (event) {
       if (event.key === "Tab") {
+        event.preventDefault();
+        applyCompletion();
         resetCommandScroll();
         return;
       }
@@ -2796,12 +3200,23 @@
       runCommand();
     });
 
-    command.addEventListener("blur", resetCommandScroll);
+    command.addEventListener("input", function () {
+      hideCompletions();
+      if (state && state.dataset.mode !== "running") {
+        setState(state, "Ready", "");
+      }
+    });
+
+    command.addEventListener("blur", function () {
+      resetCommandScroll();
+      window.setTimeout(hideCompletions, 120);
+    });
 
     resetButton.addEventListener("click", function () {
       command.value = initial;
       resetCommandScroll();
       renderCommandHighlight();
+      hideCompletions();
       hideOutput(output);
       setState(state, "Ready", "");
       command.focus();
@@ -2814,6 +3229,7 @@
 
   if (window.__RESTISH_PLAYGROUND_TEST__) {
     window.__restishPlaygroundTest = {
+      completeCommand,
       encodeTOONDocument,
       parseCommand,
       render,

--- a/site/static/js/restish-playground.js
+++ b/site/static/js/restish-playground.js
@@ -156,7 +156,7 @@
   const cacheCompletions = ["clear", "dir", "list"];
   const pluginCompletions = ["debug", "install", "list", "remove"];
   const contentTypeCompletions = ["json", "form"];
-  const printCompletions = ["hbp", "hbpc", "h", "b", "Hhbp"];
+  const printCompletions = ["hbp", "hbpc", "h", "b", "HBhbp"];
   const filterLangCompletions = ["restish", "jq"];
   const imageFormatCompletions = ["jpeg", "png", "webp", "gif", "heic"];
   const documentFormatCompletions = ["json", "yaml", "xml", "html", "text", "csv"];
@@ -435,6 +435,10 @@
       return ["true", "false"];
     }
     return null;
+  }
+
+  function shouldApplyCompletionKey(event) {
+    return event.key === "Tab" && !event.shiftKey;
   }
 
   function flagCompletions(completedWords) {
@@ -3187,7 +3191,7 @@
     }
 
     command.addEventListener("keydown", function (event) {
-      if (event.key === "Tab") {
+      if (shouldApplyCompletionKey(event)) {
         event.preventDefault();
         applyCompletion();
         resetCommandScroll();
@@ -3233,6 +3237,7 @@
       encodeTOONDocument,
       parseCommand,
       render,
+      shouldApplyCompletionKey,
       toonOutput
     };
   }


### PR DESCRIPTION
## Summary

- Add a new OpenAPI-to-CLI blog post with an interactive command anatomy graphic.
- Add docs-site interactive examples for output flow, shorthand input, and filtering.
- Add browser-side TOON support and `llms.txt` for the docs site.
- Add next/previous blog links and remove docs tag clouds from the standard docs sidebar.
- Update the docs writing skill guidance for future blog review passes.

## Validation

- `node --check site/static/js/restish-docs-interactions.js`
- `npm test` in `site/`
- `hugo --source site --quiet --buildFuture`