### PR TITLE
docs: refresh AGENTS.md and agent skills for accuracy and CI coverage

### DIFF
--- a/.agents/skills/rsh-docs/SKILL.md
+++ b/.agents/skills/rsh-docs/SKILL.md
@@ -238,16 +238,18 @@ When migrating older docs, track whether material was retired, already migrated,
 After meaningful site changes, run what CI runs:
 
 ```bash
-hugo --source site --quiet          # site builds
+hugo --source site --quiet          # site builds (quick check)
+npm --prefix site run build        # CI parity: social images + Hugo (npm ci once first)
 scripts/check-doc-examples.rb      # restish-example shortcodes are valid
 scripts/check-doc-links.rb         # internal links resolve
 go run ./cmd/restish-docgen --check # generated regions are not stale
 ```
 
+`npm run social-images` parses front matter across `content/en` and can fail
+independently of Hugo, so run the npm build for blog and front-matter changes
+even when the quick Hugo check passes.
+
 When touching site JavaScript or interactive examples (playground, query
 runner, docs interactions), also run `npm --prefix site test`.
-
-For blog changes that affect social cards, run `npm run social-images` from
-`site/` or `npm run build` if dependencies are available.
 
 Also verify new links, check examples against current CLI behavior, grep touched docs for stale `api.example.com` placeholders and leftover `Source material:` sections, and prefer examples that can later be validated against `api.rest.sh` or promoted into tests.

--- a/.agents/skills/rsh-docs/SKILL.md
+++ b/.agents/skills/rsh-docs/SKILL.md
@@ -77,7 +77,28 @@ Use examples that look like real work:
 - Explain intentional placeholders when they might look accidental.
 - Prefer JSONC for config examples when comments clarify fields.
 
+### Command Example Style
+
+These apply to every command example in docs, guides, recipes, and blog posts:
+
+- Prefer shorthand in examples over `jq` or plain JSON when possible.
+- Do not use `get` or `post` in examples when the auto mode is clear (e.g.,
+  `restish api.rest.sh/example` instead of `restish get api.rest.sh/example`).
+- Do not add options for no reason. E.g. `--rsh-no-paginate` when not talking
+  explicitly about pagination, or `--rsh-columns` when the default output is
+  fine. Extra flags complicate commands and make examples harder to read.
+  Avoid `-o lines` unless it significantly improves output readability.
+
 ### Shorthand Examples
+
+`restish-example` shortcode commands are extracted and validated by
+`scripts/check-doc-examples.rb`: CI enforces that each one is a single direct
+`restish` invocation (no pipes, redirects, `;`, `&&`, command substitution, or
+backticks) that parses cleanly with shell word-splitting, and a weekly job
+executes every one live against `api.rest.sh` and fails on non-zero exit.
+Write shortcode examples as commands that actually succeed against the public
+API; use plain fenced code blocks for pipelines, local-only setup, or
+illustrative failures.
 
 Restish shorthand examples should be shell-safe and match how the docs display
 them:
@@ -170,14 +191,11 @@ post reveals a gap.
 
 ### Blog Improvement
 
-Whenever you write a new blog post or modify an existing one, spin off a sub-agent to do a review of the changes and suggest improvements, which you should then apply. The review should check for:
+Whenever you write a new blog post or modify an existing one, do a separate review pass of the changes (use a sub-agent if available) and apply the resulting improvements. The review should check for:
 
 1. Clarity: Is the post easy to understand? Are there any ambiguous statements or jargon that could be clarified?
 2. Engagement: Does the post have a compelling hook? Does it maintain the reader's interest throughout?
-3. Accuracy: Are all technical details correct? Are there any factual errors or misleading statements?
-   1. Commands should prefer shorthand in examples over jq or plain JSON when possible.
-   2. Do not use `get` or `post` in examples when the auto mode is clear (e.g., `restish api.rest.sh/example` instead of `restish get api.rest.sh/example`).
-   3. Do not add options for no reason. E.g. `--rsh-no-paginate` when not talking explicitly about pagination, or `--rsh-columns` when the default output is fine. This complicates commands and makes it harder for readers. Another good example is `-o lines` unless it significantly improves readability of the output.
+3. Accuracy: Are all technical details correct? Are there any factual errors or misleading statements? Do all examples follow the Command Example Style rules above?
 4. Structure: Is the post well-organized? Does it have a logical flow from introduction to conclusion? Do the headings make sense (and are they short enough to not wrap for common screen widths)?
 5. Do all the command examples actually make sense? Are they good examples, or could they be improved to better illustrate the point? Are the examples in the right place in the post or should they be moved?
 
@@ -217,11 +235,17 @@ When migrating older docs, track whether material was retired, already migrated,
 
 ## Validation
 
-After meaningful site changes, run:
+After meaningful site changes, run what CI runs:
 
 ```bash
-hugo --source site --quiet
+hugo --source site --quiet          # site builds
+scripts/check-doc-examples.rb      # restish-example shortcodes are valid
+scripts/check-doc-links.rb         # internal links resolve
+go run ./cmd/restish-docgen --check # generated regions are not stale
 ```
+
+When touching site JavaScript or interactive examples (playground, query
+runner, docs interactions), also run `npm --prefix site test`.
 
 For blog changes that affect social cards, run `npm run social-images` from
 `site/` or `npm run build` if dependencies are available.

--- a/.agents/skills/rsh-docs/agents/openai.yaml
+++ b/.agents/skills/rsh-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Restish Docs"
+  short_description: "Write and maintain Restish documentation"
+  default_prompt: "Use $rsh-docs to write or update Restish documentation, blog posts, or design docs for a feature or change."

--- a/.agents/skills/rsh-product/SKILL.md
+++ b/.agents/skills/rsh-product/SKILL.md
@@ -37,28 +37,13 @@ For source-backed rationale and examples from product/UX references and popular 
 
 ### 1. Frame The Opportunity
 
-Write the smallest useful product frame before designing commands:
+Before designing commands, write the smallest useful product frame: who the user is (first-time user, daily CLI user, API integrator, plugin operator, plugin author, or maintainer), the job they are doing outside Restish, their current workaround, the pain, the intended outcome, and the evidence (issue text, failing example, repeated support question, code/test signal). If evidence is thin, propose the lightest validation instead of inventing a large feature.
 
-- **User**: Who is this for? First-time user, daily CLI user, API integrator, plugin operator, plugin author, or maintainer?
-- **Job**: What is the user trying to get done outside Restish?
-- **Current workaround**: What command sequence, script, config edit, docs lookup, or mental model do they use today?
-- **Pain**: Is the problem failure, slowness, repeated typing, poor discoverability, unsafe behavior, bad output, weak automation, or missing capability?
-- **Outcome**: What should be easier, safer, faster, or more understandable after the change?
-- **Evidence**: Point to issue text, user report, failing example, design-doc gap, docs search, repeated support question, or code/test signal.
-
-If evidence is thin, propose the lightest validation instead of inventing a large feature.
+Concrete evidence sources for Restish: the v1 issue tracker (`rest-sh/restish` on GitHub — dozens of open issues and PRs represent real user demand), `docs/design/000-restish-v1-baseline.md` for v1 behavior, `docs/design/031-compatibility-and-migration.md` for compatibility promises, and `docs/design/037-v2-command-surface-review.md` for prior command-surface decisions.
 
 ### 2. Classify The Investment
 
-Classify the work so scope and validation match risk:
-
-- **Reliability**: Makes existing behavior more correct, predictable, secure, or recoverable.
-- **Usability**: Makes existing behavior easier to discover, understand, compose, or debug.
-- **Feature**: Adds a new user-visible capability.
-- **Compatibility**: Preserves or improves v1, plugin, OpenAPI, shell, or documented behavior.
-- **Platform**: Improves internal architecture only when it unlocks user-facing reliability, velocity, or simplicity.
-
-Favor reliability and usability improvements when a new feature would deepen existing confusion.
+Classify the work — reliability, usability, feature, compatibility, or platform — so scope and validation match risk. Favor reliability and usability improvements when a new feature would deepen existing confusion. Platform work counts only when it unlocks user-facing reliability, velocity, or simplicity.
 
 ### 3. Shape The Product Bet
 
@@ -141,7 +126,7 @@ Use validation proportional to risk:
 - **Product validation**: Compare against user jobs, known feedback, current docs, and one or two realistic command transcripts.
 - **Usability review**: Run a heuristic pass for status visibility, vocabulary, control/escape, consistency, error prevention, recognition over recall, efficiency, minimal output, error recovery, and help.
 - **CLI contract tests**: Cover TTY vs non-TTY when behavior differs, `stdout`/`stderr`, exit codes, help text, output formats, malformed input, cancellation, auth/config precedence, and shell composition.
-- **Golden output tests**: Use for intentional formatter/help changes; do not accept drift casually.
+- **Output regression tests**: Use for intentional formatter/help changes; do not accept drift casually.
 - **Docs checks**: Update `site/` for user behavior and `docs/design/` for significant subsystem behavior; link guides and reference pages both ways.
 - **Compatibility checks**: Test v1-style workflows, generated OpenAPI command shape, plugin boundaries, and scripting behavior when touched.
 

--- a/.agents/skills/rsh-release-qa/references/release-gates.md
+++ b/.agents/skills/rsh-release-qa/references/release-gates.md
@@ -91,7 +91,13 @@ chmod 600 "$RUN_DIR/empty.json"
 
 ```bash
 env GOCACHE="$RUN_DIR/go-cache" GOPATH="$RUN_DIR/go-path" go run ./cmd/restish-docgen --check
+scripts/check-doc-links.rb
+scripts/check-doc-examples.rb
 ```
+
+The example check's `--mode live` variant executes every docs `restish-example`
+against `api.rest.sh`; include it when the release touches command surface or
+docs examples and the network allows it.
 
 For the docs site, use a disposable npm cache if the user cache is not writable
 or contains permission problems. These commands must run against `site/`, which

--- a/.agents/skills/rsh-release-qa/references/release-risk-map.md
+++ b/.agents/skills/rsh-release-qa/references/release-risk-map.md
@@ -15,7 +15,7 @@ checks after reading recent commits.
 - Pagination and hypermedia: page params, Link headers, item extraction,
   limits, metadata filters, and streaming output.
 - Output formatting: terminal color, JSON/table stability, scalar utility
-  output, plugin formatter behavior, and golden/reference drift.
+  output, plugin formatter behavior, and fixture/reference drift.
 - Plugin lifecycle: command plugins, formatter plugins, hook plugins,
   `restish-mcp`, subprocess cleanup, and protocol compatibility.
 - User-facing docs and generated command reference.

--- a/.agents/skills/rsh-review/SKILL.md
+++ b/.agents/skills/rsh-review/SKILL.md
@@ -60,13 +60,13 @@ Review code changes with a bug-finding mindset. Prioritize correctness, regressi
 
 ## Restish-Specific Watchlist
 
-These are high-value repo-specific checks, not an exhaustive checklist. Use them when relevant; do not force them into unrelated reviews.
+These are high-value repo-specific checks, not an exhaustive checklist. Use them when relevant; do not force them into unrelated reviews. For the full catalog of historical bug classes found in past releases, see `../rsh-release-qa/references/findings-mining.md`. When a changed subsystem has a design doc (`docs/design/README.md`), check the diff against its stated invariants.
 
 ### Path-specific cues
 
 - `internal/cli/`: flags, exit codes, stdin/stdout/stderr, config precedence, generated commands
 - `internal/request/`: content negotiation, auth headers, redirects, pagination, retries, streaming, cancellation
-- `internal/output/`: formatter drift, golden tests, terminal width behavior, stable ordering
+- `internal/output/`: formatter drift, regression fixtures, terminal width behavior, stable ordering
 - `internal/config/`: defaults, file permissions, migrations, backward compatibility
 - `internal/plugin/` and `cmd/restish-*`: plugin protocol, subprocess lifecycle, wire compatibility
 - `cmd/restish` and `site/`: user-facing CLI behavior, examples, docs impact
@@ -99,9 +99,25 @@ Config fields should not be added unless their behavior is implemented. Otherwis
 
 Spec-loading or command-generation changes can break existing workflows indirectly. Check for backward compatibility in generated command shape, naming, argument expectations, and operation discovery.
 
-### Output formatting and golden tests
+### Spec and operation cache invalidation
 
-Intentional formatter changes should usually come with targeted regression coverage or golden updates. Unintentional output drift is a common source of user-visible regressions.
+A recurring source of fixes: stale generated commands after config or spec changes. Caches are keyed by base URL, operation base, server variables, and raw spec hash. Changes to `api edit`/`api connect`, profiles, base URLs, or spec loading must invalidate or refresh the relevant caches, and concurrent `api connect` runs must not clobber each other's entries.
+
+### OAuth and auth concurrency
+
+Token refreshes must stay serialized; discovery transports and OAuth state are shared across generated commands. Changes to `internal/auth` should be checked for refresh races, cache-key reuse across profiles/issuers, and browser-launch behavior (`$BROWSER` handling, Linux flows).
+
+### v1 → v2 migration of persisted state
+
+Changing config schema, cache key formats, or credential storage breaks existing user state unless migrated. Past fixes migrated legacy token cache keys, legacy `tls.cert`/`tls.key` fields, and added migration warnings. New formats need a mapping from the old one or an explicit, tested migration error.
+
+### Command surface and help contracts
+
+`internal/cli/command_surface_test.go` locks the built-in command tree, help grouping, error-message UX, and removed pre-release names. Adding, renaming, or regrouping commands should update it deliberately — treat unexplained churn there as a regression signal.
+
+### Output formatting
+
+Intentional formatter changes should usually come with targeted regression coverage. Unintentional output drift is a common source of user-visible regressions.
 
 ### Auth, pagination, filtering, and caching flows
 
@@ -109,17 +125,16 @@ Changes in these areas often regress behavior only in realistic end-to-end paths
 
 For auth, redaction, and cache metadata changes, check both positive behavior and negative leakage boundaries: where credentials are applied, where they must not be applied, what gets persisted, and what appears in errors or traces. Keep findings tied to the PR's changed paths.
 
+`internal/secrets` holds the central allow-lists for recognizing credential-like fields; new secret-ish field names belong there, not in ad-hoc checks. Past fixes covered suffixed fields (`confirm_password`), URL userinfo and query credentials in network errors, and avoiding false positives on ordinary fields like `max_tokens`.
+
 ### Test buffer races
 
 Tests that share a `bytes.Buffer` across concurrent writers can hide data races, especially when subprocess stderr/stdout is wired into test buffers.
 
 ## Verification Hints
 
-- Prefer the narrowest meaningful test first: `go test ./internal/cli/...`, `go test ./internal/request/...`, `go test ./internal/output/...`, or another touched package.
-- Run `go test ./...` for broad or shared changes.
-- Run `go test -tags=integration ./...` before approving CLI or plugin behavior changes with integration risk.
-- Update golden files only when behavior intentionally changed.
-- Consider `go test -race ./...` when concurrency, subprocess handling, or shared buffers are touched.
+- Run the AGENTS.md verification ladder: narrowest touched package first, then `go test ./...`, then `-tags=integration` for CLI/plugin behavior changes, and `-race` when concurrency, subprocess handling, or shared buffers are touched.
+- Run `go run ./cmd/restish-docgen --check` when CLI surface or help text changed; CI fails on stale generated docs regions.
 
 ## Example Findings
 

--- a/.agents/skills/rsh-review/agents/openai.yaml
+++ b/.agents/skills/rsh-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Restish Review"
+  short_description: "Find bugs and risks in Restish changes"
+  default_prompt: "Use $rsh-review to review the current Restish code changes for bugs, regressions, missing tests, and repo-specific risks."

--- a/.agents/skills/rsh-simplify/SKILL.md
+++ b/.agents/skills/rsh-simplify/SKILL.md
@@ -29,16 +29,7 @@ User experience comes first. Developer experience comes second. Simplifications 
 
 ## Post-Review Shrink Pass
 
-After a PR has gone through review/fix loops, do a focused simplification pass before final handoff when the diff has grown substantially. Compare `git diff --stat` or `git diff --shortstat` before and after. Target duplicated test setup, repeated assertions, over-large inline fixtures, and helper code that obscures the behavior under test. Prefer deleting ceremony over deleting coverage.
-
-Good shrink-pass moves:
-
-- Table-drive cases that share setup and assertion shape.
-- Add small helpers for repeated config/cache/server setup when they make tests read more directly.
-- Share behavioral assertions that are repeated verbatim.
-- Keep edge-case tests for auth, redaction, redirects, cache metadata, migrations, and subprocess behavior when those edge cases are the point of the PR.
-
-Avoid code golf. A shorter diff that is harder to audit, especially around security/auth/cache behavior, is not a simplification.
+Follow the "PR Review and Cleanup Discipline" section in AGENTS.md. When shrinking a PR after review loops, target duplicated test setup, repeated assertions, over-large inline fixtures, and helper code that obscures the behavior under test. Prefer deleting ceremony over deleting coverage, and avoid code golf: a shorter diff that is harder to audit, especially around security/auth/cache behavior, is not a simplification.
 
 ## Process
 
@@ -50,7 +41,7 @@ Unless the user has pointed at a specific file, package, or area, survey the who
 find . -name '*.go' | grep -v '_test.go' | grep -v 'vendor/' | sort
 ```
 
-Read the key files in `internal/cli/`, `internal/`, `auth/`, `plugin/`, `cmd/`, and any top-level packages. Look specifically for:
+Read the key files in `internal/cli/`, the other `internal/` packages, `plugin/`, and `cmd/`. Look specifically for:
 
 - **Dead code**: unexported symbols with no callers, exported symbols not used outside the package, `TODO: remove` comments, disabled or no-op code paths
 - **Redundant abstraction**: interfaces with a single implementation that is never swapped out, wrapper types that add no logic, packages that contain a single file with a handful of functions that could live one level up
@@ -132,7 +123,7 @@ These patterns are common sources of unnecessary complexity in Go codebases. Tre
 An interface with one implementation that is never injected, mocked in tests, or documented as an extension point is almost always removable. Replace with the concrete type directly. Exception: the `CLI` struct boundary in `internal/cli/` where plugin and test substitution is real.
 
 ### Single-file packages
-A package that contains one `.go` file (excluding tests) and fewer than ~150 lines is usually a candidate for inlining into its parent. Exception: packages that are imported by external callers (plugin API, `auth/`, `plugin/`).
+A package that contains one `.go` file (excluding tests) and fewer than ~150 lines is usually a candidate for inlining into its parent. Exception: packages that are imported by external callers (the public `plugin/` API).
 
 ### Tiny helper wrappers
 Functions of the form:
@@ -166,14 +157,8 @@ If the only reason a production interface exists is to allow mocking in tests, p
 ### `internal/cli/` package
 This is the largest package. Before merging files here, check whether the split reflects distinct responsibilities or is just historical. Files like `http.go`, `api.go`, `generated.go`, and `request_exec.go` may have overlapping concerns worth consolidating.
 
-### `auth/` vs `internal/auth/`
-Two auth trees exist. Check whether `auth/` (the exported package) re-exports or wraps `internal/auth/` superfluously. Unnecessary re-export layers are good deletion targets.
-
 ### `plugin/` vs `internal/plugin/`
-Same pattern as auth. Trace what each package actually exports and whether the split is load-bearing for external plugin authors.
-
-### Vendored legacy source
-Old Restish v1 source should not be vendored into this repository. If anything in `internal/` or `cmd/` depends on archived v1 code, that is a simplification target.
+The top-level `plugin/` package is the public contract for external plugin authors; `internal/plugin/` is the host-side implementation. Trace what each package actually exports and whether any wrapping between them is load-bearing before collapsing it.
 
 ### `docs/design/` alignment
 When removing or collapsing a subsystem, check whether a design doc describes it. If so, update or retire the design doc. Stale design docs are a form of complexity.
@@ -183,5 +168,5 @@ When removing or collapsing a subsystem, check whether a design doc describes it
 - **Never remove user-visible features.** If unsure whether something is user-visible, treat it as if it is.
 - **Never weaken test coverage.** Tests may be reorganized, consolidated, or rewritten, but the behaviors they cover must remain covered. Deleting tests requires explicit user approval.
 - **Never break the plugin protocol boundary.** The wire format between `restish` and plugin subprocesses is a public contract. Internal reshuffling that does not change the wire format is fine.
-- **Never break exported API surface** in `auth/`, `plugin/`, or `cmd/` packages without confirming with the user that a breaking change is acceptable.
+- **Never break exported API surface** in the `plugin/` or `cmd/` packages without confirming with the user that a breaking change is acceptable.
 - **Prefer building on the standard library** over keeping a thin wrapper around it.

--- a/.agents/skills/rsh-simplify/agents/openai.yaml
+++ b/.agents/skills/rsh-simplify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Restish Simplify"
+  short_description: "Remove unnecessary Restish complexity safely"
+  default_prompt: "Use $rsh-simplify to find simplification opportunities in the Restish codebase, report them, and implement approved changes."

--- a/.agents/skills/rsh-test/SKILL.md
+++ b/.agents/skills/rsh-test/SKILL.md
@@ -10,7 +10,7 @@ Write tests that prove user-visible behavior and preserve important contracts wi
 ## Use This Skill For
 
 - Adding or improving Go tests in Restish
-- Choosing between unit, package-level, CLI behavior, integration, golden, or fuzz tests
+- Choosing between unit, package-level, CLI behavior, integration, fixture-based, or fuzz tests
 - Covering regressions, CLI flows, OpenAPI-generated commands, auth, config, plugins, output formatting, pagination, streaming, caching, filtering, and request construction
 - Reviewing whether a proposed test is worth its maintenance cost
 
@@ -20,7 +20,7 @@ Write tests that prove user-visible behavior and preserve important contracts wi
 2. Prefer a behavioral CLI test when the change affects users: build a small OpenAPI spec or config, serve responses with `httptest.Server` or a fake transport, run `CLI.Run`, then assert stdout, stderr, request shape, exit/error behavior, and persisted files.
 3. Use package unit tests for pure logic, parsers, serializers, and edge cases where a CLI test would be noisy.
 4. Use table-driven subtests only when cases share the same setup and assertion shape. Name cases by behavior or bug, not by implementation detail.
-5. Use golden files only for stable, reviewable output that is too large or visually structured for inline expectations. Keep fixtures in `testdata/`, and update only when output changes intentionally.
+5. Use `testdata/` fixture files only for stable, reviewable output that is too large or visually structured for inline expectations. There is no automatic `-update` flag; regenerate fixtures deliberately and only when output changes intentionally.
 6. Use integration tests or `-tags=integration` when the real binary, plugin subprocesses, shell behavior, or external process lifecycle is the thing being tested.
 7. Use fuzz tests for parsers, shorthand/input decoding, OpenAPI schema handling, filters, and other input-heavy code. Seed fuzzers with realistic examples and past crashes; keep deterministic regression seeds runnable under normal `go test`.
 
@@ -30,7 +30,7 @@ Write tests that prove user-visible behavior and preserve important contracts wi
 - Request construction only: use fake transport plus `requestRecorder`.
 - Real HTTP semantics, redirects, compression, TLS, streaming, or server state: use `httptest.Server`.
 - Pure parser/formatter/schema/helper logic: write a package unit test, often table-driven.
-- Stable multi-line help, formatter, or tabular output: consider a golden file.
+- Stable multi-line help, formatter, or tabular output: consider a `testdata/` fixture.
 - Plugin protocol, subprocess lifecycle, shell setup, or binary packaging: use integration tests.
 - Input-heavy code with many edge cases: add or extend fuzz tests with realistic seeds.
 
@@ -39,6 +39,7 @@ When writing a test from scratch, load `references/patterns.md` for copyable Res
 ## Restish Patterns To Reuse
 
 - In `internal/cli`, prefer `newTestApp`, `newTestCLI`, `testArgs`, `requestRecorder`, `requireContains`, `writeTestFile`, and existing generated-command helpers when they fit.
+- Put new coverage where the contract already lives: `internal/cli/command_surface_test.go` for the built-in command tree, help grouping, and error-message UX; `internal/cli/generated_test.go` for OpenAPI command generation behavior.
 - Instantiate `CLI` directly instead of shelling out unless subprocess behavior is the point of the test.
 - Use `httptest.Server` for realistic HTTP behavior and real URLs; use fake transports for focused request-construction assertions.
 - Keep config, cache, home, plugin, and spec files under `t.TempDir()`.
@@ -46,14 +47,9 @@ When writing a test from scratch, load `references/patterns.md` for copyable Res
 - Register helper failures with `t.Helper()`.
 - Assert exact output when it is stable and meaningful. For JSON, prefer decoding and checking semantic fields when ordering or formatting is incidental.
 
-## Plain Go Over Gherkin
+## Plain Go Over Scenario DSLs
 
-Prefer plain Go tests with a small Restish-specific helper vocabulary over Gherkin/Cucumber-style scenario files.
-
-- Restish CLI tests often need precise Go-native control over `httptest.Server`, fake transports, temp config/cache/plugin paths, `CLI` hooks, stdout/stderr buffers, request bodies, auth state, and persisted files. Go helpers keep those details close to the assertion and make failures easier to debug.
-- Gherkin usually moves repeated setup into step definitions without removing the real complexity. Use it only if there is a concrete product need for executable acceptance specs readable and maintained by non-Go contributors.
-- When tests start to read like repeated scenarios, improve the Go vocabulary instead: add focused helpers for tiny OpenAPI operation specs, mock API servers that serve both specs and endpoint routes, config/profile/auth constructors, CLI run helpers, JSON stdout assertions, and request assertions for method/path/query/header/body.
-- Keep helper APIs scenario-like but explicit. A good test should read as setup, run command, assert observable output/request/state, without hiding important behavior behind broad "Given/When/Then" magic.
+Prefer plain Go tests with a small Restish-specific helper vocabulary over Gherkin/Cucumber-style scenario files. When tests start to read like repeated scenarios, improve the Go helper vocabulary instead; a good test reads as setup, run command, assert observable output/request/state, without hiding important behavior behind step-definition magic.
 
 ## High-Density Test Rules
 
@@ -85,7 +81,7 @@ Prefer plain Go tests with a small Restish-specific helper vocabulary over Gherk
 - Independent mismatches after setup: `t.Errorf` is fine, but keep failure output useful.
 - Raw text or line output: exact string when stable; substring checks when surrounding formatting is incidental.
 - JSON output: decode and assert semantic fields unless formatting is the feature.
-- Help, table, and formatter output: use exact strings or golden files when layout is the contract.
+- Help, table, and formatter output: use exact strings or `testdata/` fixtures when layout is the contract.
 - Errors: assert type/sentinel/exit behavior when available; assert full strings only for user-facing message contracts.
 - Diffs: label direction as `-want +got` when using a diff helper already present in the package.
 
@@ -100,12 +96,4 @@ Prefer plain Go tests with a small Restish-specific helper vocabulary over Gherk
 
 ## Verification
 
-Run the narrowest meaningful package first:
-
-```bash
-go test ./internal/cli/...
-go test ./internal/request/...
-go test ./internal/output/...
-```
-
-Then run `go test ./...` for shared behavior. Run `go test -tags=integration ./...` before commits that touch CLI/plugin behavior or real subprocess boundaries. Use `go test -race ./...` when changing concurrency, streaming, subprocess lifecycle, shared buffers, or caches.
+Run the AGENTS.md verification ladder: narrowest touched package first, then `go test ./...`, then `go test -tags=integration ./...` before commits that touch CLI/plugin behavior or real subprocess boundaries. Use `go test -race ./...` when changing concurrency, streaming, subprocess lifecycle, shared buffers, or caches.

--- a/.agents/skills/rsh-test/references/patterns.md
+++ b/.agents/skills/rsh-test/references/patterns.md
@@ -137,10 +137,12 @@ if got, want := out.String(), "data: {\"n\":1}\n\n"; got != want {
 }
 ```
 
-Use golden files for large stable formatter/help output:
+Use `testdata/` fixture files for large stable formatter/help output. There is
+no automatic `-update` flag; regenerate fixtures deliberately when output
+changes intentionally:
 
 ```go
-want := readFile(t, "testdata/list-items.golden")
+want := readFile(t, "testdata/list-items.txt")
 if got := out.String(); got != want {
 	t.Fatalf("output mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,18 +12,41 @@ go build ./cmd/restish-csv
 go build ./cmd/restish-mcp
 go build ./cmd/restish-pkcs11
 
-# Run fast tests (default development loop; excludes slow integration tests)
-go test ./...
+# Regenerate docs-site regions derived from CLI help and flags.
+# Run --write after changing CLI surface (commands, flags, help text);
+# CI fails on stale regions via --check.
+go run ./cmd/restish-docgen --write
+go run ./cmd/restish-docgen --check
 
-# Run tests for a specific package
-go test ./internal/cli/...
+# Validate the docs site after changes under site/
+hugo --source site --quiet
 
-# Run the full suite, including slow plugin and CLI integration tests.
-# Run this before commits that touch CLI/plugin behavior, and before final commits.
-go test -tags=integration ./...
+# Validate docs examples and links (CI runs both)
+scripts/check-doc-examples.rb
+scripts/check-doc-links.rb
+```
 
-# Update golden files for output formatter regression tests
-go test -update ./internal/output/...
+### Verification Ladder
+
+Run the narrowest meaningful test first, then widen:
+
+```bash
+go test ./internal/cli/...       # or another touched package
+go test ./...                    # fast suite; default development loop
+go test -tags=integration ./...  # full suite, including slow plugin and CLI
+                                 # integration tests; run before commits that
+                                 # touch CLI/plugin behavior and final commits
+go test -race ./...              # when touching concurrency, streaming,
+                                 # subprocess lifecycle, or shared buffers
+```
+
+CI requires all of: `go test ./...`, `go test -tags=integration ./...`, building all five binaries above, `restish-docgen --check`, `scripts/check-doc-links.rb`, `scripts/check-doc-examples.rb`, and the Hugo/npm docs-site build. A weekly job also executes every docs `restish-example` live against `api.rest.sh`.
+
+### Manual Smoke Test
+
+```bash
+go build -o /tmp/restish ./cmd/restish
+/tmp/restish api.rest.sh/types   # safe public test API
 ```
 
 ## Architecture
@@ -35,6 +58,19 @@ Restish is a CLI for interacting with REST-ish HTTP APIs. It generates commands 
 The core design is a `CLI` struct in `internal/cli/cli.go` that owns all state — I/O handles, config, content registry, spec loaders, link parsers, formatters, and plugins. Tests instantiate `CLI` directly with `bytes.Buffer` for I/O and `httptest.Server` for HTTP.
 
 **Entry point**: `cmd/restish/main.go` creates a `CLI` and calls `Run(os.Args)`.
+
+### Package Map
+
+- `internal/cli` — command tree, flags, generated commands, pagination, help; the `CLI` struct lives here
+- `internal/request` — HTTP execution: retries, redirects, TLS, redaction
+- `internal/spec`, `internal/openapi` — spec discovery/loading/caching and OpenAPI → command generation
+- `internal/output` — response formatters (JSON, YAML, tables, TOON, …); regression fixtures in `testdata/`
+- `internal/auth`, `internal/secrets` — auth schemes; credential-recognition allow-lists
+- `internal/config` — config files, profiles, comment-preserving JSONC edits, file locking
+- `internal/content`, `internal/input`, `internal/filter`, `internal/hypermedia` — content negotiation, shorthand request bodies, shorthand/jq filtering, link parsing
+- `internal/cache`, `internal/history` — size-bounded disk cache; request history
+- `internal/plugin`, `internal/procutil` — plugin discovery/manifests; subprocess lifecycle
+- `plugin/` (top level) — public plugin API contract; wire compatibility is a public promise
 
 ## Design Documentation
 
@@ -66,7 +102,13 @@ Prefer these types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `build`, 
 
 Invoke these skills when relevant:
 
+- `rsh-product` for shaping features, CLI UX, naming, scope, and compatibility decisions before or during implementation
 - `rsh-review` for code review feedback on code changes
 - `rsh-test` for writing concise, behavior-focused Restish tests
-- `rsh-docs` for writing and maintaining documentation
+- `rsh-docs` for writing and maintaining documentation, blog posts, and design docs
 - `rsh-simplify` for approved simplification and dead-code cleanup work
+- `rsh-release-qa` for release readiness QA from `main`
+
+## Maintenance
+
+If you find a stale fact in this file or a skill — a command that fails, a path or package that no longer exists — fix it as part of your change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,12 @@ go build ./cmd/restish-pkcs11
 go run ./cmd/restish-docgen --write
 go run ./cmd/restish-docgen --check
 
-# Validate the docs site after changes under site/
+# Validate the docs site after changes under site/ (quick check)
 hugo --source site --quiet
+
+# Full CI parity for the docs job: social preview images + Hugo
+# (npm ci needed once; social-images parses content front matter and can fail independently)
+npm --prefix site ci && npm --prefix site run build
 
 # Validate docs examples and links (CI runs both)
 scripts/check-doc-examples.rb
@@ -40,7 +44,7 @@ go test -race ./...              # when touching concurrency, streaming,
                                  # subprocess lifecycle, or shared buffers
 ```
 
-CI requires all of: `go test ./...`, `go test -tags=integration ./...`, building all five binaries above, `restish-docgen --check`, `scripts/check-doc-links.rb`, `scripts/check-doc-examples.rb`, and the Hugo/npm docs-site build. A weekly job also executes every docs `restish-example` live against `api.rest.sh`.
+CI requires all of: `go test ./...`, `go test -tags=integration ./...`, building all five binaries above, `restish-docgen --check`, `scripts/check-doc-links.rb`, `scripts/check-doc-examples.rb`, and the docs-site build (`npm --prefix site ci`, `npm --prefix site run social-images`, then Hugo). A weekly job also executes every docs `restish-example` live against `api.rest.sh`.
 
 ### Manual Smoke Test
 


### PR DESCRIPTION
## Summary

A deep-review and improvement pass over `AGENTS.md` and the six `.agents/skills/` definitions, fixing verifiably stale facts, documenting CI gates agents couldn't know about, and encoding recurring bug classes mined from the fix-commit history.

### Stale facts fixed (all verified against the repo)

- `go test -update ./internal/output/...` doesn't work — no `-update` flag exists anywhere. Removed, and all golden-file references across skills reworded to plain `testdata/` fixtures with an explicit "no `-update` flag" note.
- `rsh-simplify` referenced a top-level `auth/` package in four places; it doesn't exist. Also removed the moot vendored-v1 entry.

### CI gates now documented

- `restish-docgen --check` and `scripts/check-doc-{examples,links}.rb` run in CI but were unmentioned — agents changing CLI surface or docs would pass local tests and still fail CI. Now in AGENTS.md commands, the CI gate list, `rsh-docs` validation, and the release-qa gates.
- `rsh-docs` now states the validated `restish-example` contract: single direct `restish` invocation, no pipes/redirects/substitution, executed live against `api.rest.sh` weekly.

### Mined from fix history into `rsh-review`

New watchlist entries for the three biggest recurring v2-era bug clusters: spec/operation cache invalidation, OAuth concurrency and reuse, and v1→v2 migration of persisted state — plus pointers to `internal/secrets` allow-lists, `command_surface_test.go` contracts, and the release-qa historical findings catalog.

### Structure and conciseness

- AGENTS.md gains a package map, verification ladder, manual smoke test, all six skills with triggers, and a stale-fact maintenance note.
- Deduplicated the verification ladder and shrink-pass guidance (canonical in AGENTS.md; skills reference it).
- Condensed generic content in `rsh-product` and `rsh-test`; promoted the blog example-style rules to all docs examples; made the blog review-pass instruction harness-agnostic.
- Added `agents/openai.yaml` for the three skills missing one.

Every command now documented was executed to confirm it works (`docgen --check` clean, both doc check scripts pass, cross-skill reference paths resolve).

## Validation

- `scripts/check-doc-examples.rb` — ok (98 commands)
- `scripts/check-doc-links.rb` — ok (78 files)
- `go run ./cmd/restish-docgen --check` — clean
- Markdown/YAML-only change; no product code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)