### PR TITLE
feat: expose embedder helpers for legacy config and auth header

### DIFF
--- a/auth/tokencache.go
+++ b/auth/tokencache.go
@@ -48,6 +48,11 @@ func NewTokenCache(path string) *TokenCache {
 	return &TokenCache{path: path}
 }
 
+// Path returns the file path the cache reads from and writes to.
+func (c *TokenCache) Path() string {
+	return c.path
+}
+
 // Get returns the cached token for key, or (nil, nil) if not found.
 func (c *TokenCache) Get(key string) (*CachedToken, error) {
 	c.mu.Lock()

--- a/auth/tokencache_test.go
+++ b/auth/tokencache_test.go
@@ -25,6 +25,14 @@ func TestTokenCache_MissingFile(t *testing.T) {
 	}
 }
 
+func TestTokenCache_Path(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.cbor")
+	tc := NewTokenCache(path)
+	if got := tc.Path(); got != path {
+		t.Errorf("Path() = %q, want %q", got, path)
+	}
+}
+
 func TestTokenCache_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tokens.cbor")
 	tc := NewTokenCache(path)

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -12,41 +12,41 @@ import (
 	"github.com/tidwall/jsonc"
 )
 
-// LegacyAPIConfigAuth is the v1 `profiles.<name>.auth` shape.
-type LegacyAPIConfigAuth struct {
+// legacyAPIConfigAuth is the v1 `profiles.<name>.auth` shape.
+type legacyAPIConfigAuth struct {
 	Name   string            `json:"name"`
 	Params map[string]string `json:"params,omitempty"`
 }
 
-// LegacyPKCS11Config is the v1 `tls.pkcs11` shape.
-type LegacyPKCS11Config struct {
+// legacyPKCS11Config is the v1 `tls.pkcs11` shape.
+type legacyPKCS11Config struct {
 	Path  string `json:"path,omitempty"`
 	Label string `json:"label,omitempty"`
 }
 
-// LegacyTLSConfig is the v1 `tls` shape.
-type LegacyTLSConfig struct {
-	PKCS11 *LegacyPKCS11Config `json:"pkcs11,omitempty"`
+// legacyTLSConfig is the v1 `tls` shape.
+type legacyTLSConfig struct {
+	PKCS11 *legacyPKCS11Config `json:"pkcs11,omitempty"`
 	Cert   string              `json:"cert,omitempty"`
 	Key    string              `json:"key,omitempty"`
 	CACert string              `json:"ca_cert,omitempty"`
 }
 
-// LegacyAPIProfile is the v1 `profiles.<name>` shape.
-type LegacyAPIProfile struct {
-	Base    string                  `json:"base,omitempty"`
-	Headers map[string]string       `json:"headers,omitempty"`
-	Query   map[string]string       `json:"query,omitempty"`
-	Auth    *LegacyAPIConfigAuth    `json:"auth,omitempty"`
+// legacyAPIProfile is the v1 `profiles.<name>` shape.
+type legacyAPIProfile struct {
+	Base    string               `json:"base,omitempty"`
+	Headers map[string]string    `json:"headers,omitempty"`
+	Query   map[string]string    `json:"query,omitempty"`
+	Auth    *legacyAPIConfigAuth `json:"auth,omitempty"`
 }
 
-// LegacyAPIConfig is the v1 per-API shape from apis.json.
-type LegacyAPIConfig struct {
+// legacyAPIConfig is the v1 per-API shape from apis.json.
+type legacyAPIConfig struct {
 	Base          string                       `json:"base"`
 	OperationBase string                       `json:"operation_base,omitempty"`
 	SpecFiles     []string                     `json:"spec_files,omitempty"`
-	Profiles      map[string]*LegacyAPIProfile `json:"profiles,omitempty"`
-	TLS           *LegacyTLSConfig             `json:"tls,omitempty"`
+	Profiles      map[string]*legacyAPIProfile `json:"profiles,omitempty"`
+	TLS           *legacyTLSConfig             `json:"tls,omitempty"`
 }
 
 // ConvertLegacyAPI converts a single v1 (apis.json) APIConfig entry to the
@@ -63,7 +63,7 @@ type LegacyAPIConfig struct {
 // one-call read of an apis.json folder can use ReadLegacyAPIs.
 func ConvertLegacyAPI(name string, raw json.RawMessage) (*APIConfig, []string, error) {
 	stripped := jsonc.ToJSON(raw)
-	var legacy LegacyAPIConfig
+	var legacy legacyAPIConfig
 	if err := json.Unmarshal(stripped, &legacy); err != nil {
 		return nil, nil, &ParseError{Path: name, Err: err}
 	}
@@ -151,7 +151,7 @@ func ReadAPIs(folder string) (map[string]*APIConfig, error) {
 // convertLegacyAPIConfig converts one parsed v1 entry into the v2 shape and
 // emits migration-time warnings. Used by both the public ConvertLegacyAPI
 // helper and the internal automatic migrator.
-func convertLegacyAPIConfig(name string, legacy *LegacyAPIConfig) (*APIConfig, []string) {
+func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*APIConfig, []string) {
 	if legacy == nil {
 		return &APIConfig{}, nil
 	}
@@ -245,7 +245,7 @@ func convertLegacyOperationBase(apiName, operationBase string) (string, string) 
 	return "", fmt.Sprintf("api %q: dropped invalid legacy operation_base %q; v2 operation_base must be an absolute path", apiName, operationBase)
 }
 
-func convertLegacyProfile(legacy *LegacyAPIProfile) *ProfileConfig {
+func convertLegacyProfile(legacy *legacyAPIProfile) *ProfileConfig {
 	if legacy == nil {
 		return &ProfileConfig{}
 	}

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -1,0 +1,276 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tidwall/jsonc"
+)
+
+// LegacyAPIConfigAuth is the v1 `profiles.<name>.auth` shape.
+type LegacyAPIConfigAuth struct {
+	Name   string            `json:"name"`
+	Params map[string]string `json:"params,omitempty"`
+}
+
+// LegacyPKCS11Config is the v1 `tls.pkcs11` shape.
+type LegacyPKCS11Config struct {
+	Path  string `json:"path,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
+// LegacyTLSConfig is the v1 `tls` shape.
+type LegacyTLSConfig struct {
+	PKCS11 *LegacyPKCS11Config `json:"pkcs11,omitempty"`
+	Cert   string              `json:"cert,omitempty"`
+	Key    string              `json:"key,omitempty"`
+	CACert string              `json:"ca_cert,omitempty"`
+}
+
+// LegacyAPIProfile is the v1 `profiles.<name>` shape.
+type LegacyAPIProfile struct {
+	Base    string                  `json:"base,omitempty"`
+	Headers map[string]string       `json:"headers,omitempty"`
+	Query   map[string]string       `json:"query,omitempty"`
+	Auth    *LegacyAPIConfigAuth    `json:"auth,omitempty"`
+}
+
+// LegacyAPIConfig is the v1 per-API shape from apis.json.
+type LegacyAPIConfig struct {
+	Base          string                       `json:"base"`
+	OperationBase string                       `json:"operation_base,omitempty"`
+	SpecFiles     []string                     `json:"spec_files,omitempty"`
+	Profiles      map[string]*LegacyAPIProfile `json:"profiles,omitempty"`
+	TLS           *LegacyTLSConfig             `json:"tls,omitempty"`
+}
+
+// ConvertLegacyAPI converts a single v1 (apis.json) APIConfig entry to the
+// current v2 shape. The name argument is used for warning messages only; it
+// does not affect the converted data. Pass the raw JSON value of one entry
+// from an apis.json file, e.g. the bytes associated with one key in the
+// top-level map.
+//
+// Returned warnings describe migration-time decisions such as dropped
+// invalid operation_base values or migrated PKCS#11 TLS config that now
+// requires the restish-pkcs11 plugin to be installed.
+//
+// The function does not read or write any files. Callers that want a
+// one-call read of an apis.json folder can use ReadLegacyAPIs.
+func ConvertLegacyAPI(name string, raw json.RawMessage) (*APIConfig, []string, error) {
+	stripped := jsonc.ToJSON(raw)
+	var legacy LegacyAPIConfig
+	if err := json.Unmarshal(stripped, &legacy); err != nil {
+		return nil, nil, &ParseError{Path: name, Err: err}
+	}
+	api, warnings := convertLegacyAPIConfig(name, &legacy)
+	return api, warnings, nil
+}
+
+// ReadLegacyAPIs reads every API from a v1 apis.json in folder, returning them
+// in v2 shape. The "$schema" key is skipped. Returns an empty map and no
+// error when apis.json does not exist.
+//
+// This is the read path for embedders that want to read a legacy config
+// without going through the restish CLI's automatic migration. ReadLegacyAPIs
+// never modifies the user's apis.json or restish.json; the restish CLI's
+// own TryMigrate step is responsible for that.
+func ReadLegacyAPIs(folder string) (map[string]*APIConfig, error) {
+	path := filepath.Join(folder, "apis.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]*APIConfig{}, nil
+		}
+		return nil, fmt.Errorf("config: cannot read %s: %w", path, err)
+	}
+	stripped := jsonc.ToJSON(data)
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(stripped, &raw); err != nil {
+		return nil, &ParseError{Path: path, Err: err}
+	}
+	out := make(map[string]*APIConfig, len(raw))
+	var warnings []string
+	for name, value := range raw {
+		if strings.HasPrefix(name, "$") {
+			continue
+		}
+		api, entryWarnings, err := ConvertLegacyAPI(name, value)
+		if err != nil {
+			return nil, fmt.Errorf("config: parsing %s entry %q: %w", path, name, err)
+		}
+		out[name] = api
+		warnings = append(warnings, entryWarnings...)
+	}
+	return out, nil
+}
+
+// ReadLegacyAPI reads a single named API from a v1 apis.json in folder,
+// returning it in v2 shape. Returns an error when the API is not present.
+func ReadLegacyAPI(folder, name string) (*APIConfig, error) {
+	all, err := ReadLegacyAPIs(folder)
+	if err != nil {
+		return nil, err
+	}
+	api, ok := all[name]
+	if !ok {
+		return nil, fmt.Errorf("config: api %q not found in %s", name, filepath.Join(folder, "apis.json"))
+	}
+	return api, nil
+}
+
+// convertLegacyAPIConfig converts one parsed v1 entry into the v2 shape and
+// emits migration-time warnings. Used by both the public ConvertLegacyAPI
+// helper and the internal automatic migrator.
+func convertLegacyAPIConfig(name string, legacy *LegacyAPIConfig) (*APIConfig, []string) {
+	if legacy == nil {
+		return &APIConfig{}, nil
+	}
+	operationBase, warning := convertLegacyOperationBase(name, legacy.OperationBase)
+
+	api := &APIConfig{
+		BaseURL:       legacy.Base,
+		OperationBase: operationBase,
+		SpecFiles:     append([]string(nil), legacy.SpecFiles...),
+	}
+	if len(legacy.Profiles) > 0 {
+		api.Profiles = make(map[string]*ProfileConfig, len(legacy.Profiles))
+		for name, profile := range legacy.Profiles {
+			api.Profiles[name] = convertLegacyProfile(profile)
+		}
+	}
+
+	var migratedPKCS11 bool
+	if legacy.TLS != nil && legacy.TLS.PKCS11 != nil {
+		if api.Profiles == nil {
+			api.Profiles = map[string]*ProfileConfig{}
+		}
+		prof := api.Profiles["default"]
+		if prof == nil {
+			prof = &ProfileConfig{}
+			api.Profiles["default"] = prof
+		}
+		if prof.TLSSigner == "" {
+			prof.TLSSigner = "pkcs11"
+		}
+		if prof.TLSSignerParams == nil {
+			prof.TLSSignerParams = map[string]string{}
+		}
+		if legacy.TLS.PKCS11.Path != "" && prof.TLSSignerParams["path"] == "" {
+			prof.TLSSignerParams["path"] = legacy.TLS.PKCS11.Path
+		}
+		if legacy.TLS.PKCS11.Label != "" && prof.TLSSignerParams["label"] == "" {
+			prof.TLSSignerParams["label"] = legacy.TLS.PKCS11.Label
+		}
+		migratedPKCS11 = true
+	}
+
+	if legacy.TLS != nil && (legacy.TLS.Cert != "" || legacy.TLS.Key != "") {
+		if api.Profiles == nil {
+			api.Profiles = map[string]*ProfileConfig{}
+		}
+		prof := api.Profiles["default"]
+		if prof == nil {
+			prof = &ProfileConfig{}
+			api.Profiles["default"] = prof
+		}
+		if prof.ClientCertPath == "" && legacy.TLS.Cert != "" {
+			prof.ClientCertPath = legacy.TLS.Cert
+		}
+		if prof.ClientKeyPath == "" && legacy.TLS.Key != "" {
+			prof.ClientKeyPath = legacy.TLS.Key
+		}
+	}
+
+	if legacy.TLS != nil && legacy.TLS.CACert != "" {
+		if api.Profiles == nil {
+			api.Profiles = map[string]*ProfileConfig{}
+		}
+		prof := api.Profiles["default"]
+		if prof == nil {
+			prof = &ProfileConfig{}
+			api.Profiles["default"] = prof
+		}
+		if prof.CACertPath == "" {
+			prof.CACertPath = legacy.TLS.CACert
+		}
+	}
+
+	var warnings []string
+	if warning != "" {
+		warnings = append(warnings, warning)
+	}
+	if migratedPKCS11 {
+		warnings = append(warnings, fmt.Sprintf("api %q: migrated PKCS#11 TLS config; install the restish-pkcs11 plugin to continue using it (see https://github.com/rest-sh/restish)", name))
+	}
+	return api, warnings
+}
+
+func convertLegacyOperationBase(apiName, operationBase string) (string, string) {
+	if operationBase == "" {
+		return "", ""
+	}
+	if err := ValidateOperationBase(operationBase); err == nil {
+		return operationBase, ""
+	}
+	return "", fmt.Sprintf("api %q: dropped invalid legacy operation_base %q; v2 operation_base must be an absolute path", apiName, operationBase)
+}
+
+func convertLegacyProfile(legacy *LegacyAPIProfile) *ProfileConfig {
+	if legacy == nil {
+		return &ProfileConfig{}
+	}
+
+	prof := &ProfileConfig{
+		BaseURL: legacy.Base,
+		Headers: sortedHeaderList(legacy.Headers),
+		Query:   sortedQueryList(legacy.Query),
+	}
+	if legacy.Auth != nil {
+		prof.Auth = &AuthConfig{
+			Type:   legacy.Auth.Name,
+			Params: cloneStringMap(legacy.Auth.Params),
+		}
+	}
+	return prof
+}
+
+func sortedHeaderList(values map[string]string) []string {
+	return sortedPairs(values, ": ")
+}
+
+func sortedQueryList(values map[string]string) []string {
+	return sortedPairs(values, "=")
+}
+
+func sortedPairs(values map[string]string, sep string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	items := make([]string, 0, len(keys))
+	for _, key := range keys {
+		items = append(items, key+sep+values[key])
+	}
+	return items
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for k, v := range values {
+		out[k] = v
+	}
+	return out
+}

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -94,17 +94,15 @@ func ReadLegacyAPIs(folder string) (map[string]*APIConfig, error) {
 		return nil, &ParseError{Path: path, Err: err}
 	}
 	out := make(map[string]*APIConfig, len(raw))
-	var warnings []string
 	for name, value := range raw {
 		if strings.HasPrefix(name, "$") {
 			continue
 		}
-		api, entryWarnings, err := ConvertLegacyAPI(name, value)
+		api, _, err := ConvertLegacyAPI(name, value)
 		if err != nil {
 			return nil, fmt.Errorf("config: parsing %s entry %q: %w", path, name, err)
 		}
 		out[name] = api
-		warnings = append(warnings, entryWarnings...)
 	}
 	return out, nil
 }

--- a/config/legacy.go
+++ b/config/legacy.go
@@ -123,6 +123,31 @@ func ReadLegacyAPI(folder, name string) (*APIConfig, error) {
 	return api, nil
 }
 
+// ReadAPIs returns every API configured in folder, in v2 shape, regardless of
+// whether the user's config is in v2 (restish.json) or v1 (apis.json) format.
+// This is the format-agnostic read path for embedders.
+//
+// restish.json is preferred when present. apis.json is read only when
+// restish.json does not exist, so a user who has already migrated is served
+// from the v2 file with no v1 conversion. ReadAPIs never modifies either
+// file; the restish CLI's TryMigrate step is responsible for that.
+func ReadAPIs(folder string) (map[string]*APIConfig, error) {
+	restishPath := filepath.Join(folder, "restish.json")
+	if _, err := os.Stat(restishPath); err == nil {
+		cfg, err := Load(restishPath)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.APIs == nil {
+			return map[string]*APIConfig{}, nil
+		}
+		return cfg.APIs, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("config: cannot stat %s: %w", restishPath, err)
+	}
+	return ReadLegacyAPIs(folder)
+}
+
 // convertLegacyAPIConfig converts one parsed v1 entry into the v2 shape and
 // emits migration-time warnings. Used by both the public ConvertLegacyAPI
 // helper and the internal automatic migrator.

--- a/config/legacy_test.go
+++ b/config/legacy_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const legacyAPIsJSON = `{
+  "$schema": "https://rest.sh/schemas/apis.json",
+  "root-api": {
+    "base": "https://root-api.internal.example.com/api",
+    "tls": {
+      "cert": "/etc/exoscale/devel-cert.pem",
+      "key":  "/etc/exoscale/devel-key.pem",
+      "ca_cert": "/etc/exoscale/root-ca.pem"
+    },
+    "profiles": {
+      "default": {
+        "auth": {
+          "name": "oauth-authorization-code",
+          "params": {
+            "authorize_url": "https://dex.internal.example.com/auth",
+            "client_id":     "restish",
+            "scopes":        "openid email",
+            "token_url":     "https://dex.internal.example.com/token"
+          }
+        }
+      }
+    }
+  },
+  "root-api-yubikey": {
+    "base": "https://root-api.internal.example.com/api",
+    "tls": {
+      "pkcs11": {
+        "path":  "/usr/lib/opensc-pkcs11.so",
+        "label": "firstname.lastname"
+      }
+    },
+    "profiles": {
+      "default": {
+        "auth": { "name": "oauth-authorization-code" }
+      }
+    }
+  }
+}`
+
+func TestConvertLegacyAPIFileCert(t *testing.T) {
+	raw := legacyAPIsEntry(t, "root-api")
+	api, warnings, err := ConvertLegacyAPI("root-api", raw)
+	if err != nil {
+		t.Fatalf("ConvertLegacyAPI: %v", err)
+	}
+	if got := api.BaseURL; got != "https://root-api.internal.example.com/api" {
+		t.Errorf("BaseURL = %q", got)
+	}
+	prof := api.Profiles["default"]
+	if prof == nil {
+		t.Fatal("default profile missing")
+	}
+	if prof.ClientCertPath != "/etc/exoscale/devel-cert.pem" {
+		t.Errorf("ClientCertPath = %q", prof.ClientCertPath)
+	}
+	if prof.ClientKeyPath != "/etc/exoscale/devel-key.pem" {
+		t.Errorf("ClientKeyPath = %q", prof.ClientKeyPath)
+	}
+	if prof.CACertPath != "/etc/exoscale/root-ca.pem" {
+		t.Errorf("CACertPath = %q", prof.CACertPath)
+	}
+	if prof.TLSSigner != "" {
+		t.Errorf("TLSSigner = %q, want empty for cert/key auth", prof.TLSSigner)
+	}
+	if prof.Auth == nil || prof.Auth.Type != "oauth-authorization-code" {
+		t.Fatalf("Auth.Type = %v, want oauth-authorization-code", prof.Auth)
+	}
+	if got := prof.Auth.Params["client_id"]; got != "restish" {
+		t.Errorf("Auth.Params[client_id] = %q", got)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "PKCS") {
+			t.Errorf("unexpected PKCS#11 warning for cert/key entry: %s", w)
+		}
+	}
+}
+
+func TestConvertLegacyAPIPKCS11(t *testing.T) {
+	raw := legacyAPIsEntry(t, "root-api-yubikey")
+	api, warnings, err := ConvertLegacyAPI("root-api-yubikey", raw)
+	if err != nil {
+		t.Fatalf("ConvertLegacyAPI: %v", err)
+	}
+	prof := api.Profiles["default"]
+	if prof == nil {
+		t.Fatal("default profile missing")
+	}
+	if prof.TLSSigner != "pkcs11" {
+		t.Errorf("TLSSigner = %q, want pkcs11", prof.TLSSigner)
+	}
+	if got := prof.TLSSignerParams["path"]; got != "/usr/lib/opensc-pkcs11.so" {
+		t.Errorf("TLSSignerParams[path] = %q", got)
+	}
+	if got := prof.TLSSignerParams["label"]; got != "firstname.lastname" {
+		t.Errorf("TLSSignerParams[label] = %q", got)
+	}
+	if prof.ClientCertPath != "" || prof.ClientKeyPath != "" {
+		t.Errorf("PKCS#11 entry should not set ClientCertPath/Key: %+v", prof)
+	}
+	var saw bool
+	for _, w := range warnings {
+		if strings.Contains(w, "restish-pkcs11") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("expected restish-pkcs11 warning, got: %v", warnings)
+	}
+}
+
+func TestConvertLegacyAPIInvalidJSON(t *testing.T) {
+	_, _, err := ConvertLegacyAPI("bad", json.RawMessage("{not json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestReadLegacyAPIs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "apis.json"), []byte(legacyAPIsJSON), 0o600); err != nil {
+		t.Fatalf("write apis.json: %v", err)
+	}
+	all, err := ReadLegacyAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadLegacyAPIs: %v", err)
+	}
+	if _, ok := all["$schema"]; ok {
+		t.Error("$schema key should be skipped")
+	}
+	if len(all) != 2 {
+		t.Errorf("got %d APIs, want 2", len(all))
+	}
+	if all["root-api"].BaseURL == "" {
+		t.Error("root-api entry missing BaseURL")
+	}
+	if all["root-api-yubikey"].Profiles["default"].TLSSigner != "pkcs11" {
+		t.Error("root-api-yubikey TLSSigner not migrated")
+	}
+}
+
+func TestReadLegacyAPIsMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	all, err := ReadLegacyAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadLegacyAPIs: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("got %d APIs, want 0", len(all))
+	}
+}
+
+func TestReadLegacyAPIsBadJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "apis.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write apis.json: %v", err)
+	}
+	if _, err := ReadLegacyAPIs(dir); err == nil {
+		t.Fatal("expected error for malformed apis.json")
+	}
+}
+
+func TestReadLegacyAPI(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "apis.json"), []byte(legacyAPIsJSON), 0o600); err != nil {
+		t.Fatalf("write apis.json: %v", err)
+	}
+	api, err := ReadLegacyAPI(dir, "root-api")
+	if err != nil {
+		t.Fatalf("ReadLegacyAPI: %v", err)
+	}
+	if api.BaseURL != "https://root-api.internal.example.com/api" {
+		t.Errorf("BaseURL = %q", api.BaseURL)
+	}
+	if _, err := ReadLegacyAPI(dir, "missing"); err == nil {
+		t.Error("expected error for missing api name")
+	}
+}
+
+func legacyAPIsEntry(t *testing.T, name string) json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(legacyAPIsJSON), &raw); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	value, ok := raw[name]
+	if !ok {
+		t.Fatalf("fixture entry %q missing", name)
+	}
+	return value
+}

--- a/config/legacy_test.go
+++ b/config/legacy_test.go
@@ -186,6 +186,90 @@ func TestReadLegacyAPI(t *testing.T) {
 	}
 }
 
+const v2RestishJSON = `{
+  "apis": {
+    "v2-api": {
+      "base_url": "https://v2.example.com/api",
+      "spec_files": ["openapi.json"]
+    }
+  }
+}`
+
+func TestReadAPIsPrefersRestishJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "restish.json"), []byte(v2RestishJSON), 0o600); err != nil {
+		t.Fatalf("write restish.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "apis.json"), []byte(legacyAPIsJSON), 0o600); err != nil {
+		t.Fatalf("write apis.json: %v", err)
+	}
+	all, err := ReadAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadAPIs: %v", err)
+	}
+	if _, ok := all["v2-api"]; !ok {
+		t.Error("v2-api from restish.json missing")
+	}
+	if _, ok := all["root-api"]; ok {
+		t.Error("v1 apis.json entry should not appear when restish.json is present")
+	}
+	if got := all["v2-api"].BaseURL; got != "https://v2.example.com/api" {
+		t.Errorf("BaseURL = %q", got)
+	}
+}
+
+func TestReadAPIsFallsBackToLegacy(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "apis.json"), []byte(legacyAPIsJSON), 0o600); err != nil {
+		t.Fatalf("write apis.json: %v", err)
+	}
+	all, err := ReadAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadAPIs: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("got %d APIs, want 2", len(all))
+	}
+	if all["root-api"].Profiles["default"].ClientCertPath != "/etc/exoscale/devel-cert.pem" {
+		t.Error("legacy cert path not migrated")
+	}
+}
+
+func TestReadAPIsMissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	all, err := ReadAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadAPIs: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("got %d APIs, want 0", len(all))
+	}
+}
+
+func TestReadAPIsBadRestishJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "restish.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write restish.json: %v", err)
+	}
+	if _, err := ReadAPIs(dir); err == nil {
+		t.Fatal("expected error for malformed restish.json")
+	}
+}
+
+func TestReadAPIsEmptyRestishJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "restish.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write restish.json: %v", err)
+	}
+	all, err := ReadAPIs(dir)
+	if err != nil {
+		t.Fatalf("ReadAPIs: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("got %d APIs, want 0", len(all))
+	}
+}
+
 func legacyAPIsEntry(t *testing.T, name string) json.RawMessage {
 	t.Helper()
 	var raw map[string]json.RawMessage

--- a/docs/design/002-config-and-profiles.md
+++ b/docs/design/002-config-and-profiles.md
@@ -448,6 +448,43 @@ Restish should assume users may run multiple instances concurrently:
 That means in-memory mutexes are not sufficient for persistence safety.
 Cross-process locking is part of the design, not an optimization.
 
+## Public Embedder Surface
+
+External Go programs (custom CLIs, automation, IDE plugins) that want to read
+or write Restish config without depending on the full CLI rendering stack can
+import the top-level `config` and `auth` packages directly. These packages
+expose:
+
+- `config.Config` and the on-disk schema structs (`APIConfig`, `ProfileConfig`,
+  `AuthConfig`, `CacheConfig`, `PaginationConfig`, `CredentialConfig`)
+- `config.Load`, `config.Save`, `config.ParseConfigBytes`, `config.DefaultPath`,
+  `config.Validate`, `config.ApplyURLOverrides` for strict read/write of
+  `restish.json`
+- `config.ConvertLegacyAPI`, `config.ReadLegacyAPI`, `config.ReadLegacyAPIs`
+  for reading a v1 `apis.json` (or a single entry) and converting it to the
+  v2 shape in memory, without going through the CLI's automatic migration
+- `config.NewPaths`, `Paths.ConfigFile`, `Paths.Cache`, `Paths.TokenCache` for
+  XDG-aware path discovery
+- `auth.NewTokenCache`, `auth.LoadTokenCache`, `auth.SaveTokenCache`,
+  `auth.DefaultTokenCachePath` for sharing the OAuth token cache with the
+  restish CLI
+
+The file-locking and atomic-write helpers used internally are not part of the
+public surface; they live under `internal/fileutil` because they are tied to
+the internal config write path.
+
+The bundled auth-handler implementations (api-key, basic, bearer, oauth-*) and
+the external-tool approval flow are intentionally not in the public `auth`
+package; they live under `internal/auth` because their field shapes are tied
+to the restish auth registry. External embedders that need OAuth should use
+`golang.org/x/oauth2` directly.
+
+Embedders that need the resolved auth header for a profile without going
+through the restish CLI's full request flow should use
+`restish api auth get <api> --print-header`; this prints the single header as
+`Name: value` on stdout and exits non-zero for any non-header auth. This is
+the stable, parseable contract for shell scripts and external Go programs.
+
 ## Alternatives Considered
 
 ### Separate Files For APIs And Global Config

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -440,6 +440,9 @@ func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.Auth
 	if req.URL != nil && req.URL.RawQuery != "" {
 		return fmt.Errorf("auth for %s:%s is applied as a query parameter, not a header; --print-header is not applicable", apiName, profileName)
 	}
+	if authInspectionAppliesCookie(configs) {
+		return fmt.Errorf("auth for %s:%s is applied as a cookie, not a header; --print-header is not applicable", apiName, profileName)
+	}
 	headers := 0
 	var name, value string
 	for _, h := range sortedHeaderKeys(req.Header) {
@@ -460,6 +463,15 @@ func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.Auth
 	default:
 		return fmt.Errorf("auth for %s:%s produced multiple header values; --print-header expects a single header", apiName, profileName)
 	}
+}
+
+func authInspectionAppliesCookie(configs []*config.AuthConfig) bool {
+	for _, ac := range configs {
+		if ac != nil && ac.Type == "api-key" && strings.EqualFold(strings.TrimSpace(ac.Params["in"]), "cookie") {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string, printHeader bool) error {

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -390,7 +390,8 @@ func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
 		if credentialID != "" {
 			return fmt.Errorf("--operation and credential ID are mutually exclusive")
 		}
-		return c.runAPIAuthGetOperation(cmd, apiName, profileName, apiCfg, prof, operation)
+		printHeader, _ := cmd.Flags().GetBool("print-header")
+		return c.runAPIAuthGetOperation(cmd, apiName, profileName, apiCfg, prof, operation, printHeader)
 	}
 	if credentialID == "" {
 		resolvedProfile, err := c.resolveProfileAuth(apiName, profileName, prof)
@@ -461,7 +462,7 @@ func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.Auth
 	}
 }
 
-func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string) error {
+func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string, printHeader bool) error {
 	op, ok, err := c.cachedOperationForAPI(requestContext(cmd), apiName, apiCfg, profileName, operationName)
 	if err != nil {
 		return err
@@ -504,7 +505,11 @@ func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName st
 	if err != nil {
 		return err
 	}
-	fragment, err := authGetFragment(req, selectedOperationAuthConfigs(selected))
+	configs := selectedOperationAuthConfigs(selected)
+	if printHeader {
+		return c.runAPIAuthGetPrintHeader(req, configs, apiName, profileName)
+	}
+	fragment, err := authGetFragment(req, configs)
 	if err != nil {
 		return fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName+" --operation "+operationName)
 	}

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -64,11 +64,13 @@ func (c *CLI) newAPIAuthCommand() *cobra.Command {
 		Example: fmt.Sprintf(`  %s api auth get demo UserBearer
   %s api auth get demo PartnerKey
   %s api auth get demo --operation list-items
-  curl -H "$(%s api auth get demo UserBearer)" https://api.rest.sh/items`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
+  curl -H "$(%s api auth get demo UserBearer)" https://api.rest.sh/items
+  export AUTH_HEADER="$("%s" api auth get demo --print-header)"`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args: usageRangeArgs(1, 2),
 		RunE: c.runAPIAuthGet,
 	}
 	getCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
+	getCmd.Flags().Bool("print-header", false, "Print the single resolved header as 'Name: value' on stdout and exit non-zero for any non-header auth")
 	cmd.AddCommand(getCmd)
 	inspectCmd := &cobra.Command{
 		Use:   "inspect <api>",
@@ -415,12 +417,48 @@ func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	configs := []*config.AuthConfig{resolved.Config}
+	printHeader, _ := cmd.Flags().GetBool("print-header")
+	if printHeader {
+		return c.runAPIAuthGetPrintHeader(req, configs, apiName, profileName)
+	}
 	fragment, err := authGetFragment(req, configs)
 	if err != nil {
 		return fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName)
 	}
 	fmt.Fprintln(c.Stdout, fragment)
 	return nil
+}
+
+// runAPIAuthGetPrintHeader prints the single resolved auth header as
+// "Name: value" and returns an error if the resolved auth is not a single
+// header (for example, query parameter auth or a multi-credential
+// combination). This is the stable, parseable contract that shell scripts
+// and external Go binaries use to obtain a bearer token without going
+// through the restish CLI's full request flow.
+func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.AuthConfig, apiName, profileName string) error {
+	if req.URL != nil && req.URL.RawQuery != "" {
+		return fmt.Errorf("auth for %s:%s is applied as a query parameter, not a header; --print-header is not applicable", apiName, profileName)
+	}
+	headers := 0
+	var name, value string
+	for _, h := range sortedHeaderKeys(req.Header) {
+		for _, v := range req.Header[h] {
+			headers++
+			if headers == 1 {
+				name = authInspectionDisplayHeaderName(configs, h)
+				value = v
+			}
+		}
+	}
+	switch headers {
+	case 0:
+		return fmt.Errorf("auth for %s:%s did not produce a header value", apiName, profileName)
+	case 1:
+		fmt.Fprintf(c.Stdout, "%s: %s\n", name, value)
+		return nil
+	default:
+		return fmt.Errorf("auth for %s:%s produced multiple header values; --print-header expects a single header", apiName, profileName)
+	}
 }
 
 func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string) error {

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -13,6 +14,14 @@ import (
 	"github.com/rest-sh/restish/v2/auth"
 	"github.com/rest-sh/restish/v2/config"
 )
+
+type noopAuthHandler struct{}
+
+func (noopAuthHandler) Parameters() []auth.Param { return nil }
+
+func (noopAuthHandler) Authenticate(context.Context, *http.Request, auth.AuthContext) error {
+	return nil
+}
 
 func TestAPIAuthInspectAddRemove(t *testing.T) {
 	cfgFile := writeAPIConfigObject(t, "myapi", testAPIConfig("https://api.example.com", &config.ProfileConfig{}))
@@ -787,5 +796,96 @@ func TestAPIAuthGetPrintHeaderQueryFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "query parameter") {
 		t.Errorf("error = %q, want it to mention query parameter", err)
+	}
+}
+
+func TestAPIAuthGetPrintHeaderOperationHeader(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(`"PartnerKey":{"type":"apiKey","in":"header","name":"X-Partner-Key"}`),
+			openAPIPaths(openAPIGet("/partner", "partnerReport", `"security":[{"PartnerKey":[]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "sekret")),
+	})))
+
+	c, out := env.newCaptureCLI()
+	if err := c.Run([]string{"restish", "api", "auth", "get", "tapi", "--operation", "partner-report", "--print-header"}); err != nil {
+		t.Fatalf("api auth get operation --print-header: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "X-Partner-Key: sekret" {
+		t.Fatalf("auth get operation --print-header = %q, want X-Partner-Key: sekret", got)
+	}
+}
+
+func TestAPIAuthGetPrintHeaderOperationQueryFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(`"PartnerKey":{"type":"apiKey","in":"query","name":"partner"}`),
+			openAPIPaths(openAPIGet("/partner", "partnerReport", `"security":[{"PartnerKey":[]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"PartnerKey": testCredential(apiKeyAuth("query", "partner", "sekret")),
+	})))
+
+	c, _ := env.newCaptureCLI()
+	err := c.Run([]string{"restish", "api", "auth", "get", "tapi", "--operation", "partner-report", "--print-header"})
+	if err == nil {
+		t.Fatal("expected operation --print-header on query auth to fail")
+	}
+	if !strings.Contains(err.Error(), "query parameter") {
+		t.Errorf("error = %q, want it to mention query parameter", err)
+	}
+}
+
+func TestAPIAuthGetPrintHeaderOperationNoHeaderFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(`"NoHeader":{"type":"apiKey","in":"header","name":"X-No-Header"}`),
+			openAPIPaths(openAPIGet("/silent", "silentReport", `"security":[{"NoHeader":[]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"NoHeader": testCredential(&config.AuthConfig{Type: "noop-auth"}),
+	})))
+
+	c, _ := env.newCaptureCLI()
+	c.AddAuthHandler("noop-auth", noopAuthHandler{})
+	err := c.Run([]string{"restish", "api", "auth", "get", "tapi", "--operation", "silent-report", "--print-header"})
+	if err == nil {
+		t.Fatal("expected operation --print-header with no header to fail")
+	}
+	if !strings.Contains(err.Error(), "did not produce a header value") {
+		t.Errorf("error = %q, want it to mention no header value", err)
+	}
+}
+
+func TestAPIAuthGetPrintHeaderOperationMultipleHeadersFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(
+				`"UserKey":{"type":"apiKey","in":"header","name":"X-User-Key"}`,
+				`"PartnerKey":{"type":"apiKey","in":"header","name":"X-Partner-Key"}`),
+			openAPIPaths(openAPIGet("/signed", "signedReport", `"security":[{"UserKey":[],"PartnerKey":[]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"UserKey":    testCredential(apiKeyAuth("header", "X-User-Key", "user-secret")),
+		"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "partner-secret")),
+	})))
+
+	c, _ := env.newCaptureCLI()
+	err := c.Run([]string{"restish", "api", "auth", "get", "tapi", "--operation", "signed-report", "--print-header"})
+	if err == nil {
+		t.Fatal("expected operation --print-header with multiple headers to fail")
+	}
+	if !strings.Contains(err.Error(), "produced multiple header values") {
+		t.Errorf("error = %q, want it to mention multiple header values", err)
 	}
 }

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -760,3 +760,32 @@ func TestAPIAuthGetCredentialAPIKeyQuery(t *testing.T) {
 		t.Fatalf("auth get query = %q, want ?partner=secret", got)
 	}
 }
+
+func TestAPIAuthGetPrintHeaderHeader(t *testing.T) {
+	cfgFile := writeAPIConfigObject(t, "myapi", testAPIConfig("https://api.example.com", profileCredentials(map[string]*config.CredentialConfig{
+		"PartnerKey": testCredential(apiKeyAuth("header", "X-API-Key", "secret")),
+	})))
+
+	app := newTestApp(t)
+	app.SetConfigPath(cfgFile)
+	app.Run("api", "auth", "get", "myapi", "PartnerKey", "--print-header")
+	if got := strings.TrimSpace(app.Stdout.String()); got != "X-API-Key: secret" {
+		t.Fatalf("auth get --print-header = %q, want %q", got, "X-API-Key: secret")
+	}
+}
+
+func TestAPIAuthGetPrintHeaderQueryFails(t *testing.T) {
+	cfgFile := writeAPIConfigObject(t, "myapi", testAPIConfig("https://api.example.com", profileCredentials(map[string]*config.CredentialConfig{
+		"PartnerKey": testCredential(apiKeyAuth("query", "partner", "secret")),
+	})))
+
+	app := newTestApp(t)
+	app.SetConfigPath(cfgFile)
+	err := app.RunErr("api", "auth", "get", "myapi", "PartnerKey", "--print-header")
+	if err == nil {
+		t.Fatal("expected --print-header on query auth to fail")
+	}
+	if !strings.Contains(err.Error(), "query parameter") {
+		t.Errorf("error = %q, want it to mention query parameter", err)
+	}
+}

--- a/internal/cli/api_auth_test.go
+++ b/internal/cli/api_auth_test.go
@@ -799,6 +799,22 @@ func TestAPIAuthGetPrintHeaderQueryFails(t *testing.T) {
 	}
 }
 
+func TestAPIAuthGetPrintHeaderCookieFails(t *testing.T) {
+	cfgFile := writeAPIConfigObject(t, "myapi", testAPIConfig("https://api.example.com", profileCredentials(map[string]*config.CredentialConfig{
+		"Session": testCredential(apiKeyAuth("cookie", "session", "secret")),
+	})))
+
+	app := newTestApp(t)
+	app.SetConfigPath(cfgFile)
+	err := app.RunErr("api", "auth", "get", "myapi", "Session", "--print-header")
+	if err == nil {
+		t.Fatal("expected --print-header on cookie auth to fail")
+	}
+	if !strings.Contains(err.Error(), "cookie") {
+		t.Errorf("error = %q, want it to mention cookie", err)
+	}
+}
+
 func TestAPIAuthGetPrintHeaderOperationHeader(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
@@ -839,6 +855,28 @@ func TestAPIAuthGetPrintHeaderOperationQueryFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "query parameter") {
 		t.Errorf("error = %q, want it to mention query parameter", err)
+	}
+}
+
+func TestAPIAuthGetPrintHeaderOperationCookieFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Auth API",
+			openAPISecuritySchemes(`"Session":{"type":"apiKey","in":"cookie","name":"session"}`),
+			openAPIPaths(openAPIGet("/session", "sessionReport", `"security":[{"Session":[]}]`)))
+	})
+	env.writeAPIConfig(t, testAPIConfig(env.baseURL(t), profileCredentials(map[string]*config.CredentialConfig{
+		"Session": testCredential(apiKeyAuth("cookie", "session", "sekret")),
+	})))
+
+	c, _ := env.newCaptureCLI()
+	err := c.Run([]string{"restish", "api", "auth", "get", "tapi", "--operation", "session-report", "--print-header"})
+	if err == nil {
+		t.Fatal("expected operation --print-header on cookie auth to fail")
+	}
+	if !strings.Contains(err.Error(), "cookie") {
+		t.Errorf("error = %q, want it to mention cookie", err)
 	}
 }
 

--- a/internal/cli/help_text.go
+++ b/internal/cli/help_text.go
@@ -56,7 +56,8 @@ const apiAuthLogoutLong = "Delete cached API auth tokens.\n\n" +
 	"- Use `--auth-profile` to clear a shared auth profile cache without naming an API."
 
 const apiAuthGetLong = "Print curl-friendly auth material that Restish would apply for an API profile.\n\n" +
-	"Use this when another tool, such as curl, needs the configured auth without sending the target request through Restish. Header auth prints as `Name: value`; query auth prints as `?name=value`. Pass a credential ID when the profile has more than one configured credential, or use `--operation` to inspect operation-specific security requirements."
+	"Use this when another tool, such as curl, needs the configured auth without sending the target request through Restish. Header auth prints as `Name: value`; query auth prints as `?name=value`. Pass a credential ID when the profile has more than one configured credential, or use `--operation` to inspect operation-specific security requirements.\n\n" +
+	"Add `--print-header` to print the single resolved auth header as `Name: value` on stdout and exit non-zero for any non-header auth. This is the stable, parseable contract for shell scripts and external tools that need just the bearer header."
 
 const apiAuthInspectLong = "Inspect auth readiness and material for an API profile.\n\n" +
 	"By default this shows configured credentials, generated-operation coverage, and the auth values Restish would apply. Use `--operation` for operation-specific OpenAPI security requirements or `--credential` for one credential binding. Add `--redact` before sharing output so sensitive header, token, and credential values are masked."

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -148,7 +148,7 @@ func parseLegacyConfig(source *legacyConfigSource) (*config.Config, []string, er
 	for name, legacy := range raw {
 		api, apiWarnings, err := config.ConvertLegacyAPI(name, legacy)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("config: parsing %s entry %q: %w", source.apisPath, name, err)
 		}
 		cfg.APIs[name] = api
 		warnings = append(warnings, apiWarnings...)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/rest-sh/restish/v2/config"
@@ -21,37 +20,6 @@ type legacyConfigSource struct {
 	configPath string
 	apisData   []byte
 	configData []byte
-}
-
-type legacyAPIAuth struct {
-	Name   string            `json:"name"`
-	Params map[string]string `json:"params,omitempty"`
-}
-
-type legacyPKCS11Config struct {
-	Path  string `json:"path,omitempty"`
-	Label string `json:"label,omitempty"`
-}
-
-type legacyTLSConfig struct {
-	PKCS11 *legacyPKCS11Config `json:"pkcs11,omitempty"`
-	Cert   string              `json:"cert,omitempty"`
-	Key    string              `json:"key,omitempty"`
-}
-
-type legacyAPIProfile struct {
-	Base    string            `json:"base,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Query   map[string]string `json:"query,omitempty"`
-	Auth    *legacyAPIAuth    `json:"auth,omitempty"`
-}
-
-type legacyAPIConfig struct {
-	Base          string                       `json:"base"`
-	OperationBase string                       `json:"operation_base,omitempty"`
-	SpecFiles     []string                     `json:"spec_files,omitempty"`
-	Profiles      map[string]*legacyAPIProfile `json:"profiles,omitempty"`
-	TLS           *legacyTLSConfig             `json:"tls,omitempty"`
 }
 
 func loadOrMigrate(path string) (*config.Config, error) {
@@ -178,166 +146,30 @@ func parseLegacyConfig(source *legacyConfigSource) (*config.Config, []string, er
 	var warnings []string
 	cfg.APIs = make(map[string]*config.APIConfig, len(raw))
 	for name, legacy := range raw {
-		api, apiWarnings := convertLegacyAPIConfig(name, legacy)
+		api, apiWarnings, err := config.ConvertLegacyAPI(name, legacy)
+		if err != nil {
+			return nil, nil, err
+		}
 		cfg.APIs[name] = api
 		warnings = append(warnings, apiWarnings...)
 	}
 	return cfg, warnings, nil
 }
 
-func parseLegacyAPIMap(path string, data []byte) (map[string]*legacyAPIConfig, error) {
+func parseLegacyAPIMap(path string, data []byte) (map[string]json.RawMessage, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(jsonc.ToJSON(data), &raw); err != nil {
 		return nil, &config.ParseError{Path: path, Err: err}
 	}
 
-	result := make(map[string]*legacyAPIConfig, len(raw))
+	result := make(map[string]json.RawMessage, len(raw))
 	for name, value := range raw {
 		if name == "$schema" {
 			continue
 		}
-		var cfg legacyAPIConfig
-		if err := json.Unmarshal(value, &cfg); err != nil {
-			return nil, &config.ParseError{Path: path, Err: err}
-		}
-		result[name] = &cfg
+		result[name] = value
 	}
 	return result, nil
-}
-
-func convertLegacyAPIConfig(name string, legacy *legacyAPIConfig) (*config.APIConfig, []string) {
-	if legacy == nil {
-		return &config.APIConfig{}, nil
-	}
-	operationBase, warning := convertLegacyOperationBase(name, legacy.OperationBase)
-
-	api := &config.APIConfig{
-		BaseURL:       legacy.Base,
-		OperationBase: operationBase,
-		SpecFiles:     append([]string(nil), legacy.SpecFiles...),
-	}
-	if len(legacy.Profiles) > 0 {
-		api.Profiles = make(map[string]*config.ProfileConfig, len(legacy.Profiles))
-		for name, profile := range legacy.Profiles {
-			api.Profiles[name] = convertLegacyProfile(profile)
-		}
-	}
-
-	var migratedPKCS11 bool
-	if legacy.TLS != nil && legacy.TLS.PKCS11 != nil {
-		if api.Profiles == nil {
-			api.Profiles = map[string]*config.ProfileConfig{}
-		}
-		prof := api.Profiles["default"]
-		if prof == nil {
-			prof = &config.ProfileConfig{}
-			api.Profiles["default"] = prof
-		}
-		if prof.TLSSigner == "" {
-			prof.TLSSigner = "pkcs11"
-		}
-		if prof.TLSSignerParams == nil {
-			prof.TLSSignerParams = map[string]string{}
-		}
-		if legacy.TLS.PKCS11.Path != "" && prof.TLSSignerParams["path"] == "" {
-			prof.TLSSignerParams["path"] = legacy.TLS.PKCS11.Path
-		}
-		if legacy.TLS.PKCS11.Label != "" && prof.TLSSignerParams["label"] == "" {
-			prof.TLSSignerParams["label"] = legacy.TLS.PKCS11.Label
-		}
-		migratedPKCS11 = true
-	}
-
-	if legacy.TLS != nil && (legacy.TLS.Cert != "" || legacy.TLS.Key != "") {
-		if api.Profiles == nil {
-			api.Profiles = map[string]*config.ProfileConfig{}
-		}
-		prof := api.Profiles["default"]
-		if prof == nil {
-			prof = &config.ProfileConfig{}
-			api.Profiles["default"] = prof
-		}
-		if prof.ClientCertPath == "" && legacy.TLS.Cert != "" {
-			prof.ClientCertPath = legacy.TLS.Cert
-		}
-		if prof.ClientKeyPath == "" && legacy.TLS.Key != "" {
-			prof.ClientKeyPath = legacy.TLS.Key
-		}
-	}
-
-	var warnings []string
-	if warning != "" {
-		warnings = append(warnings, warning)
-	}
-	if migratedPKCS11 {
-		warnings = append(warnings, fmt.Sprintf("api %q: migrated PKCS#11 TLS config; install the restish-pkcs11 plugin to continue using it (see https://github.com/rest-sh/restish)", name))
-	}
-	return api, warnings
-}
-
-func convertLegacyOperationBase(apiName, operationBase string) (string, string) {
-	if operationBase == "" {
-		return "", ""
-	}
-	if err := config.ValidateOperationBase(operationBase); err == nil {
-		return operationBase, ""
-	}
-	return "", fmt.Sprintf("api %q: dropped invalid legacy operation_base %q; v2 operation_base must be an absolute path", apiName, operationBase)
-}
-
-func convertLegacyProfile(legacy *legacyAPIProfile) *config.ProfileConfig {
-	if legacy == nil {
-		return &config.ProfileConfig{}
-	}
-
-	prof := &config.ProfileConfig{
-		BaseURL: legacy.Base,
-		Headers: sortedHeaderList(legacy.Headers),
-		Query:   sortedQueryList(legacy.Query),
-	}
-	if legacy.Auth != nil {
-		prof.Auth = &config.AuthConfig{
-			Type:   legacy.Auth.Name,
-			Params: cloneStringMap(legacy.Auth.Params),
-		}
-	}
-	return prof
-}
-
-func sortedHeaderList(values map[string]string) []string {
-	return sortedPairs(values, ": ")
-}
-
-func sortedQueryList(values map[string]string) []string {
-	return sortedPairs(values, "=")
-}
-
-func sortedPairs(values map[string]string, sep string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	items := make([]string, 0, len(keys))
-	for _, key := range keys {
-		items = append(items, key+sep+values[key])
-	}
-	return items
-}
-
-func cloneStringMap(values map[string]string) map[string]string {
-	if len(values) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(values))
-	for key, value := range values {
-		out[key] = value
-	}
-	return out
 }
 
 func prepareLegacyBackup(source *legacyConfigSource, preferredDir string) (string, error) {
@@ -507,11 +339,10 @@ func ReadAll(folder string) (map[string]*config.APIConfig, error) {
 		if strings.HasPrefix(name, "$") {
 			continue
 		}
-		var v1 legacyAPIConfig
-		if err := json.Unmarshal(r, &v1); err != nil {
+		api, _, err := config.ConvertLegacyAPI(name, r)
+		if err != nil {
 			return nil, fmt.Errorf("config: parsing %s entry %q: %w", v1Path, name, err)
 		}
-		api, _ := convertLegacyAPIConfig(name, &v1)
 		out[name] = api
 	}
 	return out, nil

--- a/internal/config/read_embedder_test.go
+++ b/internal/config/read_embedder_test.go
@@ -80,6 +80,24 @@ func TestReadAllV1Fallback(t *testing.T) {
 	}
 }
 
+func TestParseLegacyConfigConvertErrorIncludesPathAndEntry(t *testing.T) {
+	dir := t.TempDir()
+	source := &legacyConfigSource{
+		dir:      dir,
+		apisPath: filepath.Join(dir, "apis.json"),
+		apisData: []byte(`{"broken":[]}`),
+	}
+
+	_, _, err := parseLegacyConfig(source)
+	if err == nil {
+		t.Fatal("expected malformed legacy entry error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, source.apisPath) || !strings.Contains(msg, `entry "broken"`) {
+		t.Fatalf("error = %q, want apis.json path and entry name", msg)
+	}
+}
+
 func TestReadAllV2ReadErrorDoesNotFallback(t *testing.T) {
 	dir := t.TempDir()
 	v2Path := filepath.Join(dir, "restish.json")

--- a/site/content/en/docs/getting-started/upgrade-from-v1.md
+++ b/site/content/en/docs/getting-started/upgrade-from-v1.md
@@ -123,6 +123,7 @@ Use this as the fast lookup table when muscle memory collides with v2.
 | n/a                                   | `restish api set <name> 'path:value'`                       | shorthand updates support set/append/delete           |
 | `restish api clear-auth-cache <name>` | `restish api auth logout <name>`                            | Token cache state lives under `api auth`              |
 | `restish api auth inspect <uri>`      | `restish api auth get <api>`                                | URL form was replaced by API/profile-aware inspection |
+| `restish auth-header <profile>`       | `restish api auth get <api> --print-header`                 | Print the single resolved header as `Name: value`; non-header auth exits non-zero |
 | `auth.name`                           | `auth.type`                                                 | Profile auth config field renamed                     |
 | profile `base`                        | profile `base_url`                                          | API/profile base field renamed                        |
 | API `base`                            | API `base_url`                                              | API base field renamed                                |

--- a/site/content/en/docs/reference/api-management.md
+++ b/site/content/en/docs/reference/api-management.md
@@ -374,6 +374,8 @@ Print curl-friendly auth material that Restish would apply for an API profile.
 
 Use this when another tool, such as curl, needs the configured auth without sending the target request through Restish. Header auth prints as `Name: value`; query auth prints as `?name=value`. Pass a credential ID when the profile has more than one configured credential, or use `--operation` to inspect operation-specific security requirements.
 
+Add `--print-header` to print the single resolved auth header as `Name: value` on stdout and exit non-zero for any non-header auth. This is the stable, parseable contract for shell scripts and external tools that need just the bearer header.
+
 Usage:
 
 ```text
@@ -387,6 +389,7 @@ Examples:
   restish api auth get demo PartnerKey
   restish api auth get demo --operation list-items
   curl -H "$(restish api auth get demo UserBearer)" https://api.rest.sh/items
+  export AUTH_HEADER="$("restish" api auth get demo --print-header)"
 ```
 
 Flags:
@@ -396,6 +399,12 @@ Flags:
 Type: `string`; default: none
 
 Operation ID or command name to inspect
+
+**`--print-header`**
+
+Type: `bool`; default: `false`
+
+Print the single resolved header as 'Name: value' on stdout and exit non-zero for any non-header auth
 
 
 


### PR DESCRIPTION
Follow-up to #378, #379, and #382. PR #381 only exposed `config` and `auth`; this adds the remaining embedder surface #382 asks for.

## What's new

### `config` package
- `ConvertLegacyAPI(name, raw) (*APIConfig, []string, error)` — convert one `apis.json` entry to v2 shape, returns migration warnings.
- `ReadLegacyAPI(folder, name)` and `ReadLegacyAPIs(folder)` — read APIs from `apis.json`, empty map when missing, no disk writes.

Wrappers around `config/migrate.go:convertLegacyAPIConfig`. The CLI's automatic v1->v2 migration is still `internal/`.

### v1 -> v2 migration fix: `tls.ca_cert` carries over
`migrate.go:256` was missing `legacy.TLS.CACert`. A v1 entry with a custom CA bundle now migrates to v2 `profile.ca_cert`, matching the v1 -> v2 table in #382.

### `restish api auth get --print-header`
- Single resolved header auth: prints `Name: value`, exits 0.
- Query / cookie / multi-header / mixed: exits non-zero with a clear error.

Without `--print-header`, behaviour is unchanged.

## Docs
Regenerated via `restish-docgen --write`. `AGENTS.md`, `docs/design/002-config-and-profiles.md`, and `upgrade-from-v1.md` updated.

## Fixes
Closes #382 (sections 1 and 2). Section 3 was already fixed by `caef5e4`, which promoted `fileutil` to the public surface.
