### PR TITLE
feat(embed): add custom command surface

### DIFF
--- a/docs/design/042-custom-cli-embedding-surface.md
+++ b/docs/design/042-custom-cli-embedding-surface.md
@@ -1,0 +1,462 @@
+# Custom CLI Embedding Surface
+
+Status: accepted.
+
+## Problem
+
+Restish can already be embedded in a branded Go binary. An embedder can set the
+command name, install default config, register auth handlers, loaders,
+formatters, content types, encodings, and link parsers, then call `Run`.
+
+That is enough to build a custom binary, but not enough to make a polished
+single-API CLI. A binary such as `acme` should feel like the Acme API CLI, not
+like generic Restish with a different executable name:
+
+```text
+acme list-users
+acme get-user 123
+acme auth header
+acme cache clear
+```
+
+The current stock shape keeps generated API operations under the configured API
+name:
+
+```text
+acme api list-users
+```
+
+or, if the API is also named `acme`:
+
+```text
+acme acme list-users
+```
+
+That is a poor first impression for a shipped product CLI. At the same time,
+removing every Restish support command is too strict: auth inspection, cache
+cleanup, config display, shell completion, version output, and diagnostics are
+useful for scripting, CI, support tickets, and user recovery.
+
+## Goals
+
+- Let an embedder promote one configured API's generated operations to the CLI
+  root.
+- Keep the promoted API's generated commands present in help and dispatch on
+  first run by loading the configured spec source before commands are needed.
+- Keep a small support surface that uses app vocabulary rather than leaking the
+  Restish implementation name.
+- Preserve scriptability for auth headers, cache cleanup, config inspection,
+  diagnostics, completion, and version output.
+- Keep the public API small enough to maintain permanently.
+
+## Non-Goals
+
+- Do not expose the Cobra root command as the primary embedding API.
+- Do not add arbitrary custom Go command registration in the first pass.
+- Do not add generated-operation invocation by operation ID from Go in the
+  first pass.
+- Do not add a public embedded OpenAPI bytes helper in the first pass.
+- Do not add an immutable "never update OpenAPI from the network" embedded-spec
+  mode in the first pass.
+- Do not add arbitrary per-command-family visibility subsets until a real
+  embedder needs them.
+- Do not bundle out-of-process plugin executables into custom binaries.
+
+## Current Constraints
+
+The stock root command is built by the central `CLI` runtime. It owns global
+flags, grouped help, completions, builtin command families, generated API
+commands, plugin command discovery, request execution, auth, cache paths, and
+diagnostics.
+
+Generated OpenAPI commands are currently added as API command groups. The
+runtime loads generated metadata from cache when possible, rebuilds operation
+metadata from stale raw spec cache when needed, and can refresh stale remote
+metadata on generated command use. Local spec files are authoritative and
+invalidate stale metadata when changed.
+
+Stock startup and help intentionally do not trigger remote spec discovery. They
+load cached generated metadata, rebuild from raw cache, or reload local spec
+files, but a missing remote cache leaves the generated command group absent
+until the user runs `api sync` or invokes a generated-looking command under an
+API short name. That is the right default for the generic `restish` binary, but
+it is not enough for a branded promoted-root CLI: `acme --help` and
+`acme list-users` cannot depend on the user knowing to run a Restish-flavored
+sync command first.
+
+The existing discovery layer already supports explicit `spec_url`, local
+`spec_files`, and normal OpenAPI discovery from the API base URL. It writes the
+raw spec cache and extracted operation metadata in the same cache entry. The
+custom CLI work should reuse that machinery rather than add a new first-run
+spec source before it is proven necessary.
+
+The embedding API must not make embedders depend on internal packages or the
+exact Cobra tree. Anything exported from the root `restish` package is a
+long-term public promise.
+
+## Proposed Public Shape
+
+Names are placeholders until the implementation design is accepted. The desired
+developer experience is:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	restish "github.com/rest-sh/restish/v2"
+)
+
+func main() {
+	cli := restish.New()
+	cli.SetCommandName("acme")
+	cli.SetCommandDescription("Acme API CLI", "")
+	cli.SetDefaultConfig(&restish.Config{APIs: map[string]*restish.APIConfig{
+		"api": {
+			BaseURL: "https://api.acme.com",
+			SpecURL: "https://api.acme.com/openapi.yaml",
+		},
+	}})
+	cli.SetCommandSurface(restish.CommandSurface{
+		PromotedAPI: "api",
+	})
+
+	if err := cli.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+```
+
+The command surface options are intentionally a small public struct:
+
+```go
+type CommandSurface struct {
+	PromotedAPI string
+
+	SupportCommandNamespace string
+	HideSupportCommands     bool
+}
+```
+
+The design intent is:
+
+- The zero value preserves the stock Restish surface.
+- `PromotedAPI` promotes generated operations from the configured API to the
+  root command.
+- The promoted API is the primary API. There is no separate primary/default API
+  concept in the first pass.
+- Support commands stay at root by default when an API is promoted.
+- `SupportCommandNamespace` moves support commands under that command name, for
+  example `acme cli cache clear`.
+- `HideSupportCommands` removes support commands from the custom CLI surface.
+- `SupportCommandNamespace` and `HideSupportCommands` are mutually exclusive.
+- Support-command layout fields without `PromotedAPI` are invalid in the first
+  version.
+- Examples should configure `SpecURL` for predictable first-run behavior. A
+  promoted API may also use local `SpecFiles` or the normal discovery flow from
+  `BaseURL`, but a custom CLI that wants reliable help should provide an
+  explicit spec URL when possible.
+- There is no separate embedded spec API in the first version.
+
+## User-Facing Command Surface
+
+The default single-API surface is:
+
+```text
+acme <generated-operation> [...]
+acme auth
+acme cache
+acme config
+acme doctor
+acme completion
+acme version
+```
+
+The default single-API surface hides stock Restish control-plane commands that
+would distract from a branded API CLI:
+
+```text
+api
+plugin
+get|head|options|post|put|patch|delete
+shell
+links
+cert
+```
+
+Embedders may choose a fuller surface, hide support commands, or move the
+support commands under an embedder-owned namespace:
+
+```text
+acme cli cache clear
+acme cli auth header
+```
+
+Examples should use `cli` as the generic namespace because it describes support
+commands without exposing Restish as an implementation detail. Embedders may
+choose names such as `admin`, `support`, or `system`.
+
+## App-Shaped Support Commands
+
+Support commands at root must use the branded command name and product language
+in help text. They should not say "Restish" unless the text is explicitly about
+diagnostics for maintainers.
+
+### Auth
+
+Root `auth` exists for scripting and troubleshooting auth for the promoted API.
+It is a thin wrapper over existing `api auth` internals with the promoted API
+name injected. It must not duplicate token resolution logic.
+
+Supported root sugar:
+
+```text
+acme auth get [credential-id]
+acme auth get [credential-id] --operation <operation> [--print-header]
+acme auth header [credential-id] [--operation <operation>]
+acme auth inspect [--operation <operation>] [--credential <id>] [--redact]
+acme auth logout [--all-profiles] [--auth-profile <name>]
+```
+
+`auth header` is the preferred scripting primitive. It prints exactly:
+
+```text
+Name: value
+```
+
+and exits non-zero for query auth, cookie auth, missing auth, or multi-header
+auth. Restish should not add `auth token` as the first root sugar because many
+auth schemes are not bearer tokens.
+
+Root `auth add` and `auth remove` are deferred. If a custom CLI needs
+user-managed credential bindings before root sugar is expanded, the fuller
+advanced auth tree can live under the support namespace.
+
+### Cache
+
+Root `cache` reuses existing `cache info` and `cache clear` behavior. Do not
+change `cache clear` semantics silently: without an argument, it clears all HTTP
+cache entries.
+
+In the default single-API surface, generic HTTP and direct URL commands are
+hidden, so clearing all HTTP cache entries is acceptable. If a fuller surface
+keeps generic HTTP commands, `cache clear <api>` and `cache clear --direct`
+retain their existing meaning.
+
+### Config
+
+Root `config` reuses `path`, `show`, `set`, `edit`, and theme commands where
+retained. Help text must be app-shaped, for example "Manage local Acme CLI
+configuration" rather than "Manage local Restish configuration."
+
+`config show -o json` remains redacted and scriptable.
+
+### Doctor
+
+Root `doctor` diagnoses runtime paths, config, cache, auth cache permissions,
+and the promoted API's generated operation status.
+
+`doctor api` with no API argument diagnoses the promoted API. Full
+`doctor api <name>` and `doctor plugin <name>` belong in fuller surfaces or the
+support namespace.
+
+TTY diagnostics should use app vocabulary. JSON diagnostics may include enough
+Restish-specific detail for maintainers and support workflows.
+
+### Completion And Version
+
+`completion` and `version` remain available at root by default.
+
+`--version` must keep working even when the `version` command is hidden or moved
+under a namespace.
+
+## Spec Freshness And First-Run Help
+
+A custom single-API CLI should never show an empty operation list merely because
+the user has not run a sync command.
+
+For a promoted API, Restish should build the command tree from the best
+available source:
+
+1. fresh generated operation metadata
+2. fresh raw spec cache that can rebuild operation metadata
+3. the configured spec source, fetched or reloaded through the existing
+   discovery path and cached with extracted operations
+4. stale generated operation metadata or stale raw spec cache as last-known-good
+   when refresh fails
+5. a clear diagnostic if no source can produce generated operations
+
+The fetch-on-demand behavior is specific to promoted custom CLIs. The stock
+`restish` command should keep its current no-network startup and generic help
+behavior.
+
+Top-level help, generated operation help, and generated command execution for a
+promoted API may trigger spec discovery when no fresh command metadata is
+available. If stale metadata exists, Restish should attempt a bounded refresh
+and fall back to the stale last-known-good tree when refresh fails. The initial
+timeout should reuse the generated metadata refresh timeout, currently three
+seconds, so promoted custom CLIs do not introduce a second freshness policy.
+
+Completion should use the same metadata policy where practical, but shell
+completion must remain responsive. If completion cannot refresh within the
+bounded timeout, it should fall back to cached or stale command names rather
+than hanging the shell.
+
+Unknown-command handling for promoted roots must account for newly added remote
+operations. If a token looks like a generated operation and the promoted API has
+a refreshable spec source, Restish should try a bounded sync before returning an
+unknown-command error.
+
+`doctor` should report whether generated operations are fresh, stale, refreshed
+on demand, refresh-failed with stale fallback, or unavailable.
+
+## Command Collision Rules
+
+Generated operations, app support commands, and the optional support namespace
+must not silently shadow one another.
+
+If a promoted operation collides with a root support command such as `auth`,
+`cache`, or `doctor`, startup should fail with an actionable error that suggests
+moving support commands under a namespace or hiding them.
+
+If the chosen support namespace collides with a promoted operation, startup
+should fail with the same kind of actionable error.
+
+The stock Restish surface remains unchanged unless the embedder opts into a
+custom command surface.
+
+## Command Tree Construction
+
+The implementation should reuse the stock Restish command construction path
+instead of maintaining a second root builder for custom CLIs:
+
+- Build the normal Restish root command first.
+- Load generated commands through the existing generated-command path.
+- For promoted APIs, ensure generated metadata is available before root help,
+  generated operation help, completion, or command dispatch needs the promoted
+  command tree.
+- Reuse existing spec discovery and cache writes for configured `SpecURL`,
+  `SpecFiles`, and normal base-URL discovery.
+- Transform the command tree for the selected surface instead of maintaining a
+  separate root builder.
+- Skip adding the promoted API's normal wrapper/short-name command at root.
+- Move, hide, or retain builtin support commands according to
+  `SupportCommandNamespace` and `HideSupportCommands`.
+- Add only the minimal app-shaped auth sugar described above.
+- Reuse cache, config, and doctor behavior where possible, adjusting help text
+  and primary-API defaults rather than duplicating implementation.
+
+## Alternatives
+
+### Promote Operations And Hide All Support Commands
+
+This gives the ergonomic root promotion but removes useful operational tools
+such as auth inspection, cache cleanup, config display, completion, version, and
+diagnostics. It also pushes embedders toward rebuilding those tools in custom
+code.
+
+### Keep API Operations Under A Namespace
+
+This preserves current architecture but leaves custom CLIs with awkward command
+shapes such as `acme api list-users` or `acme acme list-users`.
+
+### Expose Raw Cobra Mutation
+
+This gives embedders maximum flexibility, but it turns the internal command tree
+into public API and makes help, completion, grouping, generated commands, and
+compatibility harder to preserve.
+
+### Add Full Custom Command Registration Now
+
+Custom Go commands are useful, but they need their own design for flags, args,
+I/O, global flags, completion, command grouping, and collision behavior. They
+are future work, not required to make single-API promotion useful.
+
+### Bundle OpenAPI Bytes In The First Pass
+
+A public helper for `go:embed` OpenAPI bytes is useful for offline help,
+pre-auth environments, and traditional CLIs that want command changes to follow
+binary releases. It also adds public API, cache identity, freshness,
+user-override, and diagnostics questions. Since a custom CLI that can reach the
+API should usually be able to fetch that API's OpenAPI document, the first pass
+should make configured spec fetch and cache behavior reliable before adding an
+embedded-spec helper.
+
+### Add Immutable Embedded Specs Now
+
+A "never update OpenAPI from the network" mode is useful for traditional
+release-driven CLIs, but it depends on the embedded-spec helper above and needs
+explicit decisions about user config overrides, sync behavior, and diagnostics.
+
+## Compatibility And Migration
+
+The default `restish` command surface remains unchanged.
+
+All new behavior is opt-in through the embedding API. A custom CLI that promotes
+an API opts into bounded spec fetches before help, completion, or generated
+command dispatch when cached metadata is missing or stale. Once exported,
+embedding types and methods must be treated as public and maintained
+additively.
+
+The public API must not expose internal packages, cache paths, Cobra command
+objects, or implementation-specific command grouping as stable contracts.
+
+## Security And Privacy
+
+OpenAPI documents may contain server URLs, examples, schemas, and operation
+metadata. They should not contain secrets. Diagnostics should avoid printing
+credential material or unredacted auth configuration.
+
+Promoted-root help and completion can make network requests when metadata is
+missing or stale. That behavior must stay bounded and must use the existing
+discovery transport, auth, TLS, redaction, and cross-origin protections.
+
+`auth header` prints credential material by design and must write only the
+single header line to stdout on success. Errors and diagnostics go to stderr via
+normal CLI error handling.
+
+Config and doctor output must preserve existing redaction behavior.
+
+## Testing Plan
+
+Add focused tests for:
+
+- promoted operation execution at root
+- promoted operation help at root on first run from configured `SpecURL`
+- promoted operation help when only stale cached metadata is available and
+  refresh fails
+- remote `spec_url` refresh populating raw spec and generated operation caches
+- local `SpecFiles` reload for promoted root help and execution
+- stale metadata fallback when refresh fails
+- unknown promoted operation triggering bounded refresh before error
+- collision with root support commands
+- collision with support namespace
+- support commands retained at root
+- support commands moved under a namespace
+- support commands hidden
+- `auth get`, `auth header`, `auth inspect`, and `auth logout` for the promoted
+  API
+- `auth header` failures for query, cookie, missing, and multi-header auth
+- cache clear semantics unchanged
+- branded config and doctor help text
+- completion and `--version` behavior
+- compile-time embedding example using the root `restish` package
+
+## Documentation Impact
+
+When implemented, update:
+
+- root package Go docs for embedding
+- a custom CLI embedding guide on the docs site
+- command reference/help generated regions if public command shape changes
+- this design record with the accepted public API names
+
+## Open Questions
+
+- How should JSON doctor output represent generated operation metadata source,
+  freshness, and the last refresh error?
+- Should the first official custom CLI example live under `examples/`, the docs
+  site, or both?

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -176,6 +176,7 @@ were a recurring source of remediation work.
 
 - [../plugin-quickstart.md](../plugin-quickstart.md) - Fastest path to a working plugin, with small formatter and command-plugin examples.
 - [018-plugin-architecture-overview.md](./018-plugin-architecture-overview.md) - Discovery, manifests, plugin trust model, lifecycle ownership, and the relationship to the in-process registry model.
+- [042-custom-cli-embedding-surface.md](./042-custom-cli-embedding-surface.md) - Proposed custom CLI embedding surface for single-API branded binaries, including root API promotion, on-demand spec refresh, support command placement, and app-shaped auth/cache/config/doctor sugar.
 - [019-hook-plugins.md](./019-hook-plugins.md) - Short-lived auth, middleware, loader, and formatter plugins, including timeout, error, and output contracts.
 - [020-command-plugins.md](./020-command-plugins.md) - Long-lived workflow commands that delegate HTTP and formatting back to Restish, with message lifecycle and stdio rules.
 - [021-tls-signer-plugins.md](./021-tls-signer-plugins.md) - External mTLS signing for hardware-backed or otherwise non-exportable client keys, including signer lifecycle and teardown.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# Restish Examples
+
+This directory contains small, buildable examples for embedding or extending
+Restish.
+
+- [example-cli](./example-cli/) shows a branded single-API CLI backed by
+  `https://api.rest.sh`, with generated OpenAPI operations promoted to the root
+  command.

--- a/examples/example-cli/README.md
+++ b/examples/example-cli/README.md
@@ -1,0 +1,44 @@
+# Example CLI
+
+This example is a small branded CLI built by embedding Restish. It uses
+`https://api.rest.sh` as the bundled API, fetches that API's OpenAPI document
+from `https://api.rest.sh/openapi.json`, and promotes generated operations to
+the root command.
+
+Build it from the repository root:
+
+```bash
+go build -o /tmp/example-cli ./examples/example-cli
+```
+
+Run it with an isolated temporary config file:
+
+```bash
+tmp_config="$(mktemp)"
+printf '{}' > "$tmp_config"
+chmod 600 "$tmp_config"
+RSH_CONFIG="$tmp_config" /tmp/example-cli --help
+RSH_CONFIG="$tmp_config" /tmp/example-cli list-items -o json
+```
+
+The important embedding pieces are in [main.go](./main.go):
+
+```go
+cli.SetCommandName("example")
+cli.SetCommandDescription("Example CLI", "Example CLI for api.rest.sh.")
+cli.SetDefaultConfig(&restish.Config{APIs: map[string]*restish.APIConfig{
+	"api": {
+		BaseURL: "https://api.rest.sh",
+		SpecURL: "https://api.rest.sh/openapi.json",
+	},
+}})
+cli.SetCommandSurface(restish.CommandSurface{
+	PromotedAPI: "api",
+})
+```
+
+Use this as a starting point by changing the command name, description, API
+base URL, OpenAPI spec URL, default profiles, and auth configuration. Keep the
+API key `"api"` unless you have a reason to expose more than one API; it keeps
+the public command shape focused on generated operations such as
+`example list-items`.

--- a/examples/example-cli/main.go
+++ b/examples/example-cli/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	restish "github.com/rest-sh/restish/v2"
+)
+
+func main() {
+	cli := restish.New()
+	cli.SetCommandName("example")
+	cli.SetCommandDescription("Example CLI", "Example CLI for api.rest.sh.")
+	cli.SetDefaultConfig(&restish.Config{APIs: map[string]*restish.APIConfig{
+		"api": {
+			BaseURL: "https://api.rest.sh",
+			SpecURL: "https://api.rest.sh/openapi.json",
+		},
+	}})
+	cli.SetCommandSurface(restish.CommandSurface{
+		PromotedAPI: "api",
+	})
+
+	if err := cli.Run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -373,9 +373,27 @@ func (c *CLI) runAPIAuthInspectOperation(cmd *cobra.Command, apiName, profileNam
 }
 
 func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
+	fragment, err := c.apiAuthGetFragment(cmd, args)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.Stdout, fragment)
+	return nil
+}
+
+func (c *CLI) apiAuthGetFragment(cmd *cobra.Command, args []string) (string, error) {
+	printHeader, _ := cmd.Flags().GetBool("print-header")
+	return c.apiAuthGetFragmentMode(cmd, args, printHeader)
+}
+
+func (c *CLI) apiAuthGetHeaderFragment(cmd *cobra.Command, args []string) (string, error) {
+	return c.apiAuthGetFragmentMode(cmd, args, true)
+}
+
+func (c *CLI) apiAuthGetFragmentMode(cmd *cobra.Command, args []string, printHeader bool) (string, error) {
 	apiName := args[0]
 	if looksLikeURLArgument(apiName) {
-		return fmt.Errorf("api auth get expects an API name, not a URL")
+		return "", fmt.Errorf("api auth get expects an API name, not a URL")
 	}
 	credentialID := ""
 	if len(args) == 2 {
@@ -384,47 +402,53 @@ func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
 	profileName := c.profileFromCmd(cmd)
 	apiCfg, prof, err := c.apiProfileForAuth(apiName, profileName, false)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if operation, _ := cmd.Flags().GetString("operation"); operation != "" {
 		if credentialID != "" {
-			return fmt.Errorf("--operation and credential ID are mutually exclusive")
+			return "", fmt.Errorf("--operation and credential ID are mutually exclusive")
 		}
-		printHeader, _ := cmd.Flags().GetBool("print-header")
-		return c.runAPIAuthGetOperation(cmd, apiName, profileName, apiCfg, prof, operation, printHeader)
+		return c.apiAuthGetOperationFragment(cmd, apiName, profileName, apiCfg, prof, operation, printHeader)
 	}
 	if credentialID == "" {
 		resolvedProfile, err := c.resolveProfileAuth(apiName, profileName, prof)
 		if err != nil {
-			return err
+			return "", err
 		}
 		if resolvedProfile.Config == nil {
 			ids := configuredCredentialIDs(prof)
 			if len(ids) > 1 {
-				return fmt.Errorf("profile %q of API %q has multiple configured credentials (%s); pass a credential ID: %s api auth get %s <credential-id>", profileName, apiName, strings.Join(ids, ", "), c.commandNameOrDefault(), apiName)
+				return "", fmt.Errorf("profile %q of API %q has multiple configured credentials (%s); pass a credential ID: %s api auth get %s <credential-id>", profileName, apiName, strings.Join(ids, ", "), c.commandNameOrDefault(), apiName)
 			}
 		}
 	}
 
 	resolved, _, err := c.resolveAuthInspectionConfig(apiName, profileName, prof, credentialID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if resolved.Config == nil {
-		return c.missingAuthConfigError(apiName, profileName)
+		return "", c.missingAuthConfigError(apiName, profileName)
 	}
 	req, err := c.authInspectionRequest(cmd, apiName, profileName, resolved)
 	if err != nil {
-		return err
+		return "", err
 	}
 	configs := []*config.AuthConfig{resolved.Config}
-	printHeader, _ := cmd.Flags().GetBool("print-header")
 	if printHeader {
-		return c.runAPIAuthGetPrintHeader(req, configs, apiName, profileName)
+		return authHeaderFragment(req, configs, apiName, profileName)
 	}
 	fragment, err := authGetFragment(req, configs)
 	if err != nil {
-		return fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName)
+		return "", fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName)
+	}
+	return fragment, nil
+}
+
+func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string, printHeader bool) error {
+	fragment, err := c.apiAuthGetOperationFragment(cmd, apiName, profileName, apiCfg, prof, operationName, printHeader)
+	if err != nil {
+		return err
 	}
 	fmt.Fprintln(c.Stdout, fragment)
 	return nil
@@ -437,11 +461,20 @@ func (c *CLI) runAPIAuthGet(cmd *cobra.Command, args []string) error {
 // and external Go binaries use to obtain a bearer token without going
 // through the restish CLI's full request flow.
 func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.AuthConfig, apiName, profileName string) error {
+	fragment, err := authHeaderFragment(req, configs, apiName, profileName)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.Stdout, fragment)
+	return nil
+}
+
+func authHeaderFragment(req *http.Request, configs []*config.AuthConfig, apiName, profileName string) (string, error) {
 	if req.URL != nil && req.URL.RawQuery != "" {
-		return fmt.Errorf("auth for %s:%s is applied as a query parameter, not a header; --print-header is not applicable", apiName, profileName)
+		return "", fmt.Errorf("auth for %s:%s is applied as a query parameter, not a header; --print-header is not applicable", apiName, profileName)
 	}
 	if authInspectionAppliesCookie(configs) {
-		return fmt.Errorf("auth for %s:%s is applied as a cookie, not a header; --print-header is not applicable", apiName, profileName)
+		return "", fmt.Errorf("auth for %s:%s is applied as a cookie, not a header; --print-header is not applicable", apiName, profileName)
 	}
 	headers := 0
 	var name, value string
@@ -456,12 +489,11 @@ func (c *CLI) runAPIAuthGetPrintHeader(req *http.Request, configs []*config.Auth
 	}
 	switch headers {
 	case 0:
-		return fmt.Errorf("auth for %s:%s did not produce a header value", apiName, profileName)
+		return "", fmt.Errorf("auth for %s:%s did not produce a header value", apiName, profileName)
 	case 1:
-		fmt.Fprintf(c.Stdout, "%s: %s\n", name, value)
-		return nil
+		return name + ": " + value, nil
 	default:
-		return fmt.Errorf("auth for %s:%s produced multiple header values; --print-header expects a single header", apiName, profileName)
+		return "", fmt.Errorf("auth for %s:%s produced multiple header values; --print-header expects a single header", apiName, profileName)
 	}
 }
 
@@ -474,19 +506,19 @@ func authInspectionAppliesCookie(configs []*config.AuthConfig) bool {
 	return false
 }
 
-func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string, printHeader bool) error {
+func (c *CLI) apiAuthGetOperationFragment(cmd *cobra.Command, apiName, profileName string, apiCfg *config.APIConfig, prof *config.ProfileConfig, operationName string, printHeader bool) (string, error) {
 	op, ok, err := c.cachedOperationForAPI(requestContext(cmd), apiName, apiCfg, profileName, operationName)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if !ok {
-		return fmt.Errorf("operation %q not found in cached metadata for API %q; run \"restish api sync %s\"", operationName, apiName, apiName)
+		return "", fmt.Errorf("operation %q not found in cached metadata for API %q; run \"restish api sync %s\"", operationName, apiName, apiName)
 	}
 	if op.NoAuth {
-		return fmt.Errorf("operation %q has security: [] and does not send auth material", op.ID)
+		return "", fmt.Errorf("operation %q has security: [] and does not send auth material", op.ID)
 	}
 	if op.OptionalAuth && len(op.CredentialAlternatives) == 0 {
-		return fmt.Errorf("operation %q has anonymous-only security and does not send auth material", op.ID)
+		return "", fmt.Errorf("operation %q has anonymous-only security and does not send auth material", op.ID)
 	}
 
 	var selected []selectedOperationAuth
@@ -497,36 +529,35 @@ func (c *CLI) runAPIAuthGetOperation(cmd *cobra.Command, apiName, profileName st
 			CredentialAlternatives: op.CredentialAlternatives,
 		})
 		if err != nil {
-			return err
+			return "", err
 		}
 		if !selectedOK || len(selected) == 0 {
-			return fmt.Errorf("operation %q did not select auth material", op.ID)
+			return "", fmt.Errorf("operation %q did not select auth material", op.ID)
 		}
 	} else {
 		resolved, selectedCredential, err := c.resolveAuthInspectionConfig(apiName, profileName, prof, "")
 		if err != nil {
-			return err
+			return "", err
 		}
 		if resolved.Config == nil {
-			return fmt.Errorf("profile %q of API %q has no auth config", profileName, apiName)
+			return "", fmt.Errorf("profile %q of API %q has no auth config", profileName, apiName)
 		}
 		selected = []selectedOperationAuth{{requirement: spec.CredentialRequirement{ID: selectedCredential}, resolved: resolved, source: "profile auth"}}
 	}
 
 	req, err := c.operationAuthInspectionRequest(cmd, apiName, profileName, selected)
 	if err != nil {
-		return err
+		return "", err
 	}
 	configs := selectedOperationAuthConfigs(selected)
 	if printHeader {
-		return c.runAPIAuthGetPrintHeader(req, configs, apiName, profileName)
+		return authHeaderFragment(req, configs, apiName, profileName)
 	}
 	fragment, err := authGetFragment(req, configs)
 	if err != nil {
-		return fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName+" --operation "+operationName)
+		return "", fmt.Errorf("%w; run %q for details", err, c.commandNameOrDefault()+" api auth inspect "+apiName+" --operation "+operationName)
 	}
-	fmt.Fprintln(c.Stdout, fragment)
-	return nil
+	return fragment, nil
 }
 
 func authGetFragment(req *http.Request, configs []*config.AuthConfig) (string, error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -128,6 +128,7 @@ type CLI struct {
 	silentMode              bool
 	requestExecutionStarted bool
 	bodyPrefixHinted        bool
+	commandSurface          CommandSurface
 	runCtx                  context.Context
 	projectConfig           *projectConfigState
 }
@@ -627,7 +628,7 @@ func (c *CLI) Run(args []string) error {
 		return fmt.Errorf("config theme: %w", err)
 	}
 	for apiName := range cfg.APIs {
-		if isBuiltinCommandName(apiName) {
+		if isBuiltinCommandName(apiName) && !c.isPromotedAPI(apiName) {
 			return fmt.Errorf("config: API name %q conflicts with a built-in command; rename it before continuing", apiName)
 		}
 		if err := config.ValidateAPIName(apiName); err != nil {
@@ -665,7 +666,12 @@ func (c *CLI) Run(args []string) error {
 
 	root := c.newRootCmd()
 	c.quietGeneratedWarnings = quietGeneratedWarningsForScan(argScan, cfg)
-	c.refreshStaleGeneratedMetadataForCommand(ctx, argScan, cfg)
+	if err := c.ensurePromotedAPICommandMetadata(ctx, argScan, cfg); err != nil {
+		return err
+	}
+	if !c.hasPromotedAPI() {
+		c.refreshStaleGeneratedMetadataForCommand(ctx, argScan, cfg)
+	}
 
 	// Register generated commands for APIs whose spec is already cached.
 	// When the first positional arg names a configured API, only load that
@@ -673,6 +679,7 @@ func (c *CLI) Run(args []string) error {
 	// (Network discovery is not triggered here; use "restish api sync <name>"
 	// to prime the cache for an API.)
 	startupProfile := argScan.ProfileName
+	var promotedAPICmd *cobra.Command
 	for _, apiName := range c.generatedAPINamesForScan(argScan, cfg) {
 		apiCfg := cfg.APIs[apiName]
 		opOpts := spec.OperationOptions{
@@ -683,7 +690,14 @@ func (c *CLI) Run(args []string) error {
 		stateName := c.apiStateName(apiName)
 		if set, _, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opOpts, true); ok {
 			if apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set, opOpts.OperationBase); apiCmd != nil {
-				root.AddCommand(apiCmd)
+				if c.isPromotedAPI(apiName) {
+					promotedAPICmd = apiCmd
+					if !rootHasCommand(root, apiName) {
+						root.AddCommand(apiCmd)
+					}
+				} else {
+					root.AddCommand(apiCmd)
+				}
 			}
 			continue
 		}
@@ -702,10 +716,20 @@ func (c *CLI) Run(args []string) error {
 			_ = spec.StoreOperationSetInCache(c.specCacheDir(), stateName, Version, opOpts, set)
 		}
 		if apiCmd := c.buildAPICommandFromOperationResult(apiName, apiCfg, set, opOpts.OperationBase, opsErr); apiCmd != nil {
-			root.AddCommand(apiCmd)
+			if c.isPromotedAPI(apiName) {
+				promotedAPICmd = apiCmd
+				if !rootHasCommand(root, apiName) {
+					root.AddCommand(apiCmd)
+				}
+			} else {
+				root.AddCommand(apiCmd)
+			}
 		}
 	}
 	c.addAPIShortNameCommands(root, cfg)
+	if err := c.applyCommandSurface(root, promotedAPICmd, argScan, cfg, args); err != nil {
+		return err
+	}
 
 	err = c.executeRoot(ctx, root, args)
 	// When the context was cancelled by a signal (SIGINT/SIGTERM), return
@@ -1057,7 +1081,7 @@ func (c *CLI) addAPIShortNameCommands(root *cobra.Command, cfg *config.Config) {
 
 	for _, apiName := range names {
 		apiCfg := cfg.APIs[apiName]
-		if apiCfg == nil || isBuiltinCommandName(apiName) || rootHasCommand(root, apiName) {
+		if apiCfg == nil || c.isPromotedAPI(apiName) || isBuiltinCommandName(apiName) || rootHasCommand(root, apiName) {
 			continue
 		}
 		apiName := apiName
@@ -1192,6 +1216,12 @@ func quietGeneratedWarningsForScan(scan cliArgScan, cfg *config.Config) bool {
 func (c *CLI) generatedAPINamesForScan(scan cliArgScan, cfg *config.Config) []string {
 	if scan.VersionFlag {
 		return nil
+	}
+	if promoted := c.promotedAPIName(); promoted != "" {
+		if !c.promotedAPICommandMetadataNeeded(scan) {
+			return nil
+		}
+		return []string{promoted}
 	}
 	if scan.GeneratedAPICommandTree {
 		if scan.FirstCommand != "" && !isBuiltinCommandName(scan.FirstCommand) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,8 +3,10 @@ package cli_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -112,6 +114,317 @@ paths:
 	}
 	if got := req.URL.Path; got != "/ping" {
 		t.Fatalf("path = %q, want /ping", got)
+	}
+}
+
+func TestCommandSurfacePromotesGeneratedOperationsToRoot(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	specPath := filepath.Join(t.TempDir(), "openapi.yaml")
+	specBody := `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /ping:
+    get:
+      operationId: getPing
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(specPath, []byte(specBody), 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	configBody := `{"apis":{"svc":{"base_url":"https://api.example.com","spec_files":[` + strconv.Quote(specPath) + `]}}}`
+	if err := os.WriteFile(c.Hooks().ConfigPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "svc"})
+
+	var rr requestRecorder
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		rr.capture(r)
+		return jsonResponse(200, `{"ok":true}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get-ping"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req := rr.Last()
+	if req == nil {
+		t.Fatal("expected request")
+	}
+	if got := req.Method; got != "GET" {
+		t.Fatalf("method = %q, want GET", got)
+	}
+	if got := req.URL.Path; got != "/ping" {
+		t.Fatalf("path = %q, want /ping", got)
+	}
+}
+
+func TestCommandSurfacePromotedOperationHelpDoesNotPanic(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	specPath := filepath.Join(t.TempDir(), "openapi.yaml")
+	specBody := `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /ping:
+    get:
+      operationId: getPing
+      responses:
+        "200":
+          description: OK
+`
+	if err := os.WriteFile(specPath, []byte(specBody), 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	configBody := `{"apis":{"svc":{"base_url":"https://api.example.com","spec_files":[` + strconv.Quote(specPath) + `]}}}`
+	if err := os.WriteFile(c.Hooks().ConfigPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "svc"})
+
+	if err := c.Run([]string{"restish", "get-ping", "-h"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "get-ping") {
+		t.Fatalf("expected help output to mention command, got:\n%s", got)
+	}
+}
+
+func TestCommandSurfacePromotedAPIHelpFetchesSpecURLOnFirstRun(t *testing.T) {
+	var specRequests int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.yaml":
+			specRequests++
+			w.Header().Set("Content-Type", "application/yaml")
+			fmt.Fprintf(w, `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+servers:
+  - url: %s
+paths:
+  /ping:
+    get:
+      operationId: getPing
+      responses:
+        "200":
+          description: OK
+`, baseURL)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	c, out, _ := newTestCLI(t)
+	c.SetDefaultConfig(&config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL: baseURL,
+			SpecURL: baseURL + "/openapi.yaml",
+		},
+	}})
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+	if err := c.Run([]string{"example", "--help"}); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if specRequests != 1 {
+		t.Fatalf("spec requests = %d, want 1", specRequests)
+	}
+	if got := out.String(); !strings.Contains(got, "get-ping") {
+		t.Fatalf("help missing promoted operation:\n%s", got)
+	}
+}
+
+func TestCommandSurfaceSyncedFallbackPreservesOriginalArgs(t *testing.T) {
+	specIncludesNew := false
+	var lastPath, lastHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.yaml":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, commandSurfaceRefreshSpec(specIncludesNew))
+		case "/staging/new", "/default/new":
+			lastPath = r.URL.Path
+			lastHeader = r.Header.Get("X-Keep")
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/staging/new" {
+				fmt.Fprint(w, `{"profile":"staging"}`)
+			} else {
+				fmt.Fprint(w, `{"profile":"default"}`)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL: srv.URL + "/default",
+			SpecURL: srv.URL + "/openapi.yaml",
+			Profiles: map[string]*config.ProfileConfig{
+				"staging": {BaseURL: srv.URL + "/staging"},
+			},
+		},
+	}})
+	cacheDir := t.TempDir()
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "--rsh-profile", "staging", "--help"}); err != nil {
+		t.Fatalf("prime help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "get-old") || strings.Contains(got, "get-new") {
+		t.Fatalf("expected initial help to use old cached operations, got:\n%s", got)
+	}
+
+	specIncludesNew = true
+	c, out, _ = newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "--rsh-profile", "staging", "get-new", "--rsh-header", "X-Keep: yes", "-f", "body.profile", "-o", "lines"}); err != nil {
+		t.Fatalf("refreshed generated command: %v", err)
+	}
+	if lastPath != "/staging/new" {
+		t.Fatalf("request path = %q, want /staging/new", lastPath)
+	}
+	if lastHeader != "yes" {
+		t.Fatalf("X-Keep header = %q, want yes", lastHeader)
+	}
+	if got := strings.TrimSpace(out.String()); got != "staging" {
+		t.Fatalf("filtered output = %q, want staging", got)
+	}
+}
+
+func commandSurfaceRefreshSpec(includeNew bool) string {
+	paths := `"/old":{"get":{"operationId":"getOld","responses":{"200":{"description":"OK"}}}}`
+	if includeNew {
+		paths += `,"/new":{"get":{"operationId":"getNew","responses":{"200":{"description":"OK"}}}}`
+	}
+	return `{"openapi":"3.1.0","info":{"title":"Test","version":"1.0.0"},"paths":{` + paths + `}}`
+}
+
+func TestCommandSurfaceSupportCommandsUnderNamespace(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI:             "api",
+		SupportCommandNamespace: "cli",
+	})
+
+	if err := c.Run([]string{"example", "cli", "cache", "--help"}); err != nil {
+		t.Fatalf("support command help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "clear") {
+		t.Fatalf("namespaced cache help missing subcommand:\n%s", got)
+	}
+}
+
+func TestCommandSurfaceHideSupportCommands(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI:         "api",
+		HideSupportCommands: true,
+	})
+
+	err := c.Run([]string{"example", "version"})
+	if err == nil || !strings.Contains(err.Error(), `unknown command "version"`) {
+		t.Fatalf("version command error = %v, want unknown command", err)
+	}
+
+	c, out, _ = newTestCLI(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "getPing")
+	c.SetCommandSurface(cli.CommandSurface{
+		PromotedAPI:         "api",
+		HideSupportCommands: true,
+	})
+	if err := c.Run([]string{"example", "--version"}); err != nil {
+		t.Fatalf("--version: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "2.0.0") {
+		t.Fatalf("--version output = %q", got)
+	}
+}
+
+func TestCommandSurfaceSupportCommandCollisionErrors(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	writeCommandSurfaceSpecConfig(t, c, "api", "cache")
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+	err := c.Run([]string{"example", "--help"})
+	if err == nil || !strings.Contains(err.Error(), "SupportCommandNamespace") {
+		t.Fatalf("collision error = %v, want SupportCommandNamespace hint", err)
+	}
+}
+
+func TestCommandSurfaceRootAuthHeader(t *testing.T) {
+	app := newTestApp(t)
+	app.SetConfigPath(writeAPIConfigObject(t, "api", testAPIConfig("https://api.example.com", profileAuth(apiKeyAuth("header", "X-Partner-Key", "secret")))))
+	app.CLI.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+	app.Run("auth", "header")
+	if got := strings.TrimSpace(app.Stdout.String()); got != "X-Partner-Key: secret" {
+		t.Fatalf("auth header = %q, want X-Partner-Key: secret", got)
+	}
+
+	app = newTestApp(t)
+	app.SetConfigPath(writeAPIConfigObject(t, "api", testAPIConfig("https://api.example.com", profileAuth(apiKeyAuth("header", "X-Partner-Key", "secret")))))
+	app.CLI.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	app.Run("auth", "get", "--print-header")
+	if got := strings.TrimSpace(app.Stdout.String()); got != "X-Partner-Key: secret" {
+		t.Fatalf("auth get --print-header = %q, want X-Partner-Key: secret", got)
+	}
+
+	app = newTestApp(t)
+	app.SetConfigPath(writeAPIConfigObject(t, "api", testAPIConfig("https://api.example.com", profileAuth(apiKeyAuth("query", "api_key", "secret")))))
+	app.CLI.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	err := app.RunErr("auth", "header")
+	if err == nil || !strings.Contains(err.Error(), "query parameter") {
+		t.Fatalf("query auth header error = %v, want query parameter error", err)
+	}
+
+	app = newTestApp(t)
+	app.SetConfigPath(writeAPIConfigObject(t, "api", testAPIConfig("https://api.example.com", profileAuth(apiKeyAuth("cookie", "session", "secret")))))
+	app.CLI.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	err = app.RunErr("auth", "header")
+	if err == nil || !strings.Contains(err.Error(), "cookie") {
+		t.Fatalf("cookie auth header error = %v, want cookie error", err)
+	}
+}
+
+func writeCommandSurfaceSpecConfig(t *testing.T, c *cli.CLI, apiName, operationID string) {
+	t.Helper()
+	specPath := filepath.Join(t.TempDir(), "openapi.yaml")
+	specBody := fmt.Sprintf(`openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths:
+  /ping:
+    get:
+      operationId: %s
+      responses:
+        "200":
+          description: OK
+`, operationID)
+	if err := os.WriteFile(specPath, []byte(specBody), 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	configBody := `{"apis":{` + strconv.Quote(apiName) + `:{"base_url":"https://api.example.com","spec_files":[` + strconv.Quote(specPath) + `]}}}`
+	if err := os.WriteFile(c.Hooks().ConfigPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
 	}
 }
 

--- a/internal/cli/command_surface_embed.go
+++ b/internal/cli/command_surface_embed.go
@@ -1,0 +1,379 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rest-sh/restish/v2/config"
+	"github.com/rest-sh/restish/v2/internal/spec"
+	"github.com/spf13/cobra"
+)
+
+// CommandSurface controls the command tree exposed by embedded custom CLIs.
+// The zero value preserves the stock Restish command surface.
+type CommandSurface struct {
+	// PromotedAPI promotes generated operations for this configured API to the
+	// root command.
+	PromotedAPI string
+
+	// SupportCommandNamespace moves support commands under this root command.
+	SupportCommandNamespace string
+	// HideSupportCommands removes support commands from the custom CLI surface.
+	HideSupportCommands bool
+}
+
+// SetCommandSurface changes the command tree exposed by an embedded CLI.
+// Invalid combinations panic so mistakes fail during host application setup.
+func (c *CLI) SetCommandSurface(surface CommandSurface) {
+	surface.PromotedAPI = strings.TrimSpace(surface.PromotedAPI)
+	surface.SupportCommandNamespace = strings.TrimSpace(surface.SupportCommandNamespace)
+	if surface.HideSupportCommands && surface.SupportCommandNamespace != "" {
+		panic("restish: CommandSurface SupportCommandNamespace and HideSupportCommands are mutually exclusive")
+	}
+	if surface.PromotedAPI == "" && (surface.SupportCommandNamespace != "" || surface.HideSupportCommands) {
+		panic("restish: CommandSurface support command layout requires PromotedAPI")
+	}
+	c.commandSurface = surface
+}
+
+func (c *CLI) promotedAPIName() string {
+	return c.commandSurface.PromotedAPI
+}
+
+func (c *CLI) hasPromotedAPI() bool {
+	return c.promotedAPIName() != ""
+}
+
+func (c *CLI) isPromotedAPI(apiName string) bool {
+	return apiName != "" && apiName == c.promotedAPIName()
+}
+
+func (c *CLI) ensurePromotedAPICommandMetadata(ctx context.Context, scan cliArgScan, cfg *config.Config) error {
+	apiName := c.promotedAPIName()
+	if apiName == "" || !c.promotedAPICommandMetadataNeeded(scan) {
+		return nil
+	}
+	apiCfg := cfg.APIs[apiName]
+	if apiCfg == nil {
+		return fmt.Errorf("command surface: promoted API %q is not configured", apiName)
+	}
+	opts := spec.OperationOptions{
+		BaseURL:         effectiveProfileBaseURL(apiCfg, scan.ProfileName),
+		OperationBase:   effectiveOperationBase(apiCfg, scan.ProfileName),
+		ServerVariables: effectiveServerVariables(apiCfg, scan.ProfileName),
+	}
+	stateName := c.apiStateName(apiName)
+	if _, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, false); ok && !status.Stale {
+		return nil
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, staleGeneratedOperationRefreshTimeout)
+	defer cancel()
+	if _, err := c.discoverSpecForProfile(refreshCtx, apiName, scan.ProfileName, false, staleGeneratedOperationRefreshTimeout); err != nil {
+		if status, ok := c.promotedAPIStaleMetadataStatus(apiName, apiCfg, opts); ok {
+			c.warnf("could not refresh API metadata for %q; using last synced metadata from %s: %v", apiName, formatCacheTime(status.FetchedAt), err)
+			return nil
+		}
+		return fmt.Errorf("generated commands for promoted API %q are unavailable: %w", apiName, err)
+	}
+	return nil
+}
+
+func (c *CLI) promotedAPIStaleMetadataStatus(apiName string, apiCfg *config.APIConfig, opts spec.OperationOptions) (spec.OperationCacheStatus, bool) {
+	stateName := c.apiStateName(apiName)
+	if _, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, true); ok {
+		return status, true
+	}
+	return spec.RawSpecCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles)
+}
+
+func (c *CLI) promotedAPICommandMetadataNeeded(scan cliArgScan) bool {
+	if scan.VersionFlag {
+		return false
+	}
+	if scan.FirstCommand == "" {
+		return true
+	}
+	if scan.FirstCommand == "help" {
+		return scan.SecondCommand == "" || !c.isSupportCommandToken(scan.SecondCommand)
+	}
+	if scan.FirstCommand == "__complete" || scan.FirstCommand == "__completeNoDesc" {
+		return true
+	}
+	return !c.isSupportCommandToken(scan.FirstCommand)
+}
+
+func (c *CLI) isSupportCommandToken(token string) bool {
+	if token == "" || c.commandSurface.HideSupportCommands {
+		return false
+	}
+	if ns := c.commandSurface.SupportCommandNamespace; ns != "" {
+		return token == ns
+	}
+	return promotedSupportCommandNames()[token]
+}
+
+func promotedSupportCommandNames() map[string]bool {
+	return map[string]bool{
+		"auth":       true,
+		"cache":      true,
+		"completion": true,
+		"config":     true,
+		"doctor":     true,
+		"version":    true,
+	}
+}
+
+func (c *CLI) applyCommandSurface(root, promotedAPICmd *cobra.Command, scan cliArgScan, cfg *config.Config, originalArgs []string) error {
+	apiName := c.promotedAPIName()
+	if apiName == "" {
+		return nil
+	}
+	if promotedAPICmd == nil && c.promotedAPICommandMetadataNeeded(scan) {
+		return fmt.Errorf("generated commands for promoted API %q are unavailable", apiName)
+	}
+
+	support := c.promotedSupportCommands(root, apiName)
+	for _, cmd := range root.Commands() {
+		root.RemoveCommand(cmd)
+	}
+
+	var promoted []*cobra.Command
+	if promotedAPICmd != nil {
+		root.Example = promotedAPICmd.Example
+		for _, group := range promotedAPICmd.Groups() {
+			if !rootCommandHasGroup(root, group.ID) {
+				root.AddGroup(group)
+			}
+		}
+		promoted = append(promoted, promotedAPICmd.Commands()...)
+	}
+
+	if err := c.checkPromotedCommandCollisions(promoted, support); err != nil {
+		return err
+	}
+
+	c.addSupportCommandsForSurface(root, support)
+	for _, cmd := range promoted {
+		root.AddCommand(cmd)
+	}
+	c.installPromotedRootFallback(root, cfg, originalArgs)
+	return nil
+}
+
+func (c *CLI) promotedSupportCommands(root *cobra.Command, apiName string) map[string]*cobra.Command {
+	support := map[string]*cobra.Command{}
+	if !c.commandSurface.HideSupportCommands {
+		for _, cmd := range root.Commands() {
+			if promotedSupportCommandNames()[cmd.Name()] {
+				support[cmd.Name()] = cmd
+			}
+		}
+		if support["completion"] != nil {
+			support["completion"].Hidden = false
+		}
+		if support["auth"] == nil {
+			support["auth"] = c.newPromotedAPIAuthCommand(apiName)
+		}
+		c.brandPromotedSupportCommands(support)
+	}
+	return support
+}
+
+func (c *CLI) brandPromotedSupportCommands(support map[string]*cobra.Command) {
+	name := c.commandNameOrDefault()
+	if cmd := support["config"]; cmd != nil {
+		cmd.Short = fmt.Sprintf("Manage local %s configuration", name)
+	}
+	if cmd := support["doctor"]; cmd != nil {
+		cmd.Short = fmt.Sprintf("Diagnose %s configuration and runtime paths", name)
+	}
+	if cmd := support["version"]; cmd != nil {
+		cmd.Short = fmt.Sprintf("Print the %s version", name)
+	}
+}
+
+func (c *CLI) checkPromotedCommandCollisions(promoted []*cobra.Command, support map[string]*cobra.Command) error {
+	ns := c.commandSurface.SupportCommandNamespace
+	for _, cmd := range promoted {
+		name := cmd.Name()
+		if name == "" {
+			continue
+		}
+		if ns != "" && name == ns {
+			return fmt.Errorf("command surface: promoted operation %q collides with support command namespace %q; choose another SupportCommandNamespace or hide support commands", name, ns)
+		}
+		if ns == "" && !c.commandSurface.HideSupportCommands && support[name] != nil {
+			return fmt.Errorf("command surface: promoted operation %q collides with support command %q; set SupportCommandNamespace or HideSupportCommands", name, name)
+		}
+	}
+	return nil
+}
+
+func (c *CLI) addSupportCommandsForSurface(root *cobra.Command, support map[string]*cobra.Command) {
+	if c.commandSurface.HideSupportCommands {
+		return
+	}
+	if ns := c.commandSurface.SupportCommandNamespace; ns != "" {
+		nsCmd := &cobra.Command{
+			Use:     ns,
+			Short:   "CLI support commands",
+			GroupID: rootGroupConfig,
+			Args:    cobra.ArbitraryArgs,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				if len(args) > 0 {
+					return unknownCommandError(cmd, args[0], "run "+strconvQuote(cmd.CommandPath()+" --help")+" to see support commands")
+				}
+				return cmd.Help()
+			},
+		}
+		for _, name := range sortedSupportCommandNames(support) {
+			cmd := support[name]
+			cmd.GroupID = ""
+			nsCmd.AddCommand(cmd)
+		}
+		root.AddCommand(nsCmd)
+		return
+	}
+	for _, name := range sortedSupportCommandNames(support) {
+		root.AddCommand(support[name])
+	}
+}
+
+func sortedSupportCommandNames(commands map[string]*cobra.Command) []string {
+	names := make([]string, 0, len(commands))
+	for name := range commands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (c *CLI) installPromotedRootFallback(root *cobra.Command, cfg *config.Config, originalArgs []string) {
+	originalArgs = append([]string(nil), originalArgs...)
+	root.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+		if c.shouldSyncPromotedRootCommand(cfg, args) {
+			return c.runSyncedPromotedAPICommand(cmd, cfg, args, originalArgs)
+		}
+		return unknownCommandError(cmd, args[0], "run "+strconvQuote(cmd.CommandPath()+" --help")+" to see available commands")
+	}
+}
+
+func (c *CLI) shouldSyncPromotedRootCommand(cfg *config.Config, args []string) bool {
+	if len(args) == 0 || !looksLikeGeneratedCommandToken(args[0]) {
+		return false
+	}
+	apiCfg := cfg.APIs[c.promotedAPIName()]
+	return apiHasSpecSource(apiCfg)
+}
+
+func (c *CLI) runSyncedPromotedAPICommand(cmd *cobra.Command, cfg *config.Config, args, originalArgs []string) error {
+	apiName := c.promotedAPIName()
+	apiCfg := cfg.APIs[apiName]
+	profileName := c.profileFromCmd(cmd)
+	refreshCtx, cancel := context.WithTimeout(cmd.Context(), staleGeneratedOperationRefreshTimeout)
+	defer cancel()
+	set, ok, err := c.operationSetForAPI(refreshCtx, apiName, apiCfg, profileName, true)
+	if err != nil {
+		return fmt.Errorf("generated commands for promoted API %q are not available: %w", apiName, err)
+	}
+	if !ok {
+		return fmt.Errorf("generated commands for promoted API %q are not available", apiName)
+	}
+	apiCmd := c.buildAPICommandFromOperationSet(apiName, apiCfg, set, effectiveOperationBase(apiCfg, profileName))
+	if apiCmd == nil {
+		return fmt.Errorf("generated commands for promoted API %q are unavailable after sync", apiName)
+	}
+	root := c.newRootCmd()
+	scan := cliArgScan{FirstCommand: args[0], ProfileName: profileName}
+	if err := c.applyCommandSurface(root, apiCmd, scan, cfg, originalArgs); err != nil {
+		return err
+	}
+	if !commandPathExists(root, args) {
+		return unknownCommandError(root, args[0], "run "+strconvQuote(cmd.CommandPath()+" --help")+" to see generated operations")
+	}
+	if len(originalArgs) == 0 {
+		originalArgs = append([]string{c.commandNameOrDefault()}, args...)
+	}
+	return c.executeRoot(cmd.Context(), root, originalArgs)
+}
+
+func (c *CLI) newPromotedAPIAuthCommand(apiName string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "auth",
+		Short:   "Inspect API auth credentials",
+		Long:    apiAuthLong,
+		GroupID: rootGroupConfig,
+		Args:    cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return cmd.Help()
+		},
+	}
+	getCmd := &cobra.Command{
+		Use:   "get [credential-id]",
+		Short: "Print curl-friendly auth material for the API profile",
+		Long:  apiAuthGetLong,
+		Args:  usageMaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runAPIAuthGet(cmd, append([]string{apiName}, args...))
+		},
+	}
+	getCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
+	getCmd.Flags().Bool("print-header", false, "Print the single resolved header as 'Name: value' on stdout and exit non-zero for any non-header auth")
+	cmd.AddCommand(getCmd)
+
+	headerCmd := &cobra.Command{
+		Use:   "header [credential-id]",
+		Short: "Print one HTTP auth header for the API profile",
+		Long:  apiAuthGetLong,
+		Args:  usageMaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fragment, err := c.apiAuthGetHeaderFragment(cmd, append([]string{apiName}, args...))
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(c.Stdout, fragment)
+			return nil
+		},
+	}
+	headerCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
+	cmd.AddCommand(headerCmd)
+
+	inspectCmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect the auth material applied for the API profile",
+		Long:  apiAuthInspectLong,
+		Args:  usageNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return c.runAPIAuthInspect(cmd, []string{apiName})
+		},
+	}
+	inspectCmd.Flags().String("credential", "", "Credential ID to inspect instead of profile-level auth")
+	inspectCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
+	inspectCmd.Flags().Bool("redact", false, "Redact sensitive auth values for shareable output")
+	cmd.AddCommand(inspectCmd)
+
+	logoutCmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Delete cached API auth tokens",
+		Long:  apiAuthLogoutLong,
+		Args:  usageNoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if authProfile, _ := cmd.Flags().GetString("auth-profile"); authProfile != "" {
+				return c.runAPIAuthLogout(cmd, nil)
+			}
+			return c.runAPIAuthLogout(cmd, []string{apiName})
+		},
+	}
+	addAPIAuthLogoutFlags(logoutCmd)
+	cmd.AddCommand(logoutCmd)
+	return cmd
+}

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -75,8 +75,9 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 	if long == "" {
 		long = strings.TrimSpace(set.Info.Summary)
 	}
+	isRootAPI := c.isPromotedAPI(apiName)
 	long, fullLong := generatedAPIHelpDescription(apiName, long)
-	if generatedAPIHasAuth(ops) {
+	if generatedAPIHasAuth(ops) && !isRootAPI {
 		if long != "" {
 			long += "\n\n"
 		}
@@ -117,9 +118,16 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 	for _, op := range ops {
 		tagCommandName := ""
 		examplePrefix := apiName
+		if isRootAPI {
+			examplePrefix = ""
+		}
 		if useTagLayout && len(op.Tags) > 0 {
 			tagCommandName = generatedTagCommandName(op.Tags[0], tagCommandNameByTag, tagCommands)
-			examplePrefix = apiName + " " + tagCommandName
+			if isRootAPI {
+				examplePrefix = tagCommandName
+			} else {
+				examplePrefix = apiName + " " + tagCommandName
+			}
 		}
 		cmd, err := c.buildOperationCommand(apiName, examplePrefix, op, operationBase)
 		if err != nil {
@@ -1334,18 +1342,22 @@ func generatedOperationExampleLine(commandName, apiName, use string, examples []
 	if commandName == "" {
 		commandName = "restish"
 	}
+	prefix := commandName
+	if apiName != "" {
+		prefix = commandName + " " + apiName
+	}
 	hasBody := strings.Contains(use, " [body...]") || strings.Contains(use, " <body...>")
 	use = strings.TrimSuffix(use, " [body...]")
 	use = strings.TrimSuffix(use, " <body...>")
 	if len(examples) == 0 {
-		example := "  " + commandName + " " + apiName + " " + use
+		example := "  " + prefix + " " + use
 		if hasBody {
 			example += " --rsh-generate-body"
 		}
 		return example
 	}
 	ex := examples[0]
-	example := "  " + commandName + " " + apiName + " " + use
+	example := "  " + prefix + " " + use
 	if ex != "" {
 		example += " " + shellQuoteGeneratedExample(ex)
 	}

--- a/restish.go
+++ b/restish.go
@@ -73,11 +73,14 @@ type AuthParam = auth.Param
 // AuthContext is passed to custom auth handlers during request authentication.
 type AuthContext = auth.AuthContext
 
+// CommandSurface controls the command tree exposed by embedded custom CLIs.
+type CommandSurface = internalcli.CommandSurface
+
 // New returns a CLI wired to the real OS stdin/stdout/stderr and the default
 // Restish registries. Customize it with SetCommandName,
 // SetCommandDescription, SetVersion, SetSignalHandling, SetDefaultConfig,
-// AddAuthHandler, AddContentType, AddEncoding, AddLinkParser, AddLoader, and
-// AddFormatter before calling Run.
+// SetCommandSurface, AddAuthHandler, AddContentType, AddEncoding,
+// AddLinkParser, AddLoader, and AddFormatter before calling Run.
 func New() *CLI {
 	return internalcli.New()
 }

--- a/site/content/en/docs/reference/embedding.md
+++ b/site/content/en/docs/reference/embedding.md
@@ -140,6 +140,56 @@ mycorp api connect billing https://billing.example.com --spec ./openapi.yaml
 Keep config explicit. `RSH_CONFIG_DIR`, `RSH_CONFIG`, and `--rsh-config` keep
 the same precedence rules as the stock binary.
 
+## Single-API CLI
+
+Embedders that ship a CLI dedicated to one API can promote that API to the
+root command so its generated operations appear as top-level subcommands.
+
+For a complete starting point, see
+[`examples/example-cli`](https://github.com/rest-sh/restish/tree/main/examples/example-cli).
+
+```go
+cli := restish.New()
+cli.SetCommandName("mycli")
+cli.SetDefaultConfig(&restish.Config{
+    APIs: map[string]*restish.APIConfig{
+        "api": {
+            BaseURL: "https://api.example.com",
+            SpecURL: "https://api.example.com/openapi.yaml",
+        },
+    },
+})
+cli.SetCommandSurface(restish.CommandSurface{
+    PromotedAPI: "api",
+})
+```
+
+With `SetCommandSurface`, generated operations appear directly under the CLI's
+root command instead of being nested under the API name. Support commands such
+as `auth`, `cache`, `config`, `doctor`, `completion`, and `version` remain at
+root by default. Move them under a namespace when the API's operation names need
+the entire root:
+
+```go
+cli.SetCommandSurface(restish.CommandSurface{
+    PromotedAPI:             "api",
+    SupportCommandNamespace: "cli",
+})
+```
+
+Or hide the support commands entirely:
+
+```go
+cli.SetCommandSurface(restish.CommandSurface{
+    PromotedAPI:         "api",
+    HideSupportCommands: true,
+})
+```
+
+Global Restish flags (`--rsh-profile`, `--rsh-output-format`, ...) remain
+available. The promoted API must be configured and its spec loadable when
+generated commands are needed. For a reliable first run, configure `SpecURL`.
+
 ## Related Pages
 
 - [API Setup and Discovery](/docs/guides/api-setup-and-discovery/)


### PR DESCRIPTION
Supersedes #384.

Thanks to @msessa for starting the original PR and shaping the single-API CLI use case. I could not push directly to that branch because maintainer edits are disabled by organization policy, and the current #384 branch now fails CI after merging `main` due to an `internal/cli/api_auth.go` conflict. This PR carries the feature forward on a branch maintainers can update while keeping the original contribution history linked.

## Summary

- Adds `restish.CommandSurface` and `SetCommandSurface` for embedded custom CLIs.
- Promotes one configured API's generated operations to the root command.
- Keeps support commands at root by default, with options to move them under a namespace or hide them.
- Supports a promoted API named `api` for focused single-API binaries.
- Fetches configured promoted API metadata before generated commands/help are needed, with stale-cache fallback.
- Adds promoted-root `auth get`, `auth header`, `auth inspect`, and `auth logout` sugar.
- Reuses the current `api auth get --print-header` validation for promoted `auth header`, including query, cookie, missing, and multi-header failures.
- Adds focused tests, an ADR, embedding docs, and a buildable `examples/example-cli` starter.

## Validation

- `go test ./internal/cli -run 'TestCommandSurface|TestAPIAuthGet|TestGeneratedAPIHelpMentionsAuthInspection|TestGeneratedCommandHelp|TestSpecBackedShortNameSyncsGeneratedCommandBeforeGenericFallback'`
- `go test ./...`
- `go test -tags=integration ./...`
- `go run ./cmd/restish-docgen --check`
- `go build -o /tmp/example-cli-pr384 ./examples/example-cli`
- `go build ./cmd/restish ./cmd/restish-bulk ./cmd/restish-csv ./cmd/restish-mcp ./cmd/restish-pkcs11`

I also attempted a full local Hugo render; the first run hung silently and the retry showed local module fetching was blocked by the sandbox/network path. The generated-doc check passed locally, and CI should provide the authoritative docs render signal.