### PR TITLE
fix(embed): refresh promoted API metadata

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rest-sh/restish/v2/config"
 	"github.com/rest-sh/restish/v2/internal/cli"
+	internalspec "github.com/rest-sh/restish/v2/internal/spec"
 )
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -307,6 +308,58 @@ func TestCommandSurfaceSyncedFallbackPreservesOriginalArgs(t *testing.T) {
 	}
 }
 
+func TestCommandSurfaceBaseURLFallbackRefreshesUnknownOperation(t *testing.T) {
+	specIncludesNew := false
+	var specRequests int
+	var lastPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			specRequests++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, commandSurfaceRefreshSpec(specIncludesNew))
+		case "/new":
+			lastPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"ok":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {BaseURL: srv.URL},
+	}})
+	cacheDir := t.TempDir()
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "--help"}); err != nil {
+		t.Fatalf("prime help: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "get-old") || strings.Contains(got, "get-new") {
+		t.Fatalf("expected initial help to use old cached operations, got:\n%s", got)
+	}
+
+	specIncludesNew = true
+	c, _, _ = newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "get-new"}); err != nil {
+		t.Fatalf("refreshed generated command: %v", err)
+	}
+	if lastPath != "/new" {
+		t.Fatalf("request path = %q, want /new", lastPath)
+	}
+	if specRequests < 2 {
+		t.Fatalf("spec requests = %d, want initial discovery and refresh", specRequests)
+	}
+}
+
 func commandSurfaceRefreshSpec(includeNew bool) string {
 	paths := `"/old":{"get":{"operationId":"getOld","responses":{"200":{"description":"OK"}}}}`
 	if includeNew {
@@ -402,6 +455,233 @@ func TestCommandSurfaceRootAuthHeader(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "cookie") {
 		t.Fatalf("cookie auth header error = %v, want cookie error", err)
 	}
+}
+
+func TestCommandSurfaceRootAuthOperationFetchesMetadataOnFirstRun(t *testing.T) {
+	var specRequests int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			specRequests++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, commandSurfaceAuthSpec(baseURL, true))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL: srv.URL,
+			Profiles: map[string]*config.ProfileConfig{
+				"default": profileCredentials(map[string]*config.CredentialConfig{
+					"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "secret")),
+				}),
+			},
+		},
+	}})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "auth", "header", "--operation", "partner-report"}); err != nil {
+		t.Fatalf("auth header operation: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "X-Partner-Key: secret" {
+		t.Fatalf("auth header operation = %q, want X-Partner-Key: secret", got)
+	}
+	if specRequests != 1 {
+		t.Fatalf("spec requests = %d, want 1", specRequests)
+	}
+}
+
+func TestCommandSurfaceRootAuthOperationRefreshesMissingFreshOperation(t *testing.T) {
+	specIncludesPartner := false
+	var specRequests int
+	var baseURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/openapi.json":
+			specRequests++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, commandSurfaceAuthSpec(baseURL, specIncludesPartner))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	baseURL = srv.URL
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL: srv.URL,
+			Profiles: map[string]*config.ProfileConfig{
+				"default": profileCredentials(map[string]*config.CredentialConfig{
+					"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "secret")),
+				}),
+			},
+		},
+	}})
+	cacheDir := t.TempDir()
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "--help"}); err != nil {
+		t.Fatalf("prime help: %v", err)
+	}
+	if got := out.String(); strings.Contains(got, "partner-report") {
+		t.Fatalf("expected initial help to omit partner-report, got:\n%s", got)
+	}
+
+	specIncludesPartner = true
+	c, out, _ = newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "auth", "header", "--operation", "partner-report"}); err != nil {
+		t.Fatalf("auth header operation: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "X-Partner-Key: secret" {
+		t.Fatalf("auth header operation = %q, want X-Partner-Key: secret", got)
+	}
+	if specRequests < 2 {
+		t.Fatalf("spec requests = %d, want initial discovery and refresh", specRequests)
+	}
+}
+
+func TestCommandSurfaceRootAuthOperationUsesRawSpecCacheBeforeRefresh(t *testing.T) {
+	var originRequests int
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originRequests++
+		http.NotFound(w, r)
+	}))
+	defer origin.Close()
+	var profileRequests int
+	profile := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		profileRequests++
+		http.NotFound(w, r)
+	}))
+	defer profile.Close()
+
+	rawSpec := openAPISpec(origin.URL, "Auth API",
+		openAPISecuritySchemes(`"PartnerKey":{"type":"apiKey","in":"header","name":"X-Partner-Key"}`),
+		openAPIPaths(openAPIGet("/v2/private", "", `"security":[{"PartnerKey":[]}]`)))
+	apiSpec, err := internalspec.OpenAPILoader{}.Load([]byte(rawSpec))
+	if err != nil {
+		t.Fatalf("load spec: %v", err)
+	}
+	cacheDir := t.TempDir()
+	if err := internalspec.StoreSpecInCache(cacheDir, "api", cli.Version, apiSpec, nil, internalspec.OperationOptions{
+		BaseURL:       origin.URL,
+		OperationBase: "/v1",
+	}, time.Hour); err != nil {
+		t.Fatalf("store spec cache: %v", err)
+	}
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL:       origin.URL,
+			OperationBase: "/v1",
+			Profiles: map[string]*config.ProfileConfig{
+				"staging": {
+					BaseURL:       profile.URL,
+					OperationBase: "/v2",
+					Credentials: map[string]*config.CredentialConfig{
+						"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "secret")),
+					},
+				},
+			},
+		},
+	}})
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = cacheDir
+	c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+	if err := c.Run([]string{"example", "--rsh-profile", "staging", "auth", "header", "--operation", "get-private"}); err != nil {
+		t.Fatalf("auth header operation: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "X-Partner-Key: secret" {
+		t.Fatalf("auth header operation = %q, want X-Partner-Key: secret", got)
+	}
+	if originRequests != 0 || profileRequests != 0 {
+		t.Fatalf("discovery requests: origin=%d profile=%d, want 0", originRequests, profileRequests)
+	}
+}
+
+func TestCommandSurfaceRootAuthOperationConflictsDoNotRefreshMetadata(t *testing.T) {
+	var specRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/openapi.json" {
+			specRequests++
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfgFile := writeTestConfig(t, &config.Config{APIs: map[string]*config.APIConfig{
+		"api": {
+			BaseURL: srv.URL,
+			Profiles: map[string]*config.ProfileConfig{
+				"default": profileCredentials(map[string]*config.CredentialConfig{
+					"PartnerKey": testCredential(apiKeyAuth("header", "X-Partner-Key", "secret")),
+				}),
+			},
+		},
+	}})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "auth get credential and operation",
+			args: []string{"example", "auth", "get", "PartnerKey", "--operation", "partner-report"},
+			want: "--operation and credential ID are mutually exclusive",
+		},
+		{
+			name: "auth inspect credential and operation",
+			args: []string{"example", "auth", "inspect", "--credential", "PartnerKey", "--operation", "partner-report"},
+			want: "--operation and --credential are mutually exclusive",
+		},
+		{
+			name: "auth inspect operation and output format",
+			args: []string{"example", "auth", "inspect", "--operation", "partner-report", "-o", "json"},
+			want: "does not support -o/--rsh-output-format",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specRequests = 0
+			c, _, _ := newTestCLI(t)
+			c.Hooks().ConfigPath = cfgFile
+			c.SetCommandSurface(cli.CommandSurface{PromotedAPI: "api"})
+
+			err := c.Run(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+			if specRequests != 0 {
+				t.Fatalf("spec requests = %d, want 0", specRequests)
+			}
+		})
+	}
+}
+
+func commandSurfaceAuthSpec(baseURL string, includePartner bool) string {
+	paths := []string{openAPIGet("/old", "oldReport", `"security":[{"PartnerKey":[]}]`)}
+	if includePartner {
+		paths = append(paths, openAPIGet("/partner", "partnerReport", `"security":[{"PartnerKey":[]}]`))
+	}
+	return openAPISpec(baseURL, "Auth API",
+		openAPISecuritySchemes(`"PartnerKey":{"type":"apiKey","in":"header","name":"X-Partner-Key"}`),
+		openAPIPaths(paths...))
 }
 
 func writeCommandSurfaceSpecConfig(t *testing.T, c *cli.CLI, apiName, operationID string) {

--- a/internal/cli/command_surface_embed.go
+++ b/internal/cli/command_surface_embed.go
@@ -59,10 +59,14 @@ func (c *CLI) ensurePromotedAPICommandMetadata(ctx context.Context, scan cliArgS
 	if apiCfg == nil {
 		return fmt.Errorf("command surface: promoted API %q is not configured", apiName)
 	}
+	return c.ensurePromotedAPIMetadata(ctx, apiName, scan.ProfileName, apiCfg)
+}
+
+func (c *CLI) ensurePromotedAPIMetadata(ctx context.Context, apiName, profileName string, apiCfg *config.APIConfig) error {
 	opts := spec.OperationOptions{
-		BaseURL:         effectiveProfileBaseURL(apiCfg, scan.ProfileName),
-		OperationBase:   effectiveOperationBase(apiCfg, scan.ProfileName),
-		ServerVariables: effectiveServerVariables(apiCfg, scan.ProfileName),
+		BaseURL:         effectiveProfileBaseURL(apiCfg, profileName),
+		OperationBase:   effectiveOperationBase(apiCfg, profileName),
+		ServerVariables: effectiveServerVariables(apiCfg, profileName),
 	}
 	stateName := c.apiStateName(apiName)
 	if _, status, ok := spec.LoadOperationSetFromCacheStatus(c.specCacheDir(), stateName, Version, apiCfg.SpecFiles, opts, false); ok && !status.Stale {
@@ -71,7 +75,7 @@ func (c *CLI) ensurePromotedAPICommandMetadata(ctx context.Context, scan cliArgS
 
 	refreshCtx, cancel := context.WithTimeout(ctx, staleGeneratedOperationRefreshTimeout)
 	defer cancel()
-	if _, err := c.discoverSpecForProfile(refreshCtx, apiName, scan.ProfileName, false, staleGeneratedOperationRefreshTimeout); err != nil {
+	if _, err := c.discoverSpecForProfile(refreshCtx, apiName, profileName, false, staleGeneratedOperationRefreshTimeout); err != nil {
 		if status, ok := c.promotedAPIStaleMetadataStatus(apiName, apiCfg, opts); ok {
 			c.warnf("could not refresh API metadata for %q; using last synced metadata from %s: %v", apiName, formatCacheTime(status.FetchedAt), err)
 			return nil
@@ -257,19 +261,65 @@ func (c *CLI) installPromotedRootFallback(root *cobra.Command, cfg *config.Confi
 		if len(args) == 0 {
 			return cmd.Help()
 		}
-		if c.shouldSyncPromotedRootCommand(cfg, args) {
+		if c.shouldSyncPromotedRootCommand(cmd, cfg, args) {
 			return c.runSyncedPromotedAPICommand(cmd, cfg, args, originalArgs)
 		}
 		return unknownCommandError(cmd, args[0], "run "+strconvQuote(cmd.CommandPath()+" --help")+" to see available commands")
 	}
 }
 
-func (c *CLI) shouldSyncPromotedRootCommand(cfg *config.Config, args []string) bool {
+func (c *CLI) shouldSyncPromotedRootCommand(cmd *cobra.Command, cfg *config.Config, args []string) bool {
 	if len(args) == 0 || !looksLikeGeneratedCommandToken(args[0]) {
 		return false
 	}
 	apiCfg := cfg.APIs[c.promotedAPIName()]
-	return apiHasSpecSource(apiCfg)
+	return promotedAPIHasRefreshSource(apiCfg, c.profileFromCmd(cmd))
+}
+
+func promotedAPIHasRefreshSource(apiCfg *config.APIConfig, profileName string) bool {
+	if apiCfg == nil {
+		return false
+	}
+	return apiHasSpecSource(apiCfg) || effectiveProfileBaseURL(apiCfg, profileName) != ""
+}
+
+func (c *CLI) ensurePromotedAPIAuthOperationMetadata(cmd *cobra.Command, apiName string, args []string) error {
+	operation, _ := cmd.Flags().GetString("operation")
+	operation = strings.TrimSpace(operation)
+	if operation == "" || promotedAPIAuthOperationValidationDeferred(cmd, args) {
+		return nil
+	}
+	apiCfg, err := c.requireAPI(apiName)
+	if err != nil {
+		return err
+	}
+	ctx := requestContext(cmd)
+	profileName := c.profileFromCmd(cmd)
+	if _, ok, err := c.cachedOperationForAPI(ctx, apiName, apiCfg, profileName, operation); err != nil {
+		return err
+	} else if ok || !promotedAPIHasRefreshSource(apiCfg, profileName) {
+		return nil
+	}
+
+	refreshCtx, cancel := context.WithTimeout(ctx, staleGeneratedOperationRefreshTimeout)
+	defer cancel()
+	if _, ok, err := c.operationSetForAPI(refreshCtx, apiName, apiCfg, profileName, true); err != nil {
+		return fmt.Errorf("generated commands for promoted API %q are not available: %w", apiName, err)
+	} else if !ok {
+		return fmt.Errorf("generated commands for promoted API %q are not available", apiName)
+	}
+	return nil
+}
+
+func promotedAPIAuthOperationValidationDeferred(cmd *cobra.Command, args []string) bool {
+	if len(args) > 0 {
+		return true
+	}
+	credential, _ := cmd.Flags().GetString("credential")
+	if strings.TrimSpace(credential) != "" {
+		return true
+	}
+	return false
 }
 
 func (c *CLI) runSyncedPromotedAPICommand(cmd *cobra.Command, cfg *config.Config, args, originalArgs []string) error {
@@ -328,6 +378,9 @@ func (c *CLI) newPromotedAPIAuthCommand(apiName string) *cobra.Command {
 	}
 	getCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
 	getCmd.Flags().Bool("print-header", false, "Print the single resolved header as 'Name: value' on stdout and exit non-zero for any non-header auth")
+	getCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		return c.ensurePromotedAPIAuthOperationMetadata(cmd, apiName, args)
+	}
 	cmd.AddCommand(getCmd)
 
 	headerCmd := &cobra.Command{
@@ -345,6 +398,9 @@ func (c *CLI) newPromotedAPIAuthCommand(apiName string) *cobra.Command {
 		},
 	}
 	headerCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
+	headerCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		return c.ensurePromotedAPIAuthOperationMetadata(cmd, apiName, args)
+	}
 	cmd.AddCommand(headerCmd)
 
 	inspectCmd := &cobra.Command{
@@ -359,6 +415,12 @@ func (c *CLI) newPromotedAPIAuthCommand(apiName string) *cobra.Command {
 	inspectCmd.Flags().String("credential", "", "Credential ID to inspect instead of profile-level auth")
 	inspectCmd.Flags().String("operation", "", "Operation ID or command name to inspect")
 	inspectCmd.Flags().Bool("redact", false, "Redact sensitive auth values for shareable output")
+	inspectCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if err := rejectResponseTransformFlags(cmd); err != nil {
+			return err
+		}
+		return c.ensurePromotedAPIAuthOperationMetadata(cmd, apiName, args)
+	}
 	cmd.AddCommand(inspectCmd)
 
 	logoutCmd := &cobra.Command{


### PR DESCRIPTION
## Summary

- Refresh promoted-root fallbacks for BaseURL-discovered APIs when a generated-looking command is missing from the current operation cache.
- Prime promoted auth support commands with operation metadata when `--operation` is used, so fresh custom CLIs can resolve operation auth without a separate sync.
- Add regression coverage for both promoted command-surface paths.

## Validation

- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestCommandSurface(BaseURLFallbackRefreshesUnknownOperation|RootAuthOperationFetchesMetadataOnFirstRun|SyncedFallbackPreservesOriginalArgs|RootAuthHeader)'`
- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli -run 'TestCommandSurface|TestAPIAuthGet|TestAPIAuthInspect'`
- `env GOCACHE=/tmp/restish-gocache go test ./internal/cli`
- `env GOCACHE=/tmp/restish-gocache go test ./...`
- `env GOCACHE=/tmp/restish-gocache go run ./cmd/restish-docgen --check`
- `env GOCACHE=/tmp/restish-gocache go test -tags=integration ./...`