### PR TITLE
fix: use configured command name in help and hint text

### DIFF
--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -109,7 +109,7 @@ func (c *CLI) addAPICommand(root *cobra.Command) {
 	apiCmd.AddCommand(&cobra.Command{
 		Use:   "set <name> <patch> [patch...]",
 		Short: "Patch API config using shorthand syntax",
-		Long:  apiSetLong,
+		Long:  apiSetLongFor(c.commandNameOrDefault()),
 		Example: fmt.Sprintf(`  %s api set demo 'profiles.default.headers[]: X-Trace-Id: abc'
   %s api set demo 'base_url: https://staging.example.com'
   %s api set demo 'profiles.prod.auth.type: oauth-client-credentials'`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
@@ -135,10 +135,10 @@ Use api connect to register an API explicitly:
 
 In many cases replacing "configure" with "connect" is enough. If the v1
 command prompted for auth, profiles, or other defaults, connect first and then
-adjust the API with "restish api set".
+adjust the API with "%s api set".
 
 Upgrade guide: https://rest.sh/docs/getting-started/upgrade-from-v1/
-Archived v1 docs: https://rest.sh/v1/`, replacement)
+Archived v1 docs: https://rest.sh/v1/`, replacement, commandName)
 }
 
 // runAPIAuthLogout deletes the token cache entry for the named API+profile.
@@ -351,7 +351,7 @@ func (c *CLI) syncOneAPI(cmd *cobra.Command, apiName string, sharedTransport htt
 			ServerVariables: effectiveServerVariables(apiCfg, profileName),
 		}
 		if err := spec.StoreSpecInCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
-			c.warnf("could not cache generated commands for API %q: %v; run 'restish api sync %s' before using generated help", apiName, err, apiName)
+			c.warnf("could not cache generated commands for API %q: %v; run '%s api sync %s' before using generated help", apiName, err, c.commandNameOrDefault(), apiName)
 		}
 		style := humanTextStyleFor(c.Stdout)
 		if report, err := apiSpec.XCLIExtensionReport(); err == nil {
@@ -513,7 +513,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 			ServerVariables: effectiveServerVariables(apiCfg, "default"),
 		}
 		if err := spec.StoreSpecInCache(c.specCacheDir(), c.apiStateName(apiName), Version, apiSpec, apiCfg.SpecFiles, opOpts, 0); err != nil {
-			c.warnf("could not cache generated commands for API %q: %v; run 'restish api sync %s' before using generated help", apiName, err, apiName)
+			c.warnf("could not cache generated commands for API %q: %v; run '%s api sync %s' before using generated help", apiName, err, c.commandNameOrDefault(), apiName)
 		}
 	}
 	c.printConfigWrittenPath()
@@ -528,11 +528,11 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 	}
 	if apiSpec != nil {
 		opCount := connectedOperationCount(apiSpec, apiCfg)
-		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%d operations discovered — %s)\n", style.ok("Connected"), apiName, baseURL, opCount, style.hint("run 'restish "+apiName+" --help'"))
+		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%d operations discovered — %s)\n", style.ok("Connected"), apiName, baseURL, opCount, style.hint("run '"+c.commandNameOrDefault()+" "+apiName+" --help'"))
 	} else if noDiscover {
-		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%s — %s)\n", style.ok("Connected"), apiName, baseURL, style.warn("discovery skipped"), style.hint("run 'restish api sync "+apiName+"' later"))
+		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%s — %s)\n", style.ok("Connected"), apiName, baseURL, style.warn("discovery skipped"), style.hint("run '"+c.commandNameOrDefault()+" api sync "+apiName+"' later"))
 	} else {
-		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%s — %s)\n", style.ok("Connected"), apiName, baseURL, style.warn("no spec found"), style.hint("run 'restish api sync "+apiName+"' after connecting"))
+		fmt.Fprintf(c.Stdout, "%s API %q with base URL %s (%s — %s)\n", style.ok("Connected"), apiName, baseURL, style.warn("no spec found"), style.hint("run '"+c.commandNameOrDefault()+" api sync "+apiName+"' after connecting"))
 	}
 	return nil
 }
@@ -580,7 +580,7 @@ func (c *CLI) configureAllowedOperationOrigins(cmd *cobra.Command, apiName strin
 		return nil
 	}
 	if !output.IsTerminalReader(c.Stdin) {
-		c.warnf("cross-origin operation servers ignored: %s; allow with: restish api set %s 'allowed_operation_origins[]: %s'", strings.Join(origins, ", "), apiName, suggestions[0])
+		c.warnf("cross-origin operation servers ignored: %s; allow with: %s api set %s 'allowed_operation_origins[]: %s'", strings.Join(origins, ", "), c.commandNameOrDefault(), apiName, suggestions[0])
 		return nil
 	}
 	label := fmt.Sprintf("Allow generated operations to call %s? This writes allowed_operation_origins: %s [Y/n] ", strings.Join(origins, ", "), strings.Join(suggestions, ", "))

--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -117,7 +117,7 @@ func (c *CLI) printAPIAuthOverview(cmd *cobra.Command, apiName, profileName stri
 	if hasOps {
 		fmt.Fprintf(c.Stdout, "Callable secured operations: %d/%d\n", coverage.Callable, coverage.Secured)
 	} else {
-		fmt.Fprintf(c.Stdout, "Operation metadata: %s (%s)\n", style.warn("unavailable"), style.hint("run \"restish api sync "+apiName+"\" to refresh"))
+		fmt.Fprintf(c.Stdout, "Operation metadata: %s (%s)\n", style.warn("unavailable"), style.hint("run \""+c.commandNameOrDefault()+" api sync "+apiName+"\" to refresh"))
 	}
 	if len(ids) == 0 {
 		fmt.Fprintf(c.Stdout, "Credentials: %s\n", style.warn("none"))
@@ -138,7 +138,7 @@ func (c *CLI) printAPIAuthOverview(cmd *cobra.Command, apiName, profileName stri
 		coverage := c.operationAuthCoverage(apiName, profileName, prof, set.Operations)
 		c.printAPIAuthRequirementSummary(apiName, profileName, set.Operations, prof, coverage)
 		if credentialID := nextMissingCredentialID(set.Operations, prof, coverage); credentialID != "" {
-			fmt.Fprintf(c.Stdout, "%s run \"restish api auth add %s %s\".\n", style.hint("Next:"), apiName, credentialID)
+			fmt.Fprintf(c.Stdout, "%s run \"%s api auth add %s %s\".\n", style.hint("Next:"), c.commandNameOrDefault(), apiName, credentialID)
 		}
 	}
 }
@@ -185,7 +185,7 @@ func (c *CLI) runAPIAuthAdd(cmd *cobra.Command, args []string) error {
 	style := humanTextStyleFor(c.Stdout)
 	fmt.Fprintf(c.Stdout, "%s credential %q to API %q profile %q.\n", style.ok("Added"), credentialID, apiName, profileName)
 	if prof.Credentials[credentialID].Auth == nil && prof.Credentials[credentialID].AuthRef == "" {
-		fmt.Fprintf(c.Stdout, "%s run \"restish api auth inspect %s\" to review credential readiness.\n", style.hint("Next:"), apiName)
+		fmt.Fprintf(c.Stdout, "%s run \"%s api auth inspect %s\" to review credential readiness.\n", style.hint("Next:"), c.commandNameOrDefault(), apiName)
 	}
 	return nil
 }
@@ -215,7 +215,7 @@ func (c *CLI) runAPIAuthInspect(cmd *cobra.Command, args []string) error {
 	}
 	apiName := args[0]
 	if looksLikeURLArgument(apiName) {
-		return fmt.Errorf("api auth inspect expects an API name, not a URL\nv2 form: restish api auth get <api-name>")
+		return fmt.Errorf("api auth inspect expects an API name, not a URL\nv2 form: %s api auth get <api-name>", c.commandNameOrDefault())
 	}
 	profileName := c.profileFromCmd(cmd)
 	apiCfg, prof, err := c.apiProfileForAuth(apiName, profileName, false)
@@ -325,7 +325,7 @@ func (c *CLI) runAPIAuthInspectOperation(cmd *cobra.Command, apiName, profileNam
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("operation %q not found in cached metadata for API %q; run \"restish api sync %s\"", operationName, apiName, apiName)
+		return fmt.Errorf("operation %q not found in cached metadata for API %q; run \"%s api sync %s\"", operationName, apiName, c.commandNameOrDefault(), apiName)
 	}
 	if op.NoAuth {
 		fmt.Fprintf(c.Stdout, "Operation: %s\nAuth: none (security: [])\n", op.ID)
@@ -512,7 +512,7 @@ func (c *CLI) apiAuthGetOperationFragment(cmd *cobra.Command, apiName, profileNa
 		return "", err
 	}
 	if !ok {
-		return "", fmt.Errorf("operation %q not found in cached metadata for API %q; run \"restish api sync %s\"", operationName, apiName, apiName)
+		return "", fmt.Errorf("operation %q not found in cached metadata for API %q; run \"%s api sync %s\"", operationName, apiName, c.commandNameOrDefault(), apiName)
 	}
 	if op.NoAuth {
 		return "", fmt.Errorf("operation %q has security: [] and does not send auth material", op.ID)
@@ -600,7 +600,7 @@ func (c *CLI) resolveAuthInspectionConfig(apiName, profileName string, prof *con
 	switch len(ids) {
 	case 0:
 		if len(prof.Credentials) > 0 {
-			return resolvedAuthConfig{}, "", fmt.Errorf("profile %q of API %q has credentials but none have auth configured; run \"restish api auth inspect %s\"", profileName, apiName, apiName)
+			return resolvedAuthConfig{}, "", fmt.Errorf("profile %q of API %q has credentials but none have auth configured; run \"%s api auth inspect %s\"", profileName, apiName, c.commandNameOrDefault(), apiName)
 		}
 		return resolvedAuthConfig{}, "", nil
 	case 1:
@@ -799,7 +799,7 @@ func selectedOperationAuthConfigs(selected []selectedOperationAuth) []*config.Au
 func (c *CLI) apiProfileForAuth(apiName, profileName string, create bool) (*config.APIConfig, *config.ProfileConfig, error) {
 	apiCfg, err := c.requireAPI(apiName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w; run \"restish api list\" to see configured APIs", err)
+		return nil, nil, fmt.Errorf("%w; run \"%s api list\" to see configured APIs", err, c.commandNameOrDefault())
 	}
 	if apiCfg.Profiles != nil && apiCfg.Profiles[profileName] != nil {
 		return apiCfg, apiCfg.Profiles[profileName], nil
@@ -881,7 +881,7 @@ func (c *CLI) operationSetForAPI(ctx context.Context, apiName string, apiCfg *co
 	if err != nil || s == nil {
 		if !spec.HasLocalSpecFiles(apiCfg.SpecFiles) {
 			if err == nil && !forceRefresh && (apiCfg.BaseURL != "" || apiCfg.SpecURL != "" || len(apiCfg.SpecFiles) > 0) {
-				c.hintf("spec cache for API %q is empty; run \"restish api sync %s\" to populate it", apiName, apiName)
+				c.hintf("spec cache for API %q is empty; run \"%s api sync %s\" to populate it", apiName, c.commandNameOrDefault(), apiName)
 			}
 			return spec.OperationSet{}, false, err
 		}

--- a/internal/cli/command_name_hints_test.go
+++ b/internal/cli/command_name_hints_test.go
@@ -1,0 +1,56 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCommandNameInHintsAndHelp verifies that user-facing help and hint text
+// uses the configured command name (via SetCommandName) rather than the
+// hard-coded "restish" binary name. Regression guard for embedders whose
+// binary is not named "restish": a hint like `run "restish api sync"` points
+// at a binary the user does not have installed.
+func TestCommandNameInHintsAndHelp(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		// config show with no configured APIs emits the "api connect" hint.
+		{"config-show", []string{"config", "show"}},
+		// root help renders rootLongDefault, which references api connect / get / post.
+		{"root-help", []string{"--help"}},
+		// api set help renders apiSetLong, which references api inspect.
+		{"api-set-help", []string{"api", "set", "--help"}},
+		// doctor api help renders doctorAPILong, which references api auth inspect.
+		{"doctor-api-help", []string{"doctor", "api", "--help"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, out, errOut := newTestCLI(t)
+			c.SetCommandName("myapp")
+			if err := c.Run(append([]string{"myapp"}, tc.args...)); err != nil {
+				t.Fatalf("run %v: %v", tc.args, err)
+			}
+			combined := out.String() + errOut.String()
+			// No hint should tell the user to run the "restish" binary.
+			for _, bad := range []string{"restish api ", "restish get", "restish post", "`restish "} {
+				if strings.Contains(combined, bad) {
+					t.Errorf("output references hard-coded binary %q, got:\n%s", bad, combined)
+				}
+			}
+		})
+	}
+}
+
+// TestCommandNameDefaultsToRestish confirms the default (no SetCommandName)
+// still produces "restish"-branded help, so the stock binary is unchanged.
+func TestCommandNameDefaultsToRestish(t *testing.T) {
+	c, out, _ := newTestCLI(t)
+	if err := c.Run([]string{"restish", "--help"}); err != nil {
+		t.Fatalf("run --help: %v", err)
+	}
+	if !strings.Contains(out.String(), "restish api connect") {
+		t.Errorf("expected default help to reference \"restish api connect\", got:\n%s", out.String())
+	}
+}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -41,8 +41,8 @@ func (c *CLI) newCompletionCommand(root *cobra.Command) *cobra.Command {
 		Short: "Generate or install shell completion scripts",
 		Long:  completionLong,
 		Example: fmt.Sprintf(`  %s shell completion zsh
-  %s shell completion bash > restish.bash
-  %s shell completion install zsh`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
+  %s shell completion bash > %s.bash
+  %s shell completion install zsh`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unknown completion command %q", args[0])
@@ -62,8 +62,8 @@ func (c *CLI) newCompletionCommand(root *cobra.Command) *cobra.Command {
 	bash := &cobra.Command{
 		Use:                   "bash",
 		Short:                 fmt.Sprintf(shortDesc, "bash"),
-		Long:                  shellCompletionLong("bash", "restish shell completion bash > restish.bash"),
-		Example:               fmt.Sprintf("  %s shell completion bash > restish.bash", c.commandNameOrDefault()),
+		Long:                  shellCompletionLong("bash", fmt.Sprintf("%s shell completion bash > %s.bash", c.commandNameOrDefault(), c.commandNameOrDefault())),
+		Example:               fmt.Sprintf("  %s shell completion bash > %s.bash", c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args:                  usageNoArgs,
 		DisableFlagsInUseLine: true,
 		ValidArgsFunction:     cobra.NoFileCompletions,
@@ -74,9 +74,9 @@ func (c *CLI) newCompletionCommand(root *cobra.Command) *cobra.Command {
 	zsh := &cobra.Command{
 		Use:   "zsh",
 		Short: fmt.Sprintf(shortDesc, "zsh"),
-		Long:  shellCompletionLong("zsh", "restish shell completion install zsh"),
-		Example: fmt.Sprintf(`  %s shell completion zsh > _restish
-  %s shell completion install zsh`, c.commandNameOrDefault(), c.commandNameOrDefault()),
+		Long:  shellCompletionLong("zsh", fmt.Sprintf("%s shell completion install zsh", c.commandNameOrDefault())),
+		Example: fmt.Sprintf(`  %s shell completion zsh > _%s
+  %s shell completion install zsh`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args:              usageNoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -86,9 +86,9 @@ func (c *CLI) newCompletionCommand(root *cobra.Command) *cobra.Command {
 	fish := &cobra.Command{
 		Use:   "fish",
 		Short: fmt.Sprintf(shortDesc, "fish"),
-		Long:  shellCompletionLong("fish", "restish shell completion install fish"),
-		Example: fmt.Sprintf(`  %s shell completion fish > restish.fish
-  %s shell completion install fish`, c.commandNameOrDefault(), c.commandNameOrDefault()),
+		Long:  shellCompletionLong("fish", fmt.Sprintf("%s shell completion install fish", c.commandNameOrDefault())),
+		Example: fmt.Sprintf(`  %s shell completion fish > %s.fish
+  %s shell completion install fish`, c.commandNameOrDefault(), c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args:              usageNoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -98,7 +98,7 @@ func (c *CLI) newCompletionCommand(root *cobra.Command) *cobra.Command {
 	powershell := &cobra.Command{
 		Use:               "powershell",
 		Short:             fmt.Sprintf(shortDesc, "powershell"),
-		Long:              shellCompletionLong("powershell", "restish shell completion powershell | Out-String | Invoke-Expression"),
+		Long:              shellCompletionLong("powershell", fmt.Sprintf("%s shell completion powershell | Out-String | Invoke-Expression", c.commandNameOrDefault())),
 		Example:           fmt.Sprintf("  %s shell completion powershell | Out-String | Invoke-Expression", c.commandNameOrDefault()),
 		Args:              usageNoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
@@ -582,7 +582,7 @@ func (c *CLI) installZshCompletion(cmd *cobra.Command, opts completionInstallOpt
 	if err := generateCompletionScript(cmd.Root(), opts.Shell, opts.NoDesc, &script); err != nil {
 		return err
 	}
-	rcBlock := zshCompletionRCBlock(scriptPath)
+	rcBlock := zshCompletionRCBlock(c.commandNameOrDefault(), scriptPath)
 
 	existingRCBytes, _ := os.ReadFile(rcPath)
 	existingRC := string(existingRCBytes)
@@ -728,11 +728,11 @@ func sanitizePathComponent(value string) string {
 	return b.String()
 }
 
-func zshCompletionRCBlock(scriptPath string) string {
+func zshCompletionRCBlock(commandName, scriptPath string) string {
 	quotedPath := shellSingleQuote(scriptPath)
 	return strings.Join([]string{
 		completionBlockStart,
-		"# Managed by `restish completion install zsh`.",
+		"# Managed by `" + commandName + " completion install zsh`.",
 		"autoload -Uz compinit",
 		"if ! whence -w compdef >/dev/null 2>&1; then",
 		"  compinit",

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -156,7 +156,7 @@ func (c *CLI) runConfigTrust(cmd *cobra.Command, args []string) error {
 
 func (c *CLI) printConfigShowAPIs(style humanTextStyle, cfg *config.Config) {
 	if cfg == nil || len(cfg.APIs) == 0 {
-		fmt.Fprintf(c.Stdout, "%s %s (%s)\n", style.key("APIs:"), style.warn("none"), style.hint("run \"restish api connect <name> <url>\""))
+		fmt.Fprintf(c.Stdout, "%s %s (%s)\n", style.key("APIs:"), style.warn("none"), style.hint("run \""+c.commandNameOrDefault()+" api connect <name> <url>\""))
 		return
 	}
 	names := sortedConfigKeys(cfg.APIs)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -37,7 +37,7 @@ func (c *CLI) addDoctorCommand(root *cobra.Command) {
 	doctorCmd.AddCommand(&cobra.Command{
 		Use:   "api <name>",
 		Short: "Diagnose a registered API",
-		Long:  doctorAPILong,
+		Long:  doctorAPILongFor(c.commandNameOrDefault()),
 		Example: fmt.Sprintf(`  %s doctor api demo
   %s doctor api demo --check-network`, c.commandNameOrDefault(), c.commandNameOrDefault()),
 		Args: usageExactArgs(1),
@@ -332,11 +332,11 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(out, "Spec cache: %s\n", style.ok("present"))
 		}
 	} else {
-		fmt.Fprintf(out, "Spec cache: %s (%s)\n", style.warn("missing"), style.hint("run \"restish api sync "+name+"\""))
+		fmt.Fprintf(out, "Spec cache: %s (%s)\n", style.warn("missing"), style.hint("run \""+c.commandNameOrDefault()+" api sync "+name+"\""))
 	}
 	if opInfo.Available {
 		if opInfo.Cached && opInfo.CacheStatus.Stale {
-			fmt.Fprintf(out, "Generated operations: %d %s (%s; %s)\n", len(opInfo.Set.Operations), style.ok("available"), style.warn("stale"), style.hint("refresh with \"restish api sync "+name+"\""))
+			fmt.Fprintf(out, "Generated operations: %d %s (%s; %s)\n", len(opInfo.Set.Operations), style.ok("available"), style.warn("stale"), style.hint("refresh with \""+c.commandNameOrDefault()+" api sync "+name+"\""))
 		} else {
 			fmt.Fprintf(out, "Generated operations: %d %s\n", len(opInfo.Set.Operations), style.ok("available"))
 		}
@@ -345,7 +345,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 		}
 		printXCLIExtensionDoctorDetails(out, style, opInfo.Set.XCLIExtensions)
 	} else {
-		fmt.Fprintf(out, "Generated operations: %s (%s)\n", style.warn("unavailable"), style.hint("run \"restish api sync "+name+"\""))
+		fmt.Fprintf(out, "Generated operations: %s (%s)\n", style.warn("unavailable"), style.hint("run \""+c.commandNameOrDefault()+" api sync "+name+"\""))
 	}
 	if auth := c.doctorAuthForProfile(name, profileName, profileForName(api, profileName)); auth.Status == "configured" {
 		if len(auth.Sources) > 0 {
@@ -362,7 +362,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Fprintf(out, "Auth: %s\n", style.warn("no profile auth configured"))
 	}
-	fmt.Fprintf(out, "Auth details: restish api auth inspect %s\n", name)
+	fmt.Fprintf(out, "Auth details: %s api auth inspect %s\n", c.commandNameOrDefault(), name)
 	checkNetwork, _ := cmd.Flags().GetBool("check-network")
 	if checkNetwork {
 		c.printAPIReachability(out, style, c.checkAPIReachability(requestContext(cmd), name, effectiveProfileBaseURL(api, profileName), api, profileName))
@@ -467,7 +467,7 @@ func (c *CLI) doctorRootReport() doctorRootReport {
 		PluginDirectory:       c.pluginDir(),
 		InstalledPlugins:      c.doctorInstalledPluginsReport(),
 		ContentTypes:          c.doctorContentTypesReport(),
-		ShellSetup:            doctorShellSetupReportValue(),
+		ShellSetup:            doctorShellSetupReportValue(c.commandNameOrDefault()),
 	}
 }
 
@@ -714,7 +714,7 @@ func doctorFilePermissionReport(path, remediation string) doctorPermissionReport
 	return doctorPermissionReport{Status: "ok"}
 }
 
-func doctorShellSetupReportValue() doctorShellSetupReport {
+func doctorShellSetupReportValue(commandName string) doctorShellSetupReport {
 	shell, source := detectRunningShell()
 	if shell == "" {
 		return doctorShellSetupReport{Status: "unknown"}
@@ -722,7 +722,7 @@ func doctorShellSetupReportValue() doctorShellSetupReport {
 	if _, ok := shellSetups[shell]; !ok {
 		return doctorShellSetupReport{Status: "unsupported", Shell: shell, Source: source}
 	}
-	hint := fmt.Sprintf("run `restish shell setup %s` if glob expansion causes trouble", shell)
+	hint := fmt.Sprintf("run `%s shell setup %s` if glob expansion causes trouble", commandName, shell)
 	if source == "$SHELL" {
 		hint += " (detected via $SHELL)"
 	}
@@ -783,7 +783,7 @@ func (c *CLI) doctorAPIReport(cmd *cobra.Command, name string) doctorAPIReport {
 		}
 	}
 	report.Auth = c.doctorAuthForProfile(name, profileName, profileForName(api, profileName))
-	report.Auth.Hint = fmt.Sprintf("run `restish api auth inspect %s` for credential coverage and auth material", name)
+	report.Auth.Hint = fmt.Sprintf("run `%s api auth inspect %s` for credential coverage and auth material", c.commandNameOrDefault(), name)
 	checkNetwork, _ := cmd.Flags().GetBool("check-network")
 	if checkNetwork {
 		report.Reachability = c.checkAPIReachability(requestContext(cmd), name, effectiveProfileBaseURL(api, profileName), api, profileName)
@@ -933,10 +933,10 @@ func (c *CLI) printShellSetupDiagnostic(out io.Writer, style humanTextStyle) {
 		return
 	}
 	if source == "$SHELL" {
-		fmt.Fprintf(out, "Shell setup: %s if glob expansion causes trouble (detected via $SHELL)\n", style.hint("run `restish shell setup "+shell+"`"))
+		fmt.Fprintf(out, "Shell setup: %s if glob expansion causes trouble (detected via $SHELL)\n", style.hint("run `"+c.commandNameOrDefault()+" shell setup "+shell+"`"))
 		return
 	}
-	fmt.Fprintf(out, "Shell setup: %s if glob expansion causes trouble\n", style.hint("run `restish shell setup "+shell+"`"))
+	fmt.Fprintf(out, "Shell setup: %s if glob expansion causes trouble\n", style.hint("run `"+c.commandNameOrDefault()+" shell setup "+shell+"`"))
 }
 
 func (c *CLI) checkAPIReachability(ctx context.Context, apiName, baseURL string, apiCfg *config.APIConfig, profileName string) doctorReachabilityReport {

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -76,7 +76,7 @@ func (c *CLI) buildAPICommandFromOperationSet(apiName string, apiCfg *config.API
 		long = strings.TrimSpace(set.Info.Summary)
 	}
 	isRootAPI := c.isPromotedAPI(apiName)
-	long, fullLong := generatedAPIHelpDescription(apiName, long)
+	long, fullLong := generatedAPIHelpDescription(c.commandNameOrDefault(), apiName, long)
 	if generatedAPIHasAuth(ops) && !isRootAPI {
 		if long != "" {
 			long += "\n\n"
@@ -202,7 +202,7 @@ func generatedAPIHasAuth(ops []spec.Operation) bool {
 	return false
 }
 
-func generatedAPIHelpDescription(apiName, description string) (string, string) {
+func generatedAPIHelpDescription(commandName, apiName, description string) (string, string) {
 	description = strings.TrimSpace(description)
 	if description == "" {
 		return "", ""
@@ -215,7 +215,7 @@ func generatedAPIHelpDescription(apiName, description string) (string, string) {
 	if short != "" && !strings.HasSuffix(short, "...") {
 		short += "\n..."
 	}
-	note := fmt.Sprintf("Description truncated; run \"restish %s --help-all\" to show the full API description.", apiName)
+	note := fmt.Sprintf("Description truncated; run \"%s %s --help-all\" to show the full API description.", commandName, apiName)
 	if short == "" {
 		return note, description
 	}

--- a/internal/cli/help_text.go
+++ b/internal/cli/help_text.go
@@ -1,11 +1,15 @@
 package cli
 
-const rootLongDefault = "**Restish** is a CLI for interacting with REST-ish HTTP APIs.\n\n" +
-	"Every API deserves a CLI. Restish gives you:\n\n" +
-	"- Generic HTTP commands for quick one-off requests.\n" +
-	"- OpenAPI-backed commands for registered APIs.\n" +
-	"- Output, filtering, auth, pagination, retries, caching, and plugins that stay friendly to the shell.\n\n" +
-	"Run `restish api connect` when an API should become a named command surface. Run `restish get`, `restish post`, and the other HTTP commands when a direct URL is enough."
+import "fmt"
+
+func rootLongDefaultFor(commandName string) string {
+	return "**Restish** is a CLI for interacting with REST-ish HTTP APIs.\n\n" +
+		"Every API deserves a CLI. Restish gives you:\n\n" +
+		"- Generic HTTP commands for quick one-off requests.\n" +
+		"- OpenAPI-backed commands for registered APIs.\n" +
+		"- Output, filtering, auth, pagination, retries, caching, and plugins that stay friendly to the shell.\n\n" +
+		fmt.Sprintf("Run `%s api connect` when an API should become a named command surface. Run `%s get`, `%s post`, and the other HTTP commands when a direct URL is enough.", commandName, commandName, commandName)
+}
 
 const versionLong = "Print the Restish version and exit.\n\n" +
 	"Use this in bug reports, release checks, and scripts that need to confirm which Restish binary is running."
@@ -35,9 +39,11 @@ const apiConnectLong = "Connect Restish to an API, discover its OpenAPI descript
 const apiInspectLong = "Print the saved config for one registered API as redacted JSON.\n\n" +
 	"Use this when you need the local API entry, including profiles, headers, query defaults, auth config, spec URLs, and generated-command settings. Sensitive auth values, credential-like headers, and credential-like query parameters are redacted in the output."
 
-const apiSetLong = "Patch one registered API using Restish shorthand syntax.\n\n" +
-	"Use this for durable local overrides such as profile URLs, default headers, query parameters, auth settings, and server variables. Patches are applied to the saved config file; they do not update the remote API or the cached OpenAPI document.\n\n" +
-	"Run `restish api inspect <name>` first when you want to confirm the current config shape."
+func apiSetLongFor(commandName string) string {
+	return "Patch one registered API using Restish shorthand syntax.\n\n" +
+		"Use this for durable local overrides such as profile URLs, default headers, query parameters, auth settings, and server variables. Patches are applied to the saved config file; they do not update the remote API or the cached OpenAPI document.\n\n" +
+		fmt.Sprintf("Run `%s api inspect <name>` first when you want to confirm the current config shape.", commandName)
+}
 
 const apiAuthLong = "Manage auth material for a registered API profile.\n\n" +
 	"Use these commands when a generated OpenAPI command reports missing auth, when you want to see which credentials satisfy secured operations, or when cached OAuth tokens need to be cleared.\n\n" +
@@ -135,8 +141,10 @@ const linksLong = "Perform a `GET` request and print hypermedia links found in t
 const doctorLong = "Diagnose Restish configuration and runtime paths.\n\n" +
 	"Use this when Restish is reading the wrong config, permissions look suspicious, shell setup is incomplete, caches are in unexpected locations, or plugin discovery is confusing. Pass `-o json` for structured diagnostics."
 
-const doctorAPILong = "Diagnose one registered API.\n\n" +
-	"The report checks registration, spec cache freshness, generated operation availability, shallow auth readiness, and optional network reachability. Use `--check-network` when you want Restish to make a bounded request to the API base URL. For detailed credential coverage and auth material, run `restish api auth inspect <api>`."
+func doctorAPILongFor(commandName string) string {
+	return "Diagnose one registered API.\n\n" +
+		fmt.Sprintf("The report checks registration, spec cache freshness, generated operation availability, shallow auth readiness, and optional network reachability. Use `--check-network` when you want Restish to make a bounded request to the API base URL. For detailed credential coverage and auth material, run `%s api auth inspect <api>`.", commandName)
+}
 
 const doctorPluginLong = "Diagnose one Restish plugin executable.\n\n" +
 	"The report checks plugin discovery, executable status, manifest loading, declared capabilities, and Restish plugin protocol compatibility."

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,7 +32,7 @@ func (c *CLI) newRootCmd() *cobra.Command {
 	}
 	long := c.commandLong
 	if long == "" {
-		long = rootLongDefault
+		long = rootLongDefaultFor(use)
 	}
 	root := &cobra.Command{
 		Use:   use,

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -195,10 +195,10 @@ func (c *CLI) hintShellSetup() {
 		return
 	}
 	if source == "$SHELL" {
-		c.tipf("run `restish shell setup %s` to configure your shell (prevents glob expansion issues; detected via $SHELL)", shell)
+		c.tipf("run `%s shell setup %s` to configure your shell (prevents glob expansion issues; detected via $SHELL)", c.commandNameOrDefault(), shell)
 		return
 	}
-	c.tipf("run `restish shell setup %s` to configure your shell (prevents glob expansion issues)", shell)
+	c.tipf("run `%s shell setup %s` to configure your shell (prevents glob expansion issues)", c.commandNameOrDefault(), shell)
 }
 
 func detectRunningShell() (string, string) {


### PR DESCRIPTION
User-facing help, hints, and errors hard-coded the "restish" binary name in invocable command references (e.g. `run "restish api sync <api>"`). Embedders that set a custom command name via SetCommandName got hints pointing at a binary the user does not have installed. The commandNameOrDefault() accessor already existed and was used correctly in ~10 sites, but ~34 siblings still hard-coded the literal.

Replace those invocable references with commandNameOrDefault(), threading the command name into the standalone functions and help_text.go builders that lacked a *CLI receiver. Product-name prose ("Restish is a CLI", the doctor "Restish version:" label), internal identifiers, and the shell alias feature are intentionally left unchanged.

Default behavior is unchanged: the fallback is still "restish", so stock binary output is byte-identical (docgen --check passes).

Add command_name_hints_test.go asserting custom command names appear in help and hint text and the "restish" binary name does not.