### PR TITLE
fix(migrate): normalize legacy OAuth scope

### DIFF
--- a/config/legacy.go
+++ b/config/legacy.go
@@ -254,9 +254,18 @@ func convertLegacyProfile(legacy *legacyAPIProfile) *ProfileConfig {
 		Query:   sortedQueryList(legacy.Query),
 	}
 	if legacy.Auth != nil {
+		params := cloneStringMap(legacy.Auth.Params)
+		switch legacy.Auth.Name {
+		case "oauth-authorization-code", "oauth-client-credentials":
+			// v1 accepted scope as an endpoint pass-through; v2 names it scopes.
+			if scope, ok := params["scope"]; ok {
+				params["scopes"] = scope
+				delete(params, "scope")
+			}
+		}
 		prof.Auth = &AuthConfig{
 			Type:   legacy.Auth.Name,
-			Params: cloneStringMap(legacy.Auth.Params),
+			Params: params,
 		}
 	}
 	return prof

--- a/config/legacy_test.go
+++ b/config/legacy_test.go
@@ -24,7 +24,7 @@ const legacyAPIsJSON = `{
           "params": {
             "authorize_url": "https://dex.internal.example.com/auth",
             "client_id":     "restish",
-            "scopes":        "openid email",
+            "scope":         "openid email",
             "token_url":     "https://dex.internal.example.com/token"
           }
         }
@@ -78,10 +78,30 @@ func TestConvertLegacyAPIFileCert(t *testing.T) {
 	if got := prof.Auth.Params["client_id"]; got != "restish" {
 		t.Errorf("Auth.Params[client_id] = %q", got)
 	}
+	if got := prof.Auth.Params["scopes"]; got != "openid email" {
+		t.Errorf("Auth.Params[scopes] = %q", got)
+	}
+	if _, ok := prof.Auth.Params["scope"]; ok {
+		t.Error("legacy Auth.Params[scope] should be removed")
+	}
 	for _, w := range warnings {
 		if strings.Contains(w, "PKCS") {
 			t.Errorf("unexpected PKCS#11 warning for cert/key entry: %s", w)
 		}
+	}
+}
+
+func TestConvertLegacyProfileClientCredentialsScope(t *testing.T) {
+	prof := convertLegacyProfile(&legacyAPIProfile{Auth: &legacyAPIConfigAuth{
+		Name:   "oauth-client-credentials",
+		Params: map[string]string{"scope": "read write"},
+	}})
+
+	if got := prof.Auth.Params["scopes"]; got != "read write" {
+		t.Errorf("Auth.Params[scopes] = %q", got)
+	}
+	if _, ok := prof.Auth.Params["scope"]; ok {
+		t.Error("legacy Auth.Params[scope] should be removed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- normalize the singular OAuth `scope` parameter accepted by v1 to v2's canonical `scopes` parameter during legacy config conversion
- cover authorization-code and client-credentials profiles
- leave non-OAuth authentication parameters unchanged

## Context

Restish v1 accepted `scope` as an OAuth endpoint pass-through even though its documented parameter was `scopes`. The v2 CLI can still tolerate that key as a pass-through, but embedders reading converted profiles use the canonical `scopes` parameter and otherwise receive an empty scope.

When both keys exist, the singular `scope` value wins during conversion. This preserves v1 behavior, where endpoint pass-through parameters were applied after the value derived from `scopes`.

Fixes #393

---

> [!NOTE]
> AI assistance: test coverage, PR description.
