### PR TITLE
fix(mcp): use NDJSON framing for stdio transport (#388)

### DIFF
--- a/cmd/restish-mcp/mcp_test.go
+++ b/cmd/restish-mcp/mcp_test.go
@@ -693,37 +693,18 @@ func TestServeStdioInvalidRequests(t *testing.T) {
 	}
 }
 
-func TestReadFrameHeaderLimits(t *testing.T) {
+func TestReadFrameLineLimits(t *testing.T) {
 	t.Run("oversized line", func(t *testing.T) {
-		input := strings.Repeat("X", maxRPCHeaderLineBytes+1) + "\r\n\r\n"
+		input := strings.Repeat("X", maxRPCPayloadBytes+1) + "\n"
 		_, err := readFrame(bufio.NewReader(strings.NewReader(input)))
-		if err == nil || !strings.Contains(err.Error(), "header line exceeds") {
-			t.Fatalf("err = %v, want header line limit", err)
+		if err == nil || !strings.Contains(err.Error(), "line exceeds") {
+			t.Fatalf("err = %v, want line limit", err)
 		}
 	})
 
-	t.Run("oversized preamble", func(t *testing.T) {
-		var input strings.Builder
-		for input.Len() <= maxRPCHeaderBytes {
-			input.WriteString("X-Test: ")
-			input.WriteString(strings.Repeat("a", 512))
-			input.WriteString("\r\n")
-		}
-		input.WriteString("\r\n")
-		_, err := readFrame(bufio.NewReader(strings.NewReader(input.String())))
-		if err == nil || !strings.Contains(err.Error(), "headers exceed") {
-			t.Fatalf("err = %v, want total header limit", err)
-		}
-	})
-
-	t.Run("payload accepted within header limits", func(t *testing.T) {
-		payload := []byte("{}")
-		var input bytes.Buffer
-		input.WriteString("Content-Length: 2\r\n")
-		input.WriteString(strings.Repeat("X-Test: a\r\n", 10))
-		input.WriteString("\r\n")
-		input.Write(payload)
-		got, err := readFrame(bufio.NewReader(&input))
+	t.Run("payload accepted within line limits", func(t *testing.T) {
+		input := "{}\n"
+		got, err := readFrame(bufio.NewReader(strings.NewReader(input)))
 		if err != nil {
 			t.Fatalf("readFrame: %v", err)
 		}
@@ -734,7 +715,7 @@ func TestReadFrameHeaderLimits(t *testing.T) {
 }
 
 func TestServeStdioWritesFramingError(t *testing.T) {
-	input := strings.Repeat("X", maxRPCHeaderLineBytes+1) + "\r\n\r\n"
+	input := strings.Repeat("X", maxRPCPayloadBytes+1) + "\n"
 	var stdout bytes.Buffer
 	err := (&Server{}).ServeStdio(strings.NewReader(input), &stdout)
 	if err == nil {

--- a/cmd/restish-mcp/server.go
+++ b/cmd/restish-mcp/server.go
@@ -7,16 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"unicode/utf8"
 )
 
-// maxRPCPayloadBytes caps the Content-Length accepted from an MCP client to
+// maxRPCPayloadBytes caps the line length accepted from an MCP client to
 // prevent memory exhaustion. Matches the CBOR plugin protocol limit.
 const maxRPCPayloadBytes = 64 << 20 // 64 MiB
-const maxRPCHeaderLineBytes = 8 << 10
-const maxRPCHeaderBytes = 16 << 10
 
 type Server struct {
 	Tools          []*Tool
@@ -270,61 +266,33 @@ func marshalPretty(v any) string {
 }
 
 func readFrame(r *bufio.Reader) ([]byte, error) {
-	length := -1
-	totalHeaderBytes := 0
 	for {
-		line, n, err := readHeaderLine(r)
-		if err != nil {
-			if errors.Is(err, io.EOF) && line == "" {
-				return nil, io.EOF
+		var line []byte
+		for {
+			frag, err := r.ReadSlice('\n')
+			line = append(line, frag...)
+			if len(line) > maxRPCPayloadBytes {
+				return nil, fmt.Errorf("MCP frame line exceeds %d bytes", maxRPCPayloadBytes)
+			}
+			if err == nil {
+				break
+			}
+			if errors.Is(err, bufio.ErrBufferFull) {
+				continue
+			}
+			if errors.Is(err, io.EOF) {
+				if len(line) == 0 {
+					return nil, io.EOF
+				}
+				break
 			}
 			return nil, err
 		}
-		totalHeaderBytes += n
-		if totalHeaderBytes > maxRPCHeaderBytes {
-			return nil, fmt.Errorf("MCP frame headers exceed %d bytes", maxRPCHeaderBytes)
-		}
-		line = strings.TrimRight(line, "\r\n")
-		if line == "" {
-			break
-		}
-		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
-			value := strings.TrimSpace(line[len("content-length:"):])
-			n, err := strconv.Atoi(value)
-			if err != nil {
-				return nil, fmt.Errorf("invalid content-length %q", value)
-			}
-			if n < 0 || n > maxRPCPayloadBytes {
-				return nil, fmt.Errorf("content-length %d out of range (max %d)", n, maxRPCPayloadBytes)
-			}
-			length = n
-		}
-	}
-	if length < 0 {
-		return nil, errors.New("missing Content-Length header")
-	}
-	payload := make([]byte, length)
-	if _, err := io.ReadFull(r, payload); err != nil {
-		return nil, err
-	}
-	return payload, nil
-}
-
-func readHeaderLine(r *bufio.Reader) (string, int, error) {
-	var line []byte
-	for {
-		frag, err := r.ReadSlice('\n')
-		line = append(line, frag...)
-		if len(line) > maxRPCHeaderLineBytes {
-			return string(line), len(line), fmt.Errorf("MCP frame header line exceeds %d bytes", maxRPCHeaderLineBytes)
-		}
-		if err == nil {
-			return string(line), len(line), nil
-		}
-		if errors.Is(err, bufio.ErrBufferFull) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
 			continue
 		}
-		return string(line), len(line), err
+		return line, nil
 	}
 }
 
@@ -338,8 +306,13 @@ func writeRPC(w io.Writer, resp rpcResponse) error {
 
 func writeFrame(w io.Writer, payload []byte) error {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "Content-Length: %d\r\n\r\n", len(payload))
 	buf.Write(payload)
-	_, err := w.Write(buf.Bytes())
-	return err
+	buf.WriteByte('\n')
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	if f, ok := w.(interface{ Flush() error }); ok {
+		return f.Flush()
+	}
+	return nil
 }

--- a/internal/cli/mcp_plugin_test.go
+++ b/internal/cli/mcp_plugin_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -206,8 +205,8 @@ func writeMCPFrame(t *testing.T, buf *bytes.Buffer, msg map[string]any) {
 	if err != nil {
 		t.Fatalf("marshal frame: %v", err)
 	}
-	fmt.Fprintf(buf, "Content-Length: %d\r\n\r\n", len(data))
 	buf.Write(data)
+	buf.WriteByte('\n')
 }
 
 func readMCPResponses(t *testing.T, data []byte) []map[string]any {
@@ -215,46 +214,19 @@ func readMCPResponses(t *testing.T, data []byte) []map[string]any {
 	var out []map[string]any
 	reader := bufio.NewReader(bytes.NewReader(data))
 	for {
-		payload, err := readMCPFrame(reader)
-		if err != nil {
+		line, err := reader.ReadBytes('\n')
+		if err != nil && len(line) == 0 {
 			break
 		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
 		var msg map[string]any
-		if err := json.Unmarshal(payload, &msg); err != nil {
+		if err := json.Unmarshal(line, &msg); err != nil {
 			t.Fatalf("unmarshal MCP response: %v", err)
 		}
 		out = append(out, msg)
 	}
 	return out
-}
-
-func readMCPFrame(r *bufio.Reader) ([]byte, error) {
-	length := -1
-	for {
-		line, err := r.ReadString('\n')
-		if err != nil {
-			return nil, err
-		}
-		line = strings.TrimRight(line, "\r\n")
-		if line == "" {
-			break
-		}
-		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
-			var n int
-			if _, err := fmt.Sscanf(line, "Content-Length: %d", &n); err != nil {
-				if _, err := fmt.Sscanf(line, "content-length: %d", &n); err != nil {
-					return nil, err
-				}
-			}
-			length = n
-		}
-	}
-	if length < 0 {
-		return nil, fmt.Errorf("missing content-length")
-	}
-	payload := make([]byte, length)
-	if _, err := io.ReadFull(r, payload); err != nil {
-		return nil, err
-	}
-	return payload, nil
 }


### PR DESCRIPTION
Fixes #388

### Summary of Changes
- Replaced Content-Length HTTP header framing with line-delimited JSON (NDJSON) framing (`<json>\n`) for stdio transport in `cmd/restish-mcp/server.go`.
- Added automatic flushing on writers implementing `interface{ Flush() error }`.
- Updated test suite in `cmd/restish-mcp/mcp_test.go` to test NDJSON line limits and framing error handling.