### PR TITLE
feat(cli): browse OpenAPI operations by HTTP path

### DIFF
--- a/docs/design/043-generic-operation-browsing.md
+++ b/docs/design/043-generic-operation-browsing.md
@@ -1,0 +1,156 @@
+# Generic Operation Browsing
+
+Status: proposed.
+
+## Problem
+
+Restish can connect an OpenAPI-described API and expose generated commands, but
+large APIs may intentionally hide routine resource operations from that command
+tree with `x-cli-hidden`. Shell completion also omits hidden operations. The
+generic HTTP commands can still call those resources, but users have no
+command-shaped way to discover which registered paths are available.
+
+Hypermedia links do not solve this problem. A link identifies a relation and
+URI, but it does not communicate the HTTP method, operation summary,
+`operationId`, or a Restish command that can be copied and completed.
+
+## Goals
+
+- Let a generic HTTP verb browse matching OpenAPI operations below a registered
+  API path.
+- Show command templates rather than bare URLs.
+- Include `x-cli-hidden` operations because this browser is independent of the
+  generated command surface.
+- Preserve exact HTTP requests, request bodies, direct URLs, and APIs without
+  cached OpenAPI metadata.
+- Use the active profile when resolving operation paths.
+- Keep browsing local and deterministic; it must not refresh a remote spec.
+
+## Non-Goals
+
+- Do not add another generated-command tree.
+- Do not change shell completion visibility.
+- Do not browse operations for arbitrary, unregistered URLs.
+- Do not include operations removed with `x-cli-ignore`.
+- Do not infer request bodies, query values, or optional parameter values.
+- Do not replace `links`, which remains response-driven hypermedia navigation.
+
+## User Workflow
+
+After connecting an API, a user can browse all GET operations:
+
+```text
+restish get demo/
+```
+
+They can narrow the path and preserve concrete path values:
+
+```text
+restish get demo/users/42/
+```
+
+Example human output:
+
+```text
+COMMAND                                      SUMMARY       OPERATION ID
+restish get demo/users/42/sessions           List sessions listUserSessions
+restish get demo/users/42/sessions/{id}      Get session   getUserSession
+```
+
+The command value is a command template. Concrete values already present in
+the browsed prefix remain concrete; unresolved OpenAPI path parameters remain
+in `{parameter}` form for the user to replace.
+
+The selected verb filters operations:
+
+```text
+restish post demo/
+restish patch demo/users/42/
+restish delete demo/users/42/
+```
+
+## Dispatch Rules
+
+Browsing applies only when all of these conditions are true:
+
+1. The invocation uses an explicit generic HTTP verb.
+2. The first argument starts with a registered API short name.
+3. The request has no body from positional arguments, stdin, or an internal
+   body override.
+4. Cached operation metadata is available without remote discovery.
+5. No operation for that method exactly matches the requested path, or the
+   short-name path has a trailing slash that explicitly requests parent
+   browsing.
+6. One or more operations for that method are descendants of the requested
+   path.
+
+When all conditions hold, Restish renders the matching operations and does not
+send an HTTP request.
+
+Exact operation matches without a trailing slash always execute the request,
+including template matches such as `demo/users/42`. A trailing slash explicitly
+requests descendants, so `demo/users` can execute a collection operation while
+`demo/users/` browses operations below it. If there are no descendants, Restish
+falls back to the exact request. A request with a body always executes. A direct
+URL, unknown API name, missing operation cache, unmatched path, or method with
+no descendants also follows the existing HTTP request path unchanged.
+
+Query strings and fragments are not browsing prefixes. They retain normal
+request behavior.
+
+## Operation Selection
+
+Browsing uses the same cached `OperationSet`, active profile base URL, and
+`operation_base` resolution used by URL completion. It compares normalized path
+segments:
+
+- Literal OpenAPI segments must match literally.
+- A path-template segment matches one concrete browsed segment.
+- A descendant must contain at least one segment beyond the browsed prefix.
+- A trailing slash turns an exact short-name operation into a parent browse
+  only when matching descendants exist.
+
+Results are filtered case-insensitively by HTTP method and sorted by command,
+then `operationId`.
+
+`x-cli-hidden` is deliberately ignored here. That extension controls generated
+commands and shell completion, not whether generic HTTP users may discover an
+operation. `x-cli-ignore` operations are absent from the `OperationSet` and
+therefore remain undiscoverable.
+
+## Output Contract
+
+Each result contains stable fields:
+
+```json
+{
+  "command": "restish get demo/users/{user-id}",
+  "summary": "Get user",
+  "operation_id": "getUser"
+}
+```
+
+Normal Restish output selection applies. Interactive output presents a compact
+table, while non-interactive output remains structured and explicit formats
+such as `-o json` continue to work.
+
+The browser writes only to stdout. It does not emit request traces because no
+request is planned or sent.
+
+## Compatibility
+
+This is additive for parent paths backed by cached OpenAPI operations. The
+precedence rules protect exact requests without a trailing slash and
+body-bearing requests.
+Users who intentionally need to send a request to a non-operation parent path
+that has documented descendants can use the expanded full URL, which always
+retains generic HTTP behavior.
+
+## Validation
+
+- Unit/CLI tests cover root and nested browsing, method filtering,
+  `x-cli-hidden`, active profile and `operation_base`, deterministic structured
+  output, exact-operation precedence, body precedence, and request fallback.
+- Generic HTTP help and reference docs show the discovery workflow.
+- The full unit, integration-tagged, build, generated-doc, and documentation
+  checks run before the pull request is marked ready.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -144,6 +144,7 @@ were a recurring source of remediation work.
 - [007-api-command-generation.md](./007-api-command-generation.md) - Config-backed API registration, OpenAPI-to-command mapping, naming, parameter handling, and compatibility aliases.
 - [033-openapi-operation-security.md](./033-openapi-operation-security.md) - Operation-specific OpenAPI security policy, credential bindings, setup UX, and compatibility rules.
 - [034-openapi-implementation-contract.md](./034-openapi-implementation-contract.md) - Implementation-grade OpenAPI 3.x behavior matrix for loading, command generation, parameters, servers, schemas, auth, media types, caching, and tests.
+- [043-generic-operation-browsing.md](./043-generic-operation-browsing.md) - Parent-path browsing for cached OpenAPI operations through generic HTTP verb commands.
 - [008-shorthand-input.md](./008-shorthand-input.md) - Building request bodies from CLI arguments and stdin using shorthand syntax.
 - [029-request-execution-pipeline.md](./029-request-execution-pipeline.md) - End-to-end request planning, execution order, cancellation, transport layering, normalization, filtering, and rendering.
 

--- a/internal/cli/completions_test.go
+++ b/internal/cli/completions_test.go
@@ -254,6 +254,19 @@ paths:
       responses:
         "200":
           description: OK
+  /users/{user-id}:
+    get:
+      operationId: getUser
+      summary: Get user
+      parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
   /items/{item-id}/tags:
     get:
       operationId: listItemTags

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -94,14 +94,17 @@ func genericHTTPLong(method string) string {
 	case "GET", "HEAD", "OPTIONS":
 		return fmt.Sprintf("Perform an HTTP `%s` request against a full URL or registered API short-name URL.\n\n", method) +
 			"Use generic HTTP commands for one-off requests, scripting, and APIs that are not registered with `api connect`. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks.\n\n" +
+			"For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.\n\n" +
 			"Pass request headers with `-H`, query parameters with `-q`, filters with `-f`, and output format with `-o`."
 	case "POST", "PUT", "PATCH":
 		return fmt.Sprintf("Perform an HTTP `%s` request with optional shorthand, file, or stdin body input.\n\n", method) +
 			"Use generic HTTP commands for one-off writes, scripting, and APIs that are not registered with `api connect`. Body arguments use Restish shorthand by default; pass `@file.json`, pipe stdin, or set `--rsh-content-type` when you need a specific wire format.\n\n" +
+			"For a registered API with cached OpenAPI metadata, pass a parent short-name path without a body, such as `demo/`, to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash and body-bearing requests still send requests.\n\n" +
 			"Restish still applies global request flags, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks. Unsafe methods are not retried unless you opt in with `--rsh-retry-unsafe`."
 	case "DELETE":
 		return "Perform an HTTP `DELETE` request against a full URL or registered API short-name URL.\n\n" +
 			"Use this for direct delete requests when a generated OpenAPI command is not available or would add friction. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, and plugin hooks.\n\n" +
+			"For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.\n\n" +
 			"By default, HTTP error statuses produce non-zero exit codes. Use `--rsh-ignore-status-code` only when a script intentionally handles those responses."
 	default:
 		return fmt.Sprintf("Perform an HTTP `%s` request with Restish's request, output, and plugin pipeline.", method)
@@ -114,9 +117,9 @@ func genericHTTPExamples(commandName, verb string) string {
 	}
 	switch verb {
 	case "get":
-		return fmt.Sprintf("  %s get https://api.example.com/items\n  %s get https://api.example.com/items -f body.items -o table", commandName, commandName)
+		return fmt.Sprintf("  %s get https://api.example.com/items\n  %s get https://api.example.com/items -f body.items -o table\n  %s get demo/", commandName, commandName, commandName)
 	case "post":
-		return fmt.Sprintf("  %s post https://api.example.com/items 'name: Ada, active: true'\n  %s post -c json https://api.example.com/items @item.json", commandName, commandName)
+		return fmt.Sprintf("  %s post https://api.example.com/items 'name: Ada, active: true'\n  %s post -c json https://api.example.com/items @item.json\n  %s post demo/", commandName, commandName, commandName)
 	case "put":
 		return fmt.Sprintf("  %s put https://api.example.com/items/123 'name: Ada'\n  %s put -c json https://api.example.com/items/123 @item.json", commandName, commandName)
 	case "patch":
@@ -181,8 +184,7 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 	if err := c.validateHTTPOutputFlags(cmd, gf); err != nil {
 		return err
 	}
-	c.requestExecutionStarted = true
-	trace := ensureRequestTrace(cmd)
+	explicitMethod := method != ""
 	rawURL := args[0]
 	bodyArgs := args[1:] // positional args after the URL are shorthand body input
 
@@ -234,15 +236,23 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 			return err
 		}
 	}
-	inputSource := traceInputSource(bodyInfo, bodyVal != nil)
-	if bodyVal != nil {
-		trace.Step(inputSource)
-	}
 	if method == "" {
 		method = "GET"
 		if bodyVal != nil {
 			method = "POST"
 		}
+	}
+	if explicitMethod && !followMode && bodyVal == nil && !bodyOpts.bodyOverrideSet {
+		if browsed, err := c.browseGenericOperations(cmd, method, rawURL); browsed || err != nil {
+			return err
+		}
+	}
+
+	c.requestExecutionStarted = true
+	trace := ensureRequestTrace(cmd)
+	inputSource := traceInputSource(bodyInfo, bodyVal != nil)
+	if bodyVal != nil {
+		trace.Step(inputSource)
 	}
 
 	prepared, err := c.prepareRequest(requestContext(cmd), method, rawURL, profileName, opts, bodyVal, extraHeaders, noAuth, authOpts, bodyOpts.operationAuth, bodyOpts.rawBinaryBody, bodyOpts.explicitAPIName)

--- a/internal/cli/operation_browse.go
+++ b/internal/cli/operation_browse.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/rest-sh/restish/v2/config"
+	"github.com/rest-sh/restish/v2/internal/spec"
+	"github.com/spf13/cobra"
+)
+
+type operationBrowseRow struct {
+	Command     string `json:"command"`
+	Summary     string `json:"summary"`
+	OperationID string `json:"operation_id"`
+}
+
+func (c *CLI) browseGenericOperations(cmd *cobra.Command, method, rawURL string) (bool, error) {
+	if c.cfg == nil {
+		return false, nil
+	}
+	apiName, suffix := splitAPIShortNameSuffix(rawURL)
+	apiCfg := c.cfg.APIs[apiName]
+	if apiCfg == nil || strings.ContainsAny(suffix, "?#") {
+		return false, nil
+	}
+
+	profileName := c.profileFromCmd(cmd)
+	if profileName != "default" && profileForName(apiCfg, profileName) == nil {
+		return false, nil
+	}
+	set, ok := c.completionOperationSet(cmd, apiName, apiCfg, profileName)
+	if !ok {
+		return false, nil
+	}
+
+	browsePath := apiName
+	forceParentBrowse := false
+	if suffix != "" {
+		parsed, err := url.Parse(suffix)
+		if err != nil {
+			return false, nil
+		}
+		escapedPath := parsed.EscapedPath()
+		forceParentBrowse = strings.HasSuffix(escapedPath, "/")
+		browsePath += "/" + strings.TrimLeft(escapedPath, "/")
+	}
+	browsePath = strings.TrimRight(browsePath, "/")
+
+	var rows []operationBrowseRow
+	commandName := cmd.Root().Name()
+	for _, op := range set.Operations {
+		if !strings.EqualFold(op.Method, method) {
+			continue
+		}
+		template, commandTarget := operationBrowsePaths(apiName, apiCfg, profileName, op)
+		if template == "" {
+			continue
+		}
+		resolved, relation := matchOperationBrowsePath(template, browsePath)
+		if relation == operationBrowseExact {
+			if !forceParentBrowse {
+				return false, nil
+			}
+			continue
+		}
+		if relation != operationBrowseDescendant {
+			continue
+		}
+		if op.OperationServer == "" {
+			commandTarget = resolved
+		} else {
+			commandTarget = applyResolvedBrowseParameters(template, resolved, commandTarget)
+		}
+		rows = append(rows, operationBrowseRow{
+			Command:     strings.Join([]string{commandName, strings.ToLower(method), commandTarget}, " "),
+			Summary:     op.Summary,
+			OperationID: op.ID,
+		})
+	}
+	if len(rows) == 0 {
+		return false, nil
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Command == rows[j].Command {
+			return rows[i].OperationID < rows[j].OperationID
+		}
+		return rows[i].Command < rows[j].Command
+	})
+	outputFormat := globalFlagsFromContext(requestContext(cmd)).OutputFormat
+	if c.stdoutIsTerminal() && (outputFormat == "" || outputFormat == "auto") {
+		return true, writeOperationBrowseTable(c.Stdout, rows)
+	}
+	return true, c.renderValue(cmd, operationBrowseValues(rows), false)
+}
+
+func operationBrowsePaths(apiName string, apiCfg *config.APIConfig, profileName string, op spec.Operation) (string, string) {
+	baseURL, operationBase := completionOperationBase(apiCfg, profileName)
+	shortPath := shortOperationCompletionPath(baseURL, operationBase, op.Path)
+	if shortPath == "" {
+		return "", ""
+	}
+	shortPath = strings.ReplaceAll(shortPath, "%7B", "{")
+	shortPath = strings.ReplaceAll(shortPath, "%7D", "}")
+	template := apiName + "/" + strings.TrimLeft(shortPath, "/")
+	if op.OperationServer == "" {
+		return template, template
+	}
+	return template, cleanCompletionURL(strings.TrimRight(op.OperationServer, "/") + op.Path)
+}
+
+type operationBrowseRelation uint8
+
+const (
+	operationBrowseUnrelated operationBrowseRelation = iota
+	operationBrowseExact
+	operationBrowseDescendant
+)
+
+func matchOperationBrowsePath(template, browsePath string) (string, operationBrowseRelation) {
+	templateParts := splitBrowsePath(template)
+	browseParts := splitBrowsePath(browsePath)
+	if len(browseParts) > len(templateParts) {
+		return "", operationBrowseUnrelated
+	}
+
+	resolved := append([]string(nil), templateParts...)
+	for i, part := range browseParts {
+		if isPathTemplateSegment(templateParts[i]) {
+			resolved[i] = part
+			continue
+		}
+		if templateParts[i] != part {
+			return "", operationBrowseUnrelated
+		}
+	}
+	if len(browseParts) == len(templateParts) {
+		return strings.Join(resolved, "/"), operationBrowseExact
+	}
+	return strings.Join(resolved, "/"), operationBrowseDescendant
+}
+
+func splitBrowsePath(value string) []string {
+	value = strings.Trim(value, "/")
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, "/")
+}
+
+func isPathTemplateSegment(value string) bool {
+	return strings.Contains(value, "{") && strings.Contains(value, "}")
+}
+
+func applyResolvedBrowseParameters(template, resolved, target string) string {
+	templateParts := splitBrowsePath(template)
+	resolvedParts := splitBrowsePath(resolved)
+	for i, part := range templateParts {
+		if i >= len(resolvedParts) || !isPathTemplateSegment(part) {
+			continue
+		}
+		target = strings.ReplaceAll(target, part, resolvedParts[i])
+	}
+	return target
+}
+
+func operationBrowseValues(rows []operationBrowseRow) []any {
+	values := make([]any, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, map[string]any{
+			"command":      row.Command,
+			"summary":      row.Summary,
+			"operation_id": row.OperationID,
+		})
+	}
+	return values
+}
+
+func writeOperationBrowseTable(w io.Writer, rows []operationBrowseRow) error {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "COMMAND\tSUMMARY\tOPERATION ID"); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", row.Command, browseTableCell(row.Summary), browseTableCell(row.OperationID)); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func browseTableCell(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/internal/cli/operation_browse_test.go
+++ b/internal/cli/operation_browse_test.go
@@ -1,0 +1,328 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rest-sh/restish/v2/config"
+)
+
+type operationBrowseRow struct {
+	Command     string `json:"command"`
+	Summary     string `json:"summary"`
+	OperationID string `json:"operation_id"`
+}
+
+func TestGenericHTTPBrowsesOperationCommandsBelowAPIPath(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("operation browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/items/my-item/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var rows []operationBrowseRow
+	if err := json.Unmarshal([]byte(out.String()), &rows); err != nil {
+		t.Fatalf("decode output %q: %v", out.String(), err)
+	}
+	want := []operationBrowseRow{
+		{
+			Command:     "restish get demo/items/my-item/hidden",
+			Summary:     "Hidden item",
+			OperationID: "hiddenItem",
+		},
+		{
+			Command:     "restish get demo/items/my-item/tags",
+			Summary:     "List item tags",
+			OperationID: "listItemTags",
+		},
+		{
+			Command:     "restish get demo/items/my-item/tags/{tag-id}",
+			Summary:     "Get tag details",
+			OperationID: "getTagDetails",
+		},
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("rows = %#v, want %#v", rows, want)
+	}
+	for i := range want {
+		if rows[i] != want[i] {
+			t.Fatalf("rows[%d] = %#v, want %#v", i, rows[i], want[i])
+		}
+	}
+}
+
+func TestGenericHTTPBrowseFiltersByMethod(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("operation browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "post", "demo/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var rows []operationBrowseRow
+	if err := json.Unmarshal([]byte(out.String()), &rows); err != nil {
+		t.Fatalf("decode output %q: %v", out.String(), err)
+	}
+	want := operationBrowseRow{
+		Command:     "restish post demo/widgets",
+		Summary:     "Create widget",
+		OperationID: "createWidget",
+	}
+	if len(rows) != 1 || rows[0] != want {
+		t.Fatalf("rows = %#v, want %#v", rows, []operationBrowseRow{want})
+	}
+}
+
+func TestGenericHTTPBrowseUsesProfileOperationBase(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{
+		BaseURL:       "https://api.example.com/root",
+		OperationBase: "/",
+		Profiles: map[string]*config.ProfileConfig{
+			"staging": {
+				BaseURL:       "https://staging.example.com/root",
+				OperationBase: "/v2",
+			},
+		},
+	})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("operation browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "--rsh-profile", "staging", "demo/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var rows []operationBrowseRow
+	if err := json.Unmarshal([]byte(out.String()), &rows); err != nil {
+		t.Fatalf("decode output %q: %v", out.String(), err)
+	}
+	found := false
+	for _, row := range rows {
+		if row.Command == "restish get demo/../v2/users" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("rows = %#v, want profile operation_base command", rows)
+	}
+}
+
+func TestGenericHTTPBrowsePreservesMissingProfileError(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{
+		Profiles: map[string]*config.ProfileConfig{"staging": {}},
+	})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("missing profile must fail before sending an HTTP request")
+		return nil, nil
+	})
+
+	err := c.Run([]string{"restish", "get", "--rsh-profile", "missing", "demo/"})
+	if err == nil || !strings.Contains(err.Error(), `profile "missing" not found for API "demo"`) {
+		t.Fatalf("error = %v, want missing profile error", err)
+	}
+}
+
+func TestGenericHTTPBrowseUsesTableOnTerminal(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return true }
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("operation browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/items/my-item/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, want := range []string{
+		"COMMAND",
+		"SUMMARY",
+		"OPERATION ID",
+		"restish get demo/items/my-item/hidden",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %s, want %q", out.String(), want)
+		}
+	}
+}
+
+func TestGenericHTTPBrowseSupportsExplicitTableOutput(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("operation browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "-o", "table", "demo/items/my-item/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, want := range []string{"┌", "command", "summary", "operation_id"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output = %s, want %q", out.String(), want)
+		}
+	}
+}
+
+func TestGenericHTTPExactOperationStillSendsRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/users"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an HTTP request")
+	}
+	if got.Method != http.MethodGet || got.URL.Path != "/users" {
+		t.Fatalf("request = %s %s, want GET /users", got.Method, got.URL.Path)
+	}
+}
+
+func TestGenericHTTPTrailingSlashBrowsesBelowExactOperation(t *testing.T) {
+	c, out := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	useTransport(c, func(*http.Request) (*http.Response, error) {
+		t.Fatal("trailing-slash parent browsing must not send an HTTP request")
+		return nil, nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/users/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var rows []operationBrowseRow
+	if err := json.Unmarshal([]byte(out.String()), &rows); err != nil {
+		t.Fatalf("decode output %q: %v", out.String(), err)
+	}
+	want := operationBrowseRow{
+		Command:     "restish get demo/users/{user-id}",
+		Summary:     "Get user",
+		OperationID: "getUser",
+	}
+	if len(rows) != 1 || rows[0] != want {
+		t.Fatalf("rows = %#v, want %#v", rows, []operationBrowseRow{want})
+	}
+}
+
+func TestGenericHTTPExactTemplateOperationStillSendsRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/formats/json"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil || got.URL.Path != "/formats/json" {
+		t.Fatalf("request URL = %v, want /formats/json", got)
+	}
+}
+
+func TestGenericHTTPBodyStillSendsParentRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "post", "demo/", "name:", "Ada"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an HTTP request")
+	}
+	if got.Method != http.MethodPost || got.URL.Path != "/" {
+		t.Fatalf("request = %s %s, want POST /", got.Method, got.URL.Path)
+	}
+}
+
+func TestGenericHTTPStdinBodyStillSendsParentRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	c.Stdin = strings.NewReader(`{"name":"Ada"}`)
+	var got *http.Request
+	var body string
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		body = string(data)
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "post", "-c", "json", "demo/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an HTTP request")
+	}
+	if got.Method != http.MethodPost || body != `{"name":"Ada"}` {
+		t.Fatalf("request = %s body %q, want POST with stdin body", got.Method, body)
+	}
+}
+
+func TestGenericHTTPQueryStillSendsParentRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/?limit=1"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected an HTTP request")
+	}
+	if got.URL.Path != "/" || got.URL.RawQuery != "limit=1" {
+		t.Fatalf("URL = %s, want /?limit=1", got.URL)
+	}
+}
+
+func TestGenericHTTPUnknownParentStillSendsRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "demo/unknown"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil || !strings.HasSuffix(got.URL.Path, "/unknown") {
+		t.Fatalf("request URL = %v, want path ending in /unknown", got)
+	}
+}
+
+func TestGenericHTTPFullURLParentStillSendsRequest(t *testing.T) {
+	c, _ := newCompletionFixtureCLI(t, completionFixtureConfig{})
+	var got *http.Request
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		got = r
+		return jsonResponse(http.StatusOK, `{}`), nil
+	})
+
+	if err := c.Run([]string{"restish", "get", "https://api.example.com/items/"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got == nil || got.URL.Path != "/items/" {
+		t.Fatalf("request URL = %v, want /items/", got)
+	}
+}

--- a/site/content/en/docs/reference/http-commands.md
+++ b/site/content/en/docs/reference/http-commands.md
@@ -21,6 +21,8 @@ Perform an HTTP `GET` request against a full URL or registered API short-name UR
 
 Use generic HTTP commands for one-off requests, scripting, and APIs that are not registered with `api connect`. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks.
 
+For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.
+
 Pass request headers with `-H`, query parameters with `-q`, filters with `-f`, and output format with `-o`.
 
 Usage:
@@ -36,6 +38,7 @@ Examples:
 ```bash
   restish get https://api.example.com/items
   restish get https://api.example.com/items -f body.items -o table
+  restish get demo/
 ```
 
 
@@ -46,6 +49,8 @@ Perform an HTTP HEAD request
 Perform an HTTP `HEAD` request against a full URL or registered API short-name URL.
 
 Use generic HTTP commands for one-off requests, scripting, and APIs that are not registered with `api connect`. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks.
+
+For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.
 
 Pass request headers with `-H`, query parameters with `-q`, filters with `-f`, and output format with `-o`.
 
@@ -72,6 +77,8 @@ Perform an HTTP `OPTIONS` request against a full URL or registered API short-nam
 
 Use generic HTTP commands for one-off requests, scripting, and APIs that are not registered with `api connect`. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks.
 
+For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.
+
 Pass request headers with `-H`, query parameters with `-q`, filters with `-f`, and output format with `-o`.
 
 Usage:
@@ -97,6 +104,8 @@ Perform an HTTP `POST` request with optional shorthand, file, or stdin body inpu
 
 Use generic HTTP commands for one-off writes, scripting, and APIs that are not registered with `api connect`. Body arguments use Restish shorthand by default; pass `@file.json`, pipe stdin, or set `--rsh-content-type` when you need a specific wire format.
 
+For a registered API with cached OpenAPI metadata, pass a parent short-name path without a body, such as `demo/`, to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash and body-bearing requests still send requests.
+
 Restish still applies global request flags, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks. Unsafe methods are not retried unless you opt in with `--rsh-retry-unsafe`.
 
 Usage:
@@ -112,6 +121,7 @@ Examples:
 ```bash
   restish post https://api.example.com/items 'name: Ada, active: true'
   restish post -c json https://api.example.com/items @item.json
+  restish post demo/
 ```
 
 
@@ -122,6 +132,8 @@ Perform an HTTP PUT request
 Perform an HTTP `PUT` request with optional shorthand, file, or stdin body input.
 
 Use generic HTTP commands for one-off writes, scripting, and APIs that are not registered with `api connect`. Body arguments use Restish shorthand by default; pass `@file.json`, pipe stdin, or set `--rsh-content-type` when you need a specific wire format.
+
+For a registered API with cached OpenAPI metadata, pass a parent short-name path without a body, such as `demo/`, to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash and body-bearing requests still send requests.
 
 Restish still applies global request flags, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks. Unsafe methods are not retried unless you opt in with `--rsh-retry-unsafe`.
 
@@ -149,6 +161,8 @@ Perform an HTTP `PATCH` request with optional shorthand, file, or stdin body inp
 
 Use generic HTTP commands for one-off writes, scripting, and APIs that are not registered with `api connect`. Body arguments use Restish shorthand by default; pass `@file.json`, pipe stdin, or set `--rsh-content-type` when you need a specific wire format.
 
+For a registered API with cached OpenAPI metadata, pass a parent short-name path without a body, such as `demo/`, to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash and body-bearing requests still send requests.
+
 Restish still applies global request flags, response normalization, output formatting, filtering, retries, caching, pagination, and plugin hooks. Unsafe methods are not retried unless you opt in with `--rsh-retry-unsafe`.
 
 Usage:
@@ -175,6 +189,8 @@ Perform an HTTP `DELETE` request against a full URL or registered API short-name
 
 Use this for direct delete requests when a generated OpenAPI command is not available or would add friction. Restish still applies global request flags, profile settings for registered API short names, response normalization, output formatting, filtering, and plugin hooks.
 
+For a registered API with cached OpenAPI metadata, pass a parent short-name path such as `demo/` to list matching operation command templates instead of sending a request. Exact operation paths without a trailing slash still send requests.
+
 By default, HTTP error statuses produce non-zero exit codes. Use `--rsh-ignore-status-code` only when a script intentionally handles those responses.
 
 Usage:
@@ -192,6 +208,34 @@ Examples:
   restish delete https://api.example.com/items/123 --rsh-ignore-status-code
 ```
 <!-- END GENERATED -->
+
+## Browse Registered Operations
+
+When a registered API has cached OpenAPI metadata, use a generic HTTP verb with
+an API parent path to discover command templates for that method:
+
+```bash
+restish get demo/
+restish get demo/users/42/
+restish post demo/
+```
+
+Interactive output is a table containing `command`, `summary`, and
+`operation_id`. Redirected output is structured JSON by default, and explicit
+formats such as `-o json` and `-o table` continue to work.
+
+The browser includes operations marked `x-cli-hidden`; that extension only
+hides generated commands and shell completions. Replace any remaining
+`{parameter}` placeholders before running a listed command.
+
+An exact short-name path without a trailing slash sends a normal HTTP request.
+A trailing slash explicitly browses descendants when they exist, so
+`restish get demo/users` can execute a collection operation while
+`restish get demo/users/` browses operations below it. Restish also sends a
+request when it has a body, the target contains a query or fragment, no matching
+descendant operation exists, or the target is a full URL. Use the full URL when
+you intentionally need to request a parent path that otherwise acts as a
+browser.
 
 ## Common Examples
 


### PR DESCRIPTION
Closes #399.

## Summary

- browse cached OpenAPI operations below an API path through generic HTTP verb commands
- render matching operations as copyable command templates with summaries and operation IDs
- use a trailing slash to request descendant browsing while preserving exact requests without it
- include operations hidden from the generated command tree
- preserve profiles, operation bases, request bodies, queries, full URLs, and normal request fallbacks

## Behavior

`restish get demo/` lists matching GET operations from the cached OpenAPI document. `restish get demo/users` executes the exact request, while `restish get demo/users/` browses descendants.

Browsing uses cached metadata only. If no cached document or matching operation exists, Restish retains its existing request behavior.

## Verification

- `CGO_ENABLED=1 go test ./...`
- `CGO_ENABLED=1 go test -tags=integration ./...`
- `go run ./cmd/restish-docgen --check`