### PR TITLE
fix: preserve large JSON integers

### DIFF
--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -72,6 +72,33 @@ func TestJSONOutput(t *testing.T) {
 	}
 }
 
+func TestJSONOutputPreservesLargeInteger(t *testing.T) {
+	for _, id := range []string{"9007199254740993", "18446744073709551616"} {
+		t.Run(id, func(t *testing.T) {
+			c, out, _ := newTestCLI(t)
+			useJSONResponse(c, 200, `{"id":`+id+`}`)
+			if err := c.Run([]string{"restish", "get", "-o", "json", "https://api.example.com/items"}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got, want := out.String(), "{\n  \"id\": "+id+"\n}\n"; got != want {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestYAMLOutputPreservesLargeInteger(t *testing.T) {
+	const id = "9007199254740993"
+	c, out, _ := newTestCLI(t)
+	useJSONResponse(c, 200, `{"id":`+id+`}`)
+	if err := c.Run([]string{"restish", "get", "-o", "yaml", "https://api.example.com/items"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := out.String(), "id: "+id+"\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestDefaultTTYOutputPrintsResponseTranscript(t *testing.T) {
 	c, out, errOut := newTestCLI(t)
 	c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return true }

--- a/internal/cli/stream.go
+++ b/internal/cli/stream.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -11,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rest-sh/restish/v2/internal/content"
 	"github.com/rest-sh/restish/v2/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -126,8 +126,7 @@ func (c *CLI) handleSSE(cmd *cobra.Command, resp *http.Response, prepared *prepa
 }
 
 func parseJSONOrString(data string) (any, bool) {
-	var parsed any
-	if err := json.Unmarshal([]byte(data), &parsed); err == nil {
+	if parsed, err := content.UnmarshalJSON([]byte(data)); err == nil {
 		return parsed, true
 	}
 	return data, false

--- a/internal/cli/stream_test.go
+++ b/internal/cli/stream_test.go
@@ -682,6 +682,15 @@ func TestNDJSONYAMLOutputUsesFormatter(t *testing.T) {
 	}
 }
 
+func TestNDJSONJQFilterPreservesLargeInteger(t *testing.T) {
+	const id = "18446744073709551615"
+	app := runStream(t, "application/x-ndjson", `{"id":`+id+"}\n", "/records",
+		"--rsh-filter-lang", "jq", "-f", "+.body.id", "-o", "lines")
+	if got, want := app.Stdout.String(), id+"\n"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestNDJSONExplicitFormatterStreamsCompactJSON(t *testing.T) {
 	got := strings.TrimSpace(runStream(t, "application/x-ndjson", "{\"id\":1}\n{\"id\":2}\n", "/stream", "-o", "ndjson").Stdout.String())
 	lines := strings.Split(got, "\n")

--- a/internal/content/defaults.go
+++ b/internal/content/defaults.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/textproto"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/amazon-ion/ion-go/ion"
@@ -41,8 +43,8 @@ func Default() *Registry {
 			return json.Marshal(v)
 		},
 		Unmarshal: func(data []byte) (any, error) {
-			var v any
-			if err := json.Unmarshal(data, &v); err != nil {
+			v, err := UnmarshalJSON(data)
+			if err != nil {
 				if seq, seqErr := unmarshalJSONSequence(data); seqErr == nil {
 					return seq, nil
 				}
@@ -65,8 +67,8 @@ func Default() *Registry {
 				if len(line) == 0 {
 					continue
 				}
-				var v any
-				if err := json.Unmarshal(line, &v); err != nil {
+				v, err := UnmarshalJSON(line)
+				if err != nil {
 					return nil, err
 				}
 				out = append(out, v)
@@ -274,8 +276,62 @@ func Default() *Registry {
 	return r
 }
 
+// UnmarshalJSON decodes one JSON value while preserving integers that float64
+// cannot represent exactly.
+func UnmarshalJSON(data []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+	if err := dec.Decode(new(any)); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values")
+		}
+		return nil, err
+	}
+	return normalizeJSONNumbers(v), nil
+}
+
+func normalizeJSONNumbers(v any) any {
+	switch value := v.(type) {
+	case json.Number:
+		if value.String() == "-0" {
+			return math.Copysign(0, -1)
+		}
+		if !strings.ContainsAny(value.String(), ".eE") {
+			if i, err := value.Int64(); err == nil {
+				const maxExactFloatInteger = int64(1 << 53)
+				if -maxExactFloatInteger <= i && i <= maxExactFloatInteger {
+					return float64(i)
+				}
+				return i
+			}
+			if u, err := strconv.ParseUint(value.String(), 10, 64); err == nil {
+				return u
+			}
+			return value
+		}
+		if f, err := value.Float64(); err == nil {
+			return f
+		}
+		return value
+	case []any:
+		for i := range value {
+			value[i] = normalizeJSONNumbers(value[i])
+		}
+	case map[string]any:
+		for key := range value {
+			value[key] = normalizeJSONNumbers(value[key])
+		}
+	}
+	return v
+}
+
 func unmarshalJSONSequence(data []byte) ([]any, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
 	out := make([]any, 0)
 	for {
 		var v any
@@ -285,7 +341,7 @@ func unmarshalJSONSequence(data []byte) ([]any, error) {
 			}
 			return nil, err
 		}
-		out = append(out, v)
+		out = append(out, normalizeJSONNumbers(v))
 	}
 	if len(out) < 2 {
 		return nil, fmt.Errorf("JSON sequence must contain at least two values")

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -4,9 +4,13 @@ package filter
 import (
 	"container/list"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -416,7 +420,7 @@ func applyJQ(expr string, doc map[string]any) (result any, err error) {
 		if err, ok := v.(error); ok {
 			return nil, fmt.Errorf("jq: %w", err)
 		}
-		results = append(results, v)
+		results = append(results, normalizeJQResult(v))
 	}
 
 	if len(results) == 0 {
@@ -426,6 +430,39 @@ func applyJQ(expr string, doc map[string]any) (result any, err error) {
 		return results[0], nil
 	}
 	return results, nil
+}
+
+func normalizeJQResult(value any) any {
+	switch v := value.(type) {
+	case json.Number:
+		if v.String() == "-0" {
+			return math.Copysign(0, -1)
+		}
+		if !strings.ContainsAny(v.String(), ".eE") {
+			if i, err := v.Int64(); err == nil {
+				return i
+			}
+			if u, err := strconv.ParseUint(v.String(), 10, 64); err == nil {
+				return u
+			}
+		}
+	case *big.Int:
+		if v.IsInt64() {
+			return v.Int64()
+		}
+		if v.IsUint64() {
+			return v.Uint64()
+		}
+	case []any:
+		for i := range v {
+			v[i] = normalizeJQResult(v[i])
+		}
+	case map[string]any:
+		for key := range v {
+			v[key] = normalizeJQResult(v[key])
+		}
+	}
+	return value
 }
 
 func normalizeJQValue(value any) any {
@@ -459,6 +496,18 @@ func normalizeJQValue(value any) any {
 			result[i] = normalizeJQValue(rv.Index(i).Interface())
 		}
 		return result
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i := rv.Int()
+		if int64(int(i)) == i {
+			return int(i)
+		}
+		return json.Number(strconv.FormatInt(i, 10))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		u := rv.Uint()
+		if i := int(u); i >= 0 && uint64(i) == u {
+			return i
+		}
+		return json.Number(strconv.FormatUint(u, 10))
 	default:
 		return value
 	}


### PR DESCRIPTION
## Summary

- Preserve plain JSON integer values that cannot be represented exactly as `float64`.
- Keep safely representable integers and decimal values on their existing `float64` path for compatibility.
- Reuse strict single-value decoding for JSON, NDJSON, and streamed JSON values.
- Preserve exact integer types through jq filtering on both 32-bit and 64-bit platforms.

Fixes #397. Related to #130.

## Why Revisit #130

Encoding opaque identifiers as strings remains the safest API design when all
JSON consumers must interoperate with JavaScript. CBOR is also a good option
when the API supports a format with native large-integer handling.

This change does not dispute that guidance. Restish cannot control the upstream
API contract, however. When a server sends a valid JSON integer, formatted
output should not silently change its value. The v2 content pipeline now makes
it practical to preserve plain integer tokens while retaining the existing
`float64` behavior for safely representable numbers and decimals.

## Reproduction

The fictional `precision-demo` operation `GET /records/current` returns
[`2^53 + 1 = 9007199254740993`](https://www.wolframalpha.com/input?i=2%5E53%2B1):

```json
{"id":9007199254740993}
```

Before:

```console
$ restish -o json precision-demo get-current-record
{
  "id": 9007199254740992
}
```

After:

```console
$ restish -o json precision-demo get-current-record
{
  "id": 9007199254740993
}
```

## Validation

- `GOTOOLCHAIN=go1.25.3 go test ./...` passed across all packages.
- `GOTOOLCHAIN=go1.25.3 go test -tags=integration ./...` passed across all packages.
- `GOTOOLCHAIN=go1.25.3 go vet ./...` completed without findings.
- CI's `Build binaries` command set passed for `restish`, `restish-bulk`, `restish-csv`, `restish-mcp`, and `restish-pkcs11` with Go 1.25.3.
- `GOTOOLCHAIN=go1.25.3 go run ./cmd/restish-docgen --check`, `scripts/check-doc-links.rb`, and `scripts/check-doc-examples.rb` passed.

---

> [!NOTE]
> AI assistance: implementation, tests, PR description.
