### PR TITLE
fix(openapi): recognize DPoP security schemes

### DIFF
--- a/internal/cli/api_auth.go
+++ b/internal/cli/api_auth.go
@@ -995,7 +995,7 @@ func (c *CLI) printAPIAuthRequirementSummary(apiName, profileName string, ops []
 		if len(satisfies) > 0 {
 			parts = append(parts, "satisfies "+strings.Join(satisfies, " "))
 		}
-		if !authRequirementKindSupported(summary.kind) {
+		if !spec.IsRecognizedCredentialRequirementKind(summary.kind) {
 			parts = append(parts, "unsupported "+summary.kind)
 		}
 		if summary.undeclared {
@@ -1018,7 +1018,7 @@ func (c *CLI) printAPIAuthRequirementSummary(apiName, profileName string, ops []
 
 func nextMissingCredentialID(ops []spec.Operation, prof *config.ProfileConfig, coverage operationAuthCoverage) string {
 	for _, summary := range authRequirementSummaries(ops) {
-		if !authRequirementKindSupported(summary.kind) || summary.undeclared || summary.external {
+		if !spec.IsRecognizedCredentialRequirementKind(summary.kind) || summary.undeclared || summary.external {
 			continue
 		}
 		if coverage.FallbackByID[summary.id] > 0 {
@@ -1084,15 +1084,6 @@ func mergeStringSet(existing, values []string) []string {
 		}
 	}
 	return existing
-}
-
-func authRequirementKindSupported(kind string) bool {
-	switch kind {
-	case "api-key", "http-basic", "http-bearer", "oauth2", "mtls":
-		return true
-	default:
-		return false
-	}
 }
 
 func (c *CLI) cachedCredentialDefaultNeeds(ctx context.Context, apiName string, apiCfg *config.APIConfig, profileName, credentialID string) []string {

--- a/internal/cli/api_configure_auth.go
+++ b/internal/cli/api_configure_auth.go
@@ -69,8 +69,10 @@ func (c *CLI) printAPIDiscovery(apiName, baseURL string, d configureAuthDiscover
 		}
 		if scheme.Kind == "mtls" {
 			details = append(details, "use TLS client certificate or signer")
-		} else if !scheme.Supported {
+		} else if !scheme.Recognized {
 			details = append(details, "unsupported")
+		} else if !scheme.AutoConfigurable {
+			details = append(details, "requires explicit credential")
 		}
 		if scheme.Deprecated {
 			details = append(details, "deprecated")
@@ -105,7 +107,7 @@ func (c *CLI) configureFallbackAuth(ctx context.Context, apiCfg *config.APIConfi
 	configured := map[string]bool{}
 	for _, scheme := range d.schemes {
 		credential := prof.Credentials[scheme.ID]
-		if !scheme.Supported || credential == nil || credential.Auth == nil {
+		if !scheme.AutoConfigurable || credential == nil || credential.Auth == nil {
 			delete(prof.Credentials, scheme.ID)
 			continue
 		}
@@ -159,7 +161,7 @@ func (c *CLI) validateFallbackCredentialAnswers(profileName string, prof *config
 	}
 	valid := map[string]map[string]bool{}
 	for _, scheme := range d.schemes {
-		if !scheme.Supported {
+		if !scheme.AutoConfigurable {
 			continue
 		}
 		credential := prof.Credentials[scheme.ID]
@@ -233,7 +235,7 @@ func defaultConfigureSchemeID(schemes []spec.SecuritySchemeSummary, opCounts map
 	var best string
 	bestCount := -1
 	for _, scheme := range schemes {
-		if !scheme.Supported || scheme.Deprecated {
+		if !scheme.AutoConfigurable || scheme.Deprecated {
 			continue
 		}
 		count := opCounts[scheme.ID]
@@ -450,7 +452,7 @@ func yesNoDefaultSuffix(def bool) string {
 func supportedSchemeIDs(schemes []spec.SecuritySchemeSummary) []string {
 	var ids []string
 	for _, scheme := range schemes {
-		if scheme.Supported {
+		if scheme.AutoConfigurable {
 			ids = append(ids, scheme.ID)
 		}
 	}

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -3587,6 +3587,37 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
 	}
 }
 
+func TestAPISyncRecognizesDPoPSecurityScheme(t *testing.T) {
+	c := newSpecTestCLI(t, "syncapi", "https://api.example.com")
+	useOpenAPISpecTransport(c, `{
+  "openapi": "3.1.0",
+  "info": {"title": "Test API", "version": "1.0"},
+  "components": {
+    "securitySchemes": {
+      "DPoP": {"type": "http", "scheme": "DPoP"}
+    }
+  },
+  "paths": {
+    "/wallet": {
+      "get": {
+        "operationId": "getWallet",
+        "security": [{"DPoP": []}],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`)
+	var errOut strings.Builder
+	c.Stderr = &errOut
+
+	if err := c.Run([]string{"restish", "api", "sync", "syncapi"}); err != nil {
+		t.Fatalf("api sync: %v", err)
+	}
+	if strings.Contains(errOut.String(), "unsupported") {
+		t.Fatalf("unexpected unsupported security warning:\n%s", errOut.String())
+	}
+}
+
 func TestAPISyncNetworkFailureLeavesRegistrationAndCache(t *testing.T) {
 	c := newSpecTestCLI(t, "syncapi", "https://api.example.com")
 	cacheFile := filepath.Join(c.Hooks().SpecCachePath, "syncapi.cbor")

--- a/internal/cli/auth_readiness.go
+++ b/internal/cli/auth_readiness.go
@@ -141,7 +141,7 @@ func operationSecurityIssueText(requirement spec.CredentialRequirement) (string,
 	switch {
 	case requirement.Undeclared:
 		return fmt.Sprintf("security scheme %q is referenced by operations but is not declared in components.securitySchemes", requirement.ID), true
-	case !authRequirementKindSupported(requirement.Kind):
+	case !spec.IsRecognizedCredentialRequirementKind(requirement.Kind):
 		return fmt.Sprintf("security scheme %q uses unsupported kind %q", requirement.ID, requirement.Kind), true
 	default:
 		return "", false

--- a/internal/spec/operation.go
+++ b/internal/spec/operation.go
@@ -481,6 +481,8 @@ func credentialRequirementKind(scheme *v3.SecurityScheme) string {
 			return "http-basic"
 		case "bearer":
 			return "http-bearer"
+		case "dpop":
+			return "http-dpop"
 		default:
 			return "http"
 		}

--- a/internal/spec/operation_test.go
+++ b/internal/spec/operation_test.go
@@ -464,6 +464,40 @@ paths:
 	}})
 }
 
+func TestOperationsRecognizesDPoPSecurityScheme(t *testing.T) {
+	raw := `openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+components:
+  securitySchemes:
+    DPoP:
+      type: http
+      scheme: DPoP
+paths:
+  /wallet:
+    get:
+      operationId: getWallet
+      security:
+        - DPoP: []
+      responses:
+        "200":
+          description: OK`
+	loaded, err := load("application/yaml", []byte(raw), DefaultLoaders())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	ops, err := loaded.Operations(OperationOptions{BaseURL: "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("operations: %v", err)
+	}
+
+	requireCredential(t, operationByID(t, ops, "getWallet"), [][]CredentialRequirement{{
+		{ID: "DPoP", Ref: "#/components/securitySchemes/DPoP", Kind: "http-dpop", Source: "openapi"},
+	}})
+}
+
 func TestOperationsUsesConfiguredServerVariables(t *testing.T) {
 	raw := `openapi: "3.1.0"
 info:

--- a/internal/spec/security_summary.go
+++ b/internal/spec/security_summary.go
@@ -10,12 +10,13 @@ import (
 // SecuritySchemeSummary describes one declared security scheme in a
 // loader-neutral shape suitable for CLI setup and diagnostics.
 type SecuritySchemeSummary struct {
-	ID            string
-	Kind          string
-	Detail        string
-	Supported     bool
-	GlobalDefault bool
-	Deprecated    bool
+	ID               string
+	Kind             string
+	Detail           string
+	Recognized       bool
+	AutoConfigurable bool
+	GlobalDefault    bool
+	Deprecated       bool
 }
 
 // SecuritySchemeSummaries returns the declared OpenAPI security schemes in
@@ -42,16 +43,30 @@ func (s *APISpec) SecuritySchemeSummaries() ([]SecuritySchemeSummary, error) {
 
 	var out []SecuritySchemeSummary
 	for id, scheme := range model.Model.Components.SecuritySchemes.FromOldest() {
+		kind := credentialRequirementKind(scheme)
 		out = append(out, SecuritySchemeSummary{
-			ID:            id,
-			Kind:          credentialRequirementKind(scheme),
-			Detail:        securitySchemeDetail(scheme),
-			Supported:     SchemeToXCLIAuth(scheme, nil) != nil,
-			GlobalDefault: global[id],
-			Deprecated:    scheme.Deprecated,
+			ID:               id,
+			Kind:             kind,
+			Detail:           securitySchemeDetail(scheme),
+			Recognized:       IsRecognizedCredentialRequirementKind(kind),
+			AutoConfigurable: SchemeToXCLIAuth(scheme, nil) != nil,
+			GlobalDefault:    global[id],
+			Deprecated:       scheme.Deprecated,
 		})
 	}
 	return out, nil
+}
+
+// IsRecognizedCredentialRequirementKind reports whether Restish understands
+// how a credential kind is satisfied, even when setup requires an explicit
+// credential provider.
+func IsRecognizedCredentialRequirementKind(kind string) bool {
+	switch kind {
+	case "api-key", "http-basic", "http-bearer", "http-dpop", "oauth2", "mtls":
+		return true
+	default:
+		return false
+	}
 }
 
 func securitySchemeDetail(scheme *v3high.SecurityScheme) string {

--- a/internal/spec/xcliconfig.go
+++ b/internal/spec/xcliconfig.go
@@ -255,7 +255,7 @@ func SchemeToXCLIAuth(scheme *v3high.SecurityScheme, params map[string]string) *
 		p["name"] = scheme.Name
 		p["value"] = ""
 	case "http":
-		switch scheme.Scheme {
+		switch strings.ToLower(scheme.Scheme) {
 		case "basic":
 			authType = "http-basic"
 			p["username"] = ""

--- a/internal/spec/xcliconfig_test.go
+++ b/internal/spec/xcliconfig_test.go
@@ -184,6 +184,30 @@ components:
 	}
 }
 
+func TestSchemeToXCLIAuth_HTTPNamesAreCaseInsensitive(t *testing.T) {
+	raw := `
+openapi: "3.1.0"
+info:
+  title: Test
+  version: "1.0.0"
+paths: {}
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: Bearer`
+	doc := loadDoc(t, raw)
+	model, err := doc.V3Model()
+	if err != nil || model == nil {
+		t.Fatalf("BuildV3Model: %v", err)
+	}
+	scheme := model.Model.Components.SecuritySchemes.GetOrZero("bearer")
+	auth := SchemeToXCLIAuth(scheme, nil)
+	if auth == nil || auth.Type != "bearer" {
+		t.Fatalf("auth = %#v, want bearer", auth)
+	}
+}
+
 func TestSchemeToXCLIAuth_OAuth2AuthCode(t *testing.T) {
 	raw := `
 openapi: "3.1.0"

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -372,6 +372,11 @@ Prefer standard OpenAPI security schemes first. Restish derives basic auth,
 API keys, and supported OAuth setup from the spec. Use `x-cli-config` only for
 Restish-specific prompting and defaults.
 
+Restish recognizes the standard DPoP HTTP authentication scheme as a named
+credential requirement. DPoP proof generation still requires a configured
+proof-capable auth provider or plugin; Restish does not treat DPoP as a static
+Bearer token.
+
 Document-level `x-cli-config` pre-populates API profiles during `api connect`:
 
 ```yaml


### PR DESCRIPTION
## Summary

- preserve RFC 9449 DPoP as the distinct OpenAPI credential kind `http-dpop`
- treat HTTP authentication scheme names case-insensitively
- distinguish recognized credential kinds from schemes Restish can configure automatically
- report DPoP as requiring a proof-capable credential provider instead of treating the scheme as unsupported
- document that DPoP is not a static Bearer token

## Behavior

OpenAPI security schemes declared as `type: http`, `scheme: DPoP` are recognized without an unsupported-security warning. Requests still require a provider capable of generating DPoP proofs.

## Verification

- `go test ./internal/spec ./internal/cli -run 'DPoP|HTTPNamesAreCaseInsensitive'`
- `go test -tags=integration ./internal/spec ./internal/cli -run 'DPoP|HTTPNamesAreCaseInsensitive'`
- `go run ./cmd/restish-docgen --check`
- `scripts/check-doc-links.rb`
- `scripts/check-doc-examples.rb`
