### PR TITLE
feat(openapi): support contract command layout defaults

### DIFF
--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -229,7 +229,7 @@ preserve.
 
 | Command | Local state touched | Safety contract |
 | --- | --- | --- |
-| `api connect` | `restish.json`, spec cache, generated-operation cache | Without `--replace`, refresh API-level metadata and cache state while preserving existing profiles and credentials. With `--replace`, regenerate replaceable profiles while preserving values that cannot be rediscovered safely. |
+| `api connect` | `restish.json`, spec cache, generated-operation cache | Without `--replace`, refresh API-level metadata and cache state while preserving existing profiles, credentials, and explicit local defaults. With `--replace`, regenerate replaceable profiles and reapply contract-provided defaults while preserving values that cannot be rediscovered safely. |
 | `api sync` | spec cache, generated-operation cache, sometimes `restish.json` API metadata | Refresh discovered API metadata and generated operations without replacing credential-containing profiles. |
 | `api set` | one API section in `restish.json` | Patch only the requested API fields and preserve comments/formatting when possible. |
 | `api remove` | `restish.json`, API-owned HTTP cache namespaces, API-scoped auth token cache entries | Remove the API and clean API-owned local state. Shared auth-profile tokens are removed only when no remaining API references that shared profile. |

--- a/docs/design/033-openapi-operation-security.md
+++ b/docs/design/033-openapi-operation-security.md
@@ -736,6 +736,20 @@ x-cli-config:
               description: Partner API key
 ```
 
+API-level generated-command defaults remain outside profiles:
+
+```yaml
+x-cli-config:
+  command_layout: tags
+  profiles:
+    default:
+      credentials: {}
+```
+
+`command_layout` accepts `flat` or `tags`. `api connect` applies it as a remote
+default, while an existing non-empty local value remains operator-owned unless
+the user reconnects with `--replace`. `api sync` does not overwrite it.
+
 Existing single-scheme shapes remain supported:
 
 ```yaml

--- a/internal/cli/api.go
+++ b/internal/cli/api.go
@@ -86,7 +86,7 @@ func (c *CLI) addAPICommand(root *cobra.Command) {
 	connectCmd.Flags().Bool("allow-cross-origin-spec", false, "Allow safe Link-header spec discovery from another host; private/local follow targets are still rejected")
 	connectCmd.Flags().Bool("no-discover", false, "Register the API locally without network spec discovery")
 	connectCmd.Flags().String("spec", "", "OpenAPI spec URL or local file to use instead of discovery")
-	connectCmd.Flags().Bool("replace", false, "Replace existing profiles with discovered OpenAPI/x-cli-config defaults")
+	connectCmd.Flags().Bool("replace", false, "Replace existing profiles and reapply discovered x-cli-config defaults")
 	connectCmd.Flags().Bool("yes", false, "Accept safe api connect prompts without asking")
 	apiCmd.AddCommand(connectCmd)
 	apiCmd.AddCommand(&cobra.Command{
@@ -376,7 +376,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 	allowCrossOrigin, _ := cmd.Flags().GetBool("allow-cross-origin-spec")
 	noDiscover, _ := cmd.Flags().GetBool("no-discover")
 	explicitSpec, _ := cmd.Flags().GetString("spec")
-	replaceProfiles, _ := cmd.Flags().GetBool("replace")
+	replaceDefaults, _ := cmd.Flags().GetBool("replace")
 	yes, _ := cmd.Flags().GetBool("yes")
 	promptAnswers, setupExprs, err := parseAPIConfigureSetupExpressions(args[2:])
 	if err != nil {
@@ -455,7 +455,7 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 		}
 		if xcli != nil {
 			xcli = xcli.Normalize()
-			if !replaceProfiles {
+			if !replaceDefaults {
 				removeExistingXCLIProfiles(xcli, existingAPI)
 			}
 			if !fallbackXCLI {
@@ -463,12 +463,12 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 					return err
 				}
 			}
-			if len(xcli.Profiles) > 0 {
-				c.applyXCLIConfig(apiCfg, xcli.Resolve(apiSpec))
-				if fallbackXCLI {
-					if err := c.configureFallbackAuth(requestContext(cmd), apiCfg, discovery, promptAnswers); err != nil {
-						return err
-					}
+			if err := c.applyXCLIConfig(apiCfg, xcli.Resolve(apiSpec)); err != nil {
+				return err
+			}
+			if fallbackXCLI && len(xcli.Profiles) > 0 {
+				if err := c.configureFallbackAuth(requestContext(cmd), apiCfg, discovery, promptAnswers); err != nil {
+					return err
 				}
 			}
 		}
@@ -481,12 +481,15 @@ func (c *CLI) runAPIConnect(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	if !replaceProfiles {
+	if !replaceDefaults {
 		if err := preserveExistingProfiles(apiCfg, existingAPI); err != nil {
 			return err
 		}
+		if existingAPI != nil && existingAPI.CommandLayout != "" {
+			apiCfg.CommandLayout = existingAPI.CommandLayout
+		}
 	}
-	preservedProfiles := preservedProfileNames(existingAPI, replaceProfiles)
+	preservedProfiles := preservedProfileNames(existingAPI, replaceDefaults)
 	if len(setupExprs) > 0 {
 		patched, err := c.applyAPIShorthandConfig(apiName, apiCfg, setupExprs)
 		if err != nil {
@@ -1095,9 +1098,15 @@ func xcliPromptLooksSecret(name string) bool {
 // Auth type "external-tool" is rejected: a server-provided x-cli-config
 // could otherwise pre-seed arbitrary shell-command execution on the next
 // authenticated request.
-func (c *CLI) applyXCLIConfig(apiCfg *config.APIConfig, xcli *spec.XCLIConfig) {
+func (c *CLI) applyXCLIConfig(apiCfg *config.APIConfig, xcli *spec.XCLIConfig) error {
+	if err := config.ValidateCommandLayout(xcli.CommandLayout); err != nil {
+		return fmt.Errorf("x-cli-config.command_layout: %w", err)
+	}
+	if xcli.CommandLayout != "" {
+		apiCfg.CommandLayout = xcli.CommandLayout
+	}
 	if len(xcli.Profiles) == 0 {
-		return
+		return nil
 	}
 	if apiCfg.Profiles == nil {
 		apiCfg.Profiles = make(map[string]*config.ProfileConfig)
@@ -1145,6 +1154,7 @@ func (c *CLI) applyXCLIConfig(apiCfg *config.APIConfig, xcli *spec.XCLIConfig) {
 		}
 		apiCfg.Profiles[name] = prof
 	}
+	return nil
 }
 
 func (c *CLI) discoveryTransport(ctx context.Context, apiCfg *config.APIConfig, profileName string) (http.RoundTripper, interface{ Close() error }, error) {

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -32,6 +32,7 @@ func specWithXCLIConfig(baseURL string) string {
   "info": {"title": "Managed API", "version": "1.0"},
   "servers": [{"url": %q}],
   "x-cli-config": {
+    "command_layout": "tags",
     "profiles": {
       "default": {
         "headers": ["Accept: application/json"],
@@ -114,6 +115,9 @@ func TestAPIConnect(t *testing.T) {
 	if api.BaseURL != "https://api.example.com" {
 		t.Errorf("base_url: got %q, want %q", api.BaseURL, "https://api.example.com")
 	}
+	if api.CommandLayout != "tags" {
+		t.Errorf("command_layout: got %q, want tags", api.CommandLayout)
+	}
 	prof := api.Profiles["default"]
 	if prof == nil {
 		t.Fatal("expected default profile in config")
@@ -123,6 +127,84 @@ func TestAPIConnect(t *testing.T) {
 	}
 	if len(prof.Headers) == 0 || !strings.Contains(prof.Headers[0], "application/json") {
 		t.Errorf("expected Accept header in default profile, got: %v", prof.Headers)
+	}
+}
+
+func TestAPIConnectPreservesExplicitCommandLayoutByDefault(t *testing.T) {
+	cfgFile := t.TempDir() + "/restish.json"
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	useOpenAPISpecTransport(c, specWithXCLIConfig("https://api.example.com"))
+
+	if err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com"}); err != nil {
+		t.Fatalf("first api connect: %v", err)
+	}
+	if err := c.Run([]string{"restish", "api", "set", "myapi", "command_layout: flat"}); err != nil {
+		t.Fatalf("api set: %v", err)
+	}
+	if err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com"}); err != nil {
+		t.Fatalf("second api connect: %v", err)
+	}
+
+	written, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load written config: %v", err)
+	}
+	if got := written.APIs["myapi"].CommandLayout; got != "flat" {
+		t.Fatalf("command_layout = %q, want explicit local value flat", got)
+	}
+
+	if err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com", "--replace"}); err != nil {
+		t.Fatalf("replacement api connect: %v", err)
+	}
+	written, err = config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load replaced config: %v", err)
+	}
+	if got := written.APIs["myapi"].CommandLayout; got != "tags" {
+		t.Fatalf("command_layout = %q, want contract default tags after --replace", got)
+	}
+}
+
+func TestAPIConnectRejectsInvalidXCLICommandLayout(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
+	c.Hooks().SpecCachePath = t.TempDir()
+	useOpenAPISpecTransport(c, `{
+  "openapi": "3.1.0",
+  "info": {"title": "Managed API", "version": "1.0"},
+  "x-cli-config": {"command_layout": "nested"},
+  "paths": {}
+}`)
+
+	err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com"})
+	if err == nil || !strings.Contains(err.Error(), `x-cli-config.command_layout: must be "flat" or "tags"`) {
+		t.Fatalf("api connect error = %v", err)
+	}
+}
+
+func TestAPIConnectAppliesXCLICommandLayoutWithoutProfiles(t *testing.T) {
+	cfgFile := t.TempDir() + "/restish.json"
+	c, _, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	useOpenAPISpecTransport(c, `{
+  "openapi": "3.1.0",
+  "info": {"title": "Managed API", "version": "1.0"},
+  "x-cli-config": {"command_layout": "tags"},
+  "paths": {}
+}`)
+
+	if err := c.Run([]string{"restish", "api", "connect", "myapi", "https://api.example.com"}); err != nil {
+		t.Fatalf("api connect: %v", err)
+	}
+	written, err := config.Load(cfgFile)
+	if err != nil {
+		t.Fatalf("load written config: %v", err)
+	}
+	if got := written.APIs["myapi"].CommandLayout; got != "tags" {
+		t.Fatalf("command_layout = %q, want tags", got)
 	}
 }
 

--- a/internal/cli/help_text.go
+++ b/internal/cli/help_text.go
@@ -29,7 +29,7 @@ const apiConnectLong = "Connect Restish to an API, discover its OpenAPI descript
 	"- Use `--spec` when discovery is blocked, the API does not advertise its spec, or you want to pin setup to a known OpenAPI URL or local file.\n" +
 	"- Use `--allow-cross-origin-spec` only when you trust a `Link` header that points to an OpenAPI document on another host. Private, loopback, link-local, and unspecified follow targets are still rejected unless the original API is already private/local; use `--spec` when you need to name a private spec URL directly.\n" +
 	"- Use `--no-discover` to save a base URL without fetching a spec.\n" +
-	"- Use `--replace` when reconnecting should replace existing profiles with generated OpenAPI or `x-cli-config` profile defaults. Without it, existing profiles are preserved, while API-level discovery fields are refreshed from the new connect run.\n" +
+	"- Use `--replace` when reconnecting should replace existing profiles and reapply generated OpenAPI or `x-cli-config` defaults. Without it, existing profiles and explicit local defaults are preserved, while other API-level discovery fields are refreshed from the new connect run.\n" +
 	"- Use `--yes` only for safe connect prompts you have already decided to accept in automation."
 
 const apiInspectLong = "Print the saved config for one registered API as redacted JSON.\n\n" +

--- a/internal/spec/xcliconfig.go
+++ b/internal/spec/xcliconfig.go
@@ -13,6 +13,9 @@ import (
 // XCLIConfig is the x-cli-config extension at the OpenAPI document root.
 // It drives `restish api connect` pre-population of the config file.
 type XCLIConfig struct {
+	// CommandLayout selects the default arrangement for generated commands.
+	CommandLayout string `json:"command_layout,omitempty" yaml:"command_layout,omitempty"`
+
 	// Profiles maps profile names to their pre-populated settings.
 	Profiles map[string]*XCLIProfile `json:"profiles,omitempty" yaml:"profiles,omitempty"`
 
@@ -349,7 +352,8 @@ func (xcli *XCLIConfig) Normalize() *XCLIConfig {
 		return nil
 	}
 	out := &XCLIConfig{
-		Profiles: make(map[string]*XCLIProfile, len(xcli.Profiles)),
+		CommandLayout: xcli.CommandLayout,
+		Profiles:      make(map[string]*XCLIProfile, len(xcli.Profiles)),
 	}
 	for name, profile := range xcli.Profiles {
 		out.Profiles[name] = normalizeXCLIProfile(cloneXCLIProfile(profile))
@@ -531,7 +535,8 @@ func (xcli *XCLIConfig) Resolve(s *APISpec) *XCLIConfig {
 	}
 
 	resolved := &XCLIConfig{
-		Profiles: make(map[string]*XCLIProfile, len(xcli.Profiles)),
+		CommandLayout: xcli.CommandLayout,
+		Profiles:      make(map[string]*XCLIProfile, len(xcli.Profiles)),
 	}
 
 	for name, xp := range xcli.Profiles {

--- a/internal/spec/xcliconfig_test.go
+++ b/internal/spec/xcliconfig_test.go
@@ -20,6 +20,7 @@ func loadDoc(t *testing.T, raw string) *APISpec {
 func TestReadXCLIConfig_Present(t *testing.T) {
 	raw := []byte(`
 x-cli-config:
+  command_layout: tags
   profiles:
     default:
       auth:
@@ -39,6 +40,9 @@ paths: {}`)
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
 	}
+	if cfg.CommandLayout != "tags" {
+		t.Fatalf("command layout = %q, want tags", cfg.CommandLayout)
+	}
 	if cfg.Profiles["default"] == nil {
 		t.Fatal("expected default profile")
 	}
@@ -47,6 +51,9 @@ paths: {}`)
 	}
 	if cfg.Profiles["default"].Auth.Type != "bearer" {
 		t.Errorf("auth type: got %q, want %q", cfg.Profiles["default"].Auth.Type, "bearer")
+	}
+	if resolved := cfg.Resolve(spec); resolved.CommandLayout != "tags" {
+		t.Fatalf("resolved command layout = %q, want tags", resolved.CommandLayout)
 	}
 }
 

--- a/site/content/en/docs/guides/api-setup-and-discovery.md
+++ b/site/content/en/docs/guides/api-setup-and-discovery.md
@@ -61,7 +61,7 @@ When you reconnect an existing API with `api connect`, Restish preserves
 existing profiles by default because they may contain credentials or auth
 references. API-level fields are refreshed from the new connect run. Add
 `--replace` only when you want OpenAPI or `x-cli-config` profile defaults to
-replace existing profiles.
+replace existing profiles and reapply contract-provided defaults.
 
 ## Operation Base
 

--- a/site/content/en/docs/reference/api-management.md
+++ b/site/content/en/docs/reference/api-management.md
@@ -64,7 +64,7 @@ Common choices:
 - Use `--spec` when discovery is blocked, the API does not advertise its spec, or you want to pin setup to a known OpenAPI URL or local file.
 - Use `--allow-cross-origin-spec` only when you trust a `Link` header that points to an OpenAPI document on another host. Private, loopback, link-local, and unspecified follow targets are still rejected unless the original API is already private/local; use `--spec` when you need to name a private spec URL directly.
 - Use `--no-discover` to save a base URL without fetching a spec.
-- Use `--replace` when reconnecting should replace existing profiles with generated OpenAPI or `x-cli-config` profile defaults. Without it, existing profiles are preserved, while API-level discovery fields are refreshed from the new connect run.
+- Use `--replace` when reconnecting should replace existing profiles and reapply generated OpenAPI or `x-cli-config` defaults. Without it, existing profiles and explicit local defaults are preserved, while other API-level discovery fields are refreshed from the new connect run.
 - Use `--yes` only for safe connect prompts you have already decided to accept in automation.
 
 Usage:
@@ -99,7 +99,7 @@ Register the API locally without network spec discovery
 
 Type: `bool`; default: `false`
 
-Replace existing profiles with discovered OpenAPI/x-cli-config defaults
+Replace existing profiles and reapply discovered x-cli-config defaults
 
 **`--spec`**
 

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -376,6 +376,7 @@ Document-level `x-cli-config` pre-populates API profiles during `api connect`:
 
 ```yaml
 x-cli-config:
+  command_layout: tags
   profiles:
     default:
       headers:
@@ -396,6 +397,10 @@ x-cli-config:
               value: "{api_key}"
           satisfies: ["items:read"]
 ```
+
+`command_layout` is an API-level default and accepts `flat` or `tags`. An
+existing non-empty local value is preserved when reconnecting; use `--replace`
+to reapply the document default.
 
 Supported profile fields are `headers`, `query`, `auth`, `credentials`,
 `security`, `params`, and `prompt`. Credential entries support `auth`,
@@ -429,12 +434,15 @@ or external tools.
 
 ## Command Layout
 
-Flat layout is the default. Restish does not guess an automatic layout from the
-spec. Tag layout can help large APIs when the tags are stable and useful:
+Flat layout is the default. Tag layout can help large APIs when the tags are
+stable and useful. Set it locally:
 
 ```bash
 restish api set myapi 'command_layout: tags'
 ```
+
+API providers can also select the initial layout with
+`x-cli-config.command_layout`.
 
 Keep tags short and user-facing if you expect them to become command groups.
 


### PR DESCRIPTION
Closes #401.

## Summary

- support API-level `x-cli-config.command_layout` values `flat` and `tags`
- apply the contract value during `api connect`, including documents without profiles
- validate contract values with the existing command-layout validator
- preserve an explicit local layout when reconnecting
- reapply the contract default when reconnecting with `--replace`
- keep `api sync` from overwriting the local layout
- document configuration precedence

## Behavior

An OpenAPI document can select its initial Restish command layout. Local configuration remains authoritative after connection unless the API is replaced explicitly.

## Verification

- `go test ./internal/spec ./internal/cli -run 'CommandLayout|^TestAPIConnect$'`
- `go test -tags=integration ./internal/spec ./internal/cli -run 'CommandLayout|^TestAPIConnect$'`
- `go run ./cmd/restish-docgen --check`
- `scripts/check-doc-links.rb`
- `scripts/check-doc-examples.rb`
