### PR TITLE
feat(plugins): expose operation security to auth hooks

### DIFF
--- a/cmd/restish-docgen/main.go
+++ b/cmd/restish-docgen/main.go
@@ -722,7 +722,7 @@ func renderMessageSchemaRegion(root string) (string, error) {
 	for _, group := range [][]string{
 		{"InitMsg", "HTTPRequestMsg", "HTTPResponseMsg", "APISpecMsg", "APISpecResponseMsg", "APIOperation", "APIParam", "ListAPIsMsg", "ListAPIsResponseMsg", "ListProfilesMsg", "ListProfilesResponseMsg", "ConfigReadMsg", "ConfigReadResponseMsg", "PromptMsg", "PromptResponseMsg", "ConfirmMsg", "ConfirmResponseMsg", "ResponseMsg", "DoneMsg", "StdoutDataMsg", "StderrDataMsg", "WarnMsg", "ProgressMsg", "SpinnerMsg", "LogMsg", "StdinDataMsg", "StdinCloseMsg"},
 		{"FormatterResponse", "FormatterRequest", "LoaderRequest", "LoaderResponse"},
-		{"HookRequest", "HookRequestHeaderUpdate", "AuthHookInput", "AuthHookOutput", "RequestMiddlewareInput", "RequestMiddlewareOutput", "HookResponse", "ResponseMiddlewareInput", "FollowRequest", "HookResponseUpdate", "ResponseMiddlewareOutput"},
+		{"HookRequest", "HookRequestHeaderUpdate", "AuthHookInput", "AuthHookOperation", "AuthHookOutput", "RequestMiddlewareInput", "RequestMiddlewareOutput", "HookResponse", "ResponseMiddlewareInput", "FollowRequest", "HookResponseUpdate", "ResponseMiddlewareOutput"},
 		{"TLSSignerInitMsg", "TLSSignerReadyMsg", "TLSSignerSignMsg", "TLSSignerSignedMsg", "TLSSignerShutdownMsg"},
 	} {
 		for _, name := range group {

--- a/docs/design/019-hook-plugins.md
+++ b/docs/design/019-hook-plugins.md
@@ -87,6 +87,8 @@ The `auth` hook runs during request preparation. Restish sends:
 - API name
 - profile name
 - auth params from config
+- the resolved OpenAPI operation ID and effective security requirements, when
+  method and path identify one operation
 - the outbound request method, URI, and headers
 
 The plugin replies with request updates, typically header changes. The reply is
@@ -102,6 +104,13 @@ per-credential `params` in that multi-credential case until the protocol grows
 an explicit combined credential context; single-credential auth continues to
 send the credential params with secrets redacted according to the plugin
 manifest.
+
+Resolved operation security preserves OpenAPI's OR-list of AND-sets. Generated
+commands carry their operation directly; generic API-relative and absolute URL
+requests use the same method/path matcher as operation-aware authentication.
+Unmatched or ambiguous requests omit operation metadata. The additive optional
+field keeps older hook plugins wire-compatible while allowing scope-aware
+plugins to select credentials without reparsing the API contract.
 
 Provider-specific OAuth token exchange is a good fit for this hook/plugin
 boundary when the built-in OAuth flows are too small. The plugin can own the

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rest-sh/restish/v2/internal/output"
 	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
 	"github.com/rest-sh/restish/v2/internal/spec"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +79,7 @@ type testHooks struct {
 	// SignalAwareContext overrides signal-aware root context creation in tests.
 	SignalAwareContext func() (context.Context, context.CancelFunc)
 	// AuthHookFunc overrides auth hook plugin execution in tests.
-	AuthHookFunc func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, req *http.Request) error
+	AuthHookFunc func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, operation *pluginwire.AuthHookOperation, req *http.Request) error
 	// StdoutIsTerminal overrides terminal detection in tests.
 	StdoutIsTerminal func(io.Writer) bool
 }

--- a/internal/cli/generated.go
+++ b/internal/cli/generated.go
@@ -491,7 +491,7 @@ func (c *CLI) buildOperationCommand(apiName, examplePrefix string, op spec.Opera
 			}
 			acceptOverride := c.generatedOperationAcceptHeader(op.ResponseMediaTypes, op.ResponseMediaType)
 			rawBinaryBody := op.Help.Request != nil && op.Help.Request.RawBinary
-			return c.runGeneratedOp(cmd, apiName, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.Help, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, required, optional, args)
+			return c.runGeneratedOp(cmd, apiName, op.ID, op.Path, op.OperationServer, op.Method, op.RequestMediaType, acceptOverride, op.RequestMultipartContentTypes, op.Help, op.BodyRequired, rawBinaryBody, op.NoAuth, op.OptionalAuth, op.CredentialAlternatives, required, optional, args)
 		},
 	}
 	if candidates := authOverrideCandidates(op.OptionalAuth, op.CredentialAlternatives); len(candidates) > 0 {
@@ -1374,7 +1374,7 @@ func shellQuoteGeneratedExample(ex string) string {
 // runGeneratedOp is the RunE handler for generated operation commands.
 func (c *CLI) runGeneratedOp(
 	cmd *cobra.Command,
-	apiName, opPath, operationServer, method, requestMediaType, responseMediaType string,
+	apiName, operationID, opPath, operationServer, method, requestMediaType, responseMediaType string,
 	requestMultipartContentTypes map[string]string,
 	help spec.OperationHelp,
 	bodyRequired bool,
@@ -1508,6 +1508,7 @@ func (c *CLI) runGeneratedOp(
 		rawBinaryBody:             rawBinaryBody,
 		explicitAPIName:           apiName,
 		operationAuth: &operationAuthPolicy{
+			ID:                     operationID,
 			OptionalAuth:           optionalAuth,
 			NoAuth:                 noAuth,
 			CredentialAlternatives: credentialAlternatives,

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rest-sh/restish/v2/config"
 	"github.com/rest-sh/restish/v2/internal/cli"
 	"github.com/rest-sh/restish/v2/internal/spec"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
 )
 
 // specWithOperations returns an OpenAPI 3.1 spec JSON string.
@@ -1046,6 +1047,51 @@ func TestGenericURLAppliesMatchedOperationAuth(t *testing.T) {
 	for i, auth := range got {
 		if !strings.HasPrefix(auth, "Basic ") {
 			t.Fatalf("request %d Authorization = %q, want Basic auth", i+1, auth)
+		}
+	}
+}
+
+func TestAuthHookReceivesResolvedOperationForGeneratedAndGenericRequests(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wallet", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+
+	env := setupEnvWithSpec(t, mux, func(baseURL string) string {
+		return openAPISpec(baseURL, "Wallet API",
+			openAPISecuritySchemes(`"WalletKey":{"type":"apiKey","in":"header","name":"X-Wallet-Key"}`),
+			openAPIPaths(openAPIGet("/wallet", "showWallet", `"security":[{"WalletKey":[]}]`)))
+	})
+	baseURL := env.baseURL(t)
+	env.writeAPIConfig(t, testAPIConfig(baseURL, profileCredentials(map[string]*config.CredentialConfig{
+		"WalletKey": testCredential(apiKeyAuth("header", "X-Wallet-Key", "secret")),
+	})))
+
+	c := env.newCLI()
+	var operations []*pluginwire.AuthHookOperation
+	c.Hooks().AuthHookFunc = func(_ string, _ string, _ map[string]string, _ map[string]bool, operation *pluginwire.AuthHookOperation, _ *http.Request) error {
+		operations = append(operations, operation)
+		return nil
+	}
+	if err := c.Run([]string{"restish", "tapi", "show-wallet"}); err != nil {
+		t.Fatalf("generated request failed: %v", err)
+	}
+	if err := c.Run([]string{"restish", baseURL + "/wallet"}); err != nil {
+		t.Fatalf("generic request failed: %v", err)
+	}
+
+	if len(operations) != 2 {
+		t.Fatalf("auth hook operations = %#v, want generated and generic requests", operations)
+	}
+	for i, operation := range operations {
+		want := &pluginwire.AuthHookOperation{
+			ID:       "showWallet",
+			Security: []map[string][]string{{"WalletKey": {}}},
+		}
+		if !reflect.DeepEqual(operation, want) {
+			t.Fatalf("operation %d = %#v, want %#v", i+1, operation, want)
 		}
 	}
 }

--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -96,8 +97,9 @@ func (c *CLI) resolveTLSSigner(opts request.Options) (request.Options, error) {
 // Plugins that declare auth_api_names in their manifest are only called when
 // apiName appears in that list.
 func (c *CLI) runAuthHookPlugins(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, req *http.Request) error {
+	operation := authHookOperationFromContext(req.Context())
 	if c.hooks.AuthHookFunc != nil {
-		return c.hooks.AuthHookFunc(apiName, profileName, rawParams, secretKeys, req)
+		return c.hooks.AuthHookFunc(apiName, profileName, rawParams, secretKeys, operation, req)
 	}
 	plugins := append([]plugin.Plugin(nil), c.globalAuthPlugins...)
 	plugins = append(plugins, c.authPluginsByAPI[apiName]...)
@@ -117,11 +119,12 @@ func (c *CLI) runAuthHookPlugins(apiName, profileName string, rawParams map[stri
 			params = redacted
 		}
 		in := pluginwire.AuthHookInput{
-			Type:    "auth",
-			API:     apiName,
-			Profile: profileName,
-			Params:  params,
-			Request: hookRequestForPlugin(req, p),
+			Type:      "auth",
+			API:       apiName,
+			Profile:   profileName,
+			Params:    params,
+			Operation: operation,
+			Request:   hookRequestForPlugin(req, p),
 		}
 		var out pluginwire.AuthHookOutput
 		if err := plugin.CallHookWithTimeoutContext(req.Context(), p.Path, plugin.HookTimeout(p.Manifest, "auth"), in, &out); err != nil {
@@ -130,6 +133,36 @@ func (c *CLI) runAuthHookPlugins(apiName, profileName string, rawParams map[stri
 		applyRequestUpdate(req, out.Request)
 	}
 	return nil
+}
+
+type authHookOperationContextKey struct{}
+
+func authHookOperationContext(ctx context.Context, policy *operationAuthPolicy) context.Context {
+	if policy == nil || policy.ID == "" {
+		return ctx
+	}
+	security := make([]map[string][]string, 0, len(policy.CredentialAlternatives)+1)
+	if policy.OptionalAuth {
+		security = append(security, map[string][]string{})
+	}
+	for _, alternative := range policy.CredentialAlternatives {
+		requirements := make(map[string][]string, len(alternative))
+		for _, requirement := range alternative {
+			requirements[requirement.ID] = append([]string{}, requirement.Needs...)
+		}
+		security = append(security, requirements)
+	}
+	return context.WithValue(ctx, authHookOperationContextKey{}, &pluginwire.AuthHookOperation{
+		ID:           policy.ID,
+		Security:     security,
+		NoAuth:       policy.NoAuth,
+		OptionalAuth: policy.OptionalAuth,
+	})
+}
+
+func authHookOperationFromContext(ctx context.Context) *pluginwire.AuthHookOperation {
+	operation, _ := ctx.Value(authHookOperationContextKey{}).(*pluginwire.AuthHookOperation)
+	return operation
 }
 
 // runRequestMiddlewarePlugins invokes all "request-middleware" hook plugins.

--- a/internal/cli/hooks_internal_test.go
+++ b/internal/cli/hooks_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	internalplugin "github.com/rest-sh/restish/v2/internal/plugin"
+	"github.com/rest-sh/restish/v2/internal/spec"
 	pluginwire "github.com/rest-sh/restish/v2/plugin"
 )
 
@@ -98,6 +99,34 @@ func TestHookRequestForPluginIncludesBodyHashAndOptInBody(t *testing.T) {
 	}
 	if got := firstHeaderValue(withBody.Headers, "Authorization"); got != "<redacted>" {
 		t.Fatalf("Authorization header = %q, want redacted", got)
+	}
+}
+
+func TestAuthHookOperationPreservesEffectiveSecurity(t *testing.T) {
+	ctx := authHookOperationContext(context.Background(), &operationAuthPolicy{
+		ID:           "showWallet",
+		OptionalAuth: true,
+		CredentialAlternatives: []spec.CredentialAlternative{
+			{
+				{ID: "WalletOAuth", Needs: []string{"wallet:read", "wallet:budget"}},
+				{ID: "DeviceKey"},
+			},
+			{{ID: "OperatorOAuth", Needs: []string{"wallet:read"}}},
+		},
+	})
+
+	got := authHookOperationFromContext(ctx)
+	want := &pluginwire.AuthHookOperation{
+		ID:           "showWallet",
+		OptionalAuth: true,
+		Security: []map[string][]string{
+			{},
+			{"WalletOAuth": {"wallet:read", "wallet:budget"}, "DeviceKey": {}},
+			{"OperatorOAuth": {"wallet:read"}},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("operation = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/cli/operation_auth.go
+++ b/internal/cli/operation_auth.go
@@ -13,6 +13,7 @@ import (
 )
 
 type operationAuthPolicy struct {
+	ID                     string
 	OptionalAuth           bool
 	NoAuth                 bool
 	CredentialAlternatives []spec.CredentialAlternative

--- a/internal/cli/operation_auth_test.go
+++ b/internal/cli/operation_auth_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rest-sh/restish/v2/config"
 	"github.com/rest-sh/restish/v2/internal/request"
 	"github.com/rest-sh/restish/v2/internal/spec"
+	pluginwire "github.com/rest-sh/restish/v2/plugin"
 )
 
 type forceRecordingAuth struct {
@@ -611,7 +612,7 @@ func TestOperationAuthCallbacksForceCapableUnauthorizedRetry(t *testing.T) {
 func TestOperationAuthCallbacksRunHookOnceForMultipleCredentials(t *testing.T) {
 	c := New()
 	var hookCalls atomic.Int32
-	c.Hooks().AuthHookFunc = func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, req *http.Request) error {
+	c.Hooks().AuthHookFunc = func(apiName, profileName string, rawParams map[string]string, secretKeys map[string]bool, operation *pluginwire.AuthHookOperation, req *http.Request) error {
 		hookCalls.Add(1)
 		req.Header.Set("X-Hook", "called")
 		return nil

--- a/internal/cli/operation_route_auth.go
+++ b/internal/cli/operation_route_auth.go
@@ -60,13 +60,14 @@ func (c *CLI) operationAuthForGenericRequest(ctx context.Context, method, rawURL
 		return genericOperationAuthMatch{}, false
 	}
 	if best.NoAuth {
-		return genericOperationAuthMatch{noAuth: true}, true
-	}
-	if len(best.CredentialAlternatives) == 0 && !best.OptionalAuth {
-		return genericOperationAuthMatch{}, false
+		return genericOperationAuthMatch{
+			noAuth: true,
+			policy: &operationAuthPolicy{ID: best.ID, NoAuth: true},
+		}, true
 	}
 	return genericOperationAuthMatch{
 		policy: &operationAuthPolicy{
+			ID:                     best.ID,
 			OptionalAuth:           best.OptionalAuth,
 			CredentialAlternatives: best.CredentialAlternatives,
 		},

--- a/internal/cli/request_exec.go
+++ b/internal/cli/request_exec.go
@@ -25,6 +25,7 @@ type preparedRequest struct {
 	bodyContentType string
 	actualRequest   *http.Request
 	authEnabled     bool
+	operationAuth   *operationAuthPolicy
 	closer          io.Closer
 	stopClose       func() bool
 }
@@ -204,6 +205,7 @@ func (c *CLI) prepareRequest(
 		bodyRaw:         bodyRaw,
 		bodyContentType: bodyContentType,
 		authEnabled:     authEnabled,
+		operationAuth:   operationAuth,
 		closer:          transportCloser,
 		stopClose:       stopTransportClose,
 	}
@@ -340,6 +342,7 @@ func isRawBinaryContentType(contentType string) bool {
 }
 
 func (c *CLI) sendPreparedRequest(ctx context.Context, method string, prepared *preparedRequest) (*http.Response, error) {
+	ctx = authHookOperationContext(ctx, prepared.operationAuth)
 	bodyReader := func() io.Reader {
 		if len(prepared.bodyRaw) == 0 {
 			return nil

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -56,7 +56,8 @@
 // return one CBOR reply map.
 //
 //   - auth:
-//     request contains api_name, profile_name, params, and request metadata
+//     request contains API, profile, params, optional resolved operation
+//     security, and request metadata
 //     reply typically returns request.header updates
 //   - request-middleware:
 //     request contains the outbound request metadata

--- a/plugin/messages.go
+++ b/plugin/messages.go
@@ -398,11 +398,22 @@ type HookRequestHeaderUpdate struct {
 
 // AuthHookInput is sent to plugins registered for the "auth" hook.
 type AuthHookInput struct {
-	Type    string            `cbor:"type" json:"type"`
-	API     string            `cbor:"api" json:"api"`
-	Profile string            `cbor:"profile" json:"profile"`
-	Params  map[string]string `cbor:"params" json:"params"`
-	Request HookRequest       `cbor:"request" json:"request"`
+	Type      string             `cbor:"type" json:"type"`
+	API       string             `cbor:"api" json:"api"`
+	Profile   string             `cbor:"profile" json:"profile"`
+	Params    map[string]string  `cbor:"params" json:"params"`
+	Operation *AuthHookOperation `cbor:"operation,omitempty" json:"operation,omitempty"`
+	Request   HookRequest        `cbor:"request" json:"request"`
+}
+
+// AuthHookOperation identifies the OpenAPI operation resolved for an
+// authenticated request. Security preserves OpenAPI's OR-list of AND-sets:
+// each map is one alternative, and every scheme in that map is required.
+type AuthHookOperation struct {
+	ID           string                `cbor:"id" json:"id"`
+	Security     []map[string][]string `cbor:"security" json:"security"`
+	NoAuth       bool                  `cbor:"no_auth,omitempty" json:"no_auth,omitempty"`
+	OptionalAuth bool                  `cbor:"optional_auth,omitempty" json:"optional_auth,omitempty"`
 }
 
 // AuthHookOutput is the reply from an "auth" hook plugin.

--- a/site/content/en/docs/plugins/hook-plugins.md
+++ b/site/content/en/docs/plugins/hook-plugins.md
@@ -58,6 +58,14 @@ multi-credential case the hook input does not include individual credential
 params; single-credential auth continues to include params with secrets redacted
 unless the manifest opts into auth secrets.
 
+When Restish resolves the request to an OpenAPI operation, auth hooks also
+receive `operation.id` and its effective `operation.security`. Security keeps
+OpenAPI's OR-list of AND-sets, so each object is one alternative and every
+scheme in an object is required. `operation.no_auth` identifies an explicit
+`security: []`, while `operation.optional_auth` identifies an anonymous
+alternative such as `{}`. Requests that cannot be matched to one operation omit
+`operation`, which keeps existing plugins compatible.
+
 ## Pitfalls
 
 - Keep hooks narrow and deterministic.

--- a/site/content/en/docs/reference/plugin-messages.md
+++ b/site/content/en/docs/reference/plugin-messages.md
@@ -835,9 +835,34 @@ CBOR: `profile`; JSON: `profile`; type: `string`; required: yes
 
 CBOR: `params`; JSON: `params`; type: `map[string]string`; required: yes
 
+**`Operation`**
+
+CBOR: `operation`; JSON: `operation`; type: `*AuthHookOperation`; required: no
+
 **`Request`**
 
 CBOR: `request`; JSON: `request`; type: `HookRequest`; required: yes
+
+
+### `AuthHookOperation`
+
+AuthHookOperation identifies the OpenAPI operation resolved for an authenticated request. Security preserves OpenAPI's OR-list of AND-sets: each map is one alternative, and every scheme in that map is required.
+
+**`ID`**
+
+CBOR: `id`; JSON: `id`; type: `string`; required: yes
+
+**`Security`**
+
+CBOR: `security`; JSON: `security`; type: `[]map[string][]string`; required: yes
+
+**`NoAuth`**
+
+CBOR: `no_auth`; JSON: `no_auth`; type: `bool`; required: no
+
+**`OptionalAuth`**
+
+CBOR: `optional_auth`; JSON: `optional_auth`; type: `bool`; required: no
 
 
 ### `AuthHookOutput`


### PR DESCRIPTION
## Summary

- add an optional `operation` object to auth-hook input
- include the resolved operation ID and effective OpenAPI security requirements
- preserve OpenAPI OR/AND security semantics, explicit anonymous access, and optional authentication
- resolve operation metadata for generated commands and generic method/path requests
- document and regenerate the plugin message contract

## Compatibility

The new field is optional. Existing plugins can ignore it, and unmatched or ambiguous generic requests omit it.

## Verification

- `CGO_ENABLED=1 go test ./...`
- `CGO_ENABLED=1 go test -tags=integration ./...`
- builds for all five binaries
- `go run ./cmd/restish-docgen --check`
- `scripts/check-doc-links.rb`
- `scripts/check-doc-examples.rb`
