### PR TITLE
feat: add explicit raw response output

### DIFF
--- a/docs/design/009-response-normalization-and-output.md
+++ b/docs/design/009-response-normalization-and-output.md
@@ -118,12 +118,12 @@ That dual representation is what lets Restish support:
 
 without forcing an irreversible choice too early in the pipeline.
 
-For redirected unfiltered responses, raw output is byte-oriented. It must write
-the original response body bytes after transfer decoding, not a Go value
-formatted through `fmt` and not a decode/re-encode approximation. Once the user
-selects a transformed logical value with a filter, byte fidelity no longer
-applies to that transformed value. Shell-friendly filtered scalar output belongs
-to the `lines` output format instead.
+For redirected unfiltered responses and explicit `-r` / `--rsh-raw`, raw output
+is byte-oriented. It must write the original response body bytes after transfer
+decoding, not a Go value formatted through `fmt` and not a decode/re-encode
+approximation. Once the user selects a transformed logical value with a filter,
+byte fidelity no longer applies to that transformed value. Shell-friendly
+filtered scalar output belongs to the `lines` output format instead.
 
 ## Hypermedia Integration
 
@@ -141,6 +141,7 @@ This keeps link handling out of individual formatter or command implementations.
 The formatting model is intentionally adaptive:
 
 - `--rsh-print` selects the HTTP exchange parts Restish writes to stdout
+- `-r` / `--rsh-raw` explicitly selects only original response body bytes
 - `-o <format>` formats the rendered body/value selected by `--rsh-print=b`
 - `-f` selects the body/value used by `b`
 - omitted `-f` selects `body`
@@ -153,6 +154,10 @@ The formatting model is intentionally adaptive:
   metadata shortcut, pagination collection, or explicit output format is set;
   this raw-download path bypasses response middleware so installed plugins
   cannot silently rewrite saved files
+- explicit `-r` / `--rsh-raw` selects the same raw-download path regardless of
+  whether stdout is a TTY and rejects filters, formats, collection, item limits,
+  metadata shortcuts, and explicit print selections
+- commands without original HTTP response body bytes reject explicit raw output
 - non-TTY filtered or transformed values default to the rendered body part with
   pretty formatting (`bp`); explicit `--rsh-print=b` keeps JSON output compact
   for scripts
@@ -176,8 +181,9 @@ Restish separates `-o` output formats into two families:
   formatter plugins
 
 `raw` is not an `-o` output format and is not a public print part. Raw byte
-output is the automatic non-TTY path for unfiltered, unformatted responses.
-Plain scalar line output is requested with `-o lines`.
+output is the automatic non-TTY path for unfiltered, unformatted responses and
+the explicit `-r` / `--rsh-raw` path on any stdout. Plain scalar line output is
+requested with `-o lines`.
 
 Document formats must preserve framing guarantees:
 
@@ -371,6 +377,7 @@ Output behavior must not corrupt data:
   writing raw bytes or base64 JSON strings
 - redirected or piped unfiltered responses should write the payload bytes
   exactly unless the user explicitly selected a different formatter
+- explicit `-r` / `--rsh-raw` should write those bytes even on a TTY
 - JSON formatters should emit stable JSON without unnecessary HTML escaping
 
 Binary-to-string coercion is a design bug because it damages fidelity and later
@@ -405,6 +412,7 @@ Supported print parts are:
 
 The important separation is:
 
+- `--rsh-raw` selects the original response body byte path
 - `--rsh-print` decides which parts go to stdout
 - `-o` decides how `b` is rendered
 - `-f` decides which value `b` renders

--- a/docs/design/010-filtering-and-projection.md
+++ b/docs/design/010-filtering-and-projection.md
@@ -177,9 +177,10 @@ Silent discarding of user intent is not acceptable.
 
 Redirected stdout writes the original response body bytes after transfer
 decoding when no filter, metadata shortcut, collection, or rendered output
-format is requested. This raw-download path bypasses response middleware.
-Filters always select decoded normalized values; they do not have a raw-byte
-rendering mode.
+format is requested. `-r` / `--rsh-raw` selects the same path explicitly and
+cannot be combined with a filter. This raw-download path bypasses response
+middleware. Filters always select decoded normalized values; they do not have a
+raw-byte rendering mode.
 
 Filtered scalar values print plainly by default:
 

--- a/docs/design/012-streaming.md
+++ b/docs/design/012-streaming.md
@@ -122,6 +122,8 @@ meaningful.
 
 Restish therefore treats:
 
+- `-r` / `--rsh-raw` as incremental passthrough of the decompressed stream
+  bytes, without event parsing or response middleware
 - `-o ndjson` as the explicit record-oriented JSON stream format
 - `-o auto` as an incremental human view
 - `-o json` as a bounded-document request that should reject clearly live
@@ -150,6 +152,9 @@ The stream planner should decide:
 3. whether the filter can be evaluated per event
 4. whether the user requested a bounded stop such as `--rsh-max-items`
 5. whether the requested format must fail because the stream is unbounded
+
+Explicit raw output rejects `--rsh-max-items` because a record limit requires
+parsing stream framing rather than passing through the original body bytes.
 
 This ties streaming into the same output-family model as design 028.
 

--- a/docs/design/019-hook-plugins.md
+++ b/docs/design/019-hook-plugins.md
@@ -145,8 +145,8 @@ Response middleware runs on the interpreted response path: interactive output,
 explicit filters, metadata shortcuts, collection, explicit output formats, and
 explicit `--rsh-print` values. It does not run for the automatic raw-download
 path (`restish URL > file` with no filter, collection, metadata shortcut, or
-output format), because that path preserves the original response body bytes for
-files and shell pipelines.
+output format) or explicit `-r` / `--rsh-raw`, because those paths preserve the
+original response body bytes.
 
 The response update's `headers` object is a partial update: keys returned by the
 plugin replace those individual response header values, while omitted inbound

--- a/docs/design/028-document-and-record-output.md
+++ b/docs/design/028-document-and-record-output.md
@@ -122,6 +122,7 @@ unknown payloads.
 This keeps a clean product distinction:
 
 - redirection saves the response body bytes
+- `-r` / `--rsh-raw` selects those bytes explicitly on any stdout
 - `-o <format>` transforms the decoded body or selected value
 - filters and metadata shortcuts render normalized values
 - `--rsh-collect` opts into a synthesized multi-page document
@@ -399,6 +400,8 @@ Clear failure is better than silently emitting invalid or misleading output.
   on stdout
 - default redirected non-TTY without filters or formats: first response body
   bytes, with automatic pagination skipped
+- `-r` / `--rsh-raw`: first response body bytes on any stdout, with automatic
+  pagination skipped
 - `-o json`: valid pretty JSON document by default; unfiltered pagination
   merges items, filtered pagination renders filtered item results
 - `-o yaml`: valid YAML document; unfiltered pagination merges items, filtered
@@ -411,6 +414,7 @@ Clear failure is better than silently emitting invalid or misleading output.
 ### True SSE / NDJSON Stream
 
 - default TTY: auto incremental event output
+- `-r` / `--rsh-raw`: incremental passthrough of decompressed stream bytes
 - default non-TTY: NDJSON-style item output when the payload is structured
 - `-o ndjson`: one JSON value per line
 - `-o auto`: incremental human-readable event view

--- a/docs/design/030-security-model-and-trust-boundaries.md
+++ b/docs/design/030-security-model-and-trust-boundaries.md
@@ -234,9 +234,10 @@ Redirected stdout is different: when no filter, metadata shortcut, pagination
 collection, or output format is set, `--rsh-print=auto` writes body bytes
 directly because the user is saving or piping the response rather than asking
 for a TTY presentation. This raw-download path bypasses response middleware so
-installed plugins cannot silently rewrite saved files. Explicit filters,
-formats, and print strings use the interpreted response path where response
-middleware may modify, drop, or follow.
+installed plugins cannot silently rewrite saved files. `-r` / `--rsh-raw`
+selects the same byte path explicitly; writing binary bytes to a TTY is then
+operator intent. Explicit filters, formats, and print strings use the
+interpreted response path where response middleware may modify, drop, or follow.
 
 ## Plugin Safety
 

--- a/docs/design/032-implementation-contract.md
+++ b/docs/design/032-implementation-contract.md
@@ -19,6 +19,7 @@ override built-in defaults only when the matching flag was not set.
 | `--rsh-server` | `-s` | string | | empty | Overrides scheme/host; path prefixes request path. |
 | `--rsh-output-format` | `-o` | string | `RSH_OUTPUT_FORMAT` | auto | Formats the rendered body/value selected by `--rsh-print=b`; `lines` for scalar line output; no `raw` format. |
 | `--rsh-print` | | string | `RSH_PRINT` | auto | Chooses stdout parts: `H` request headers, `B` request body, `h` response status/headers, `b` rendered body, `p` pretty, `c` color. `auto` is `hbpc` on a terminal, body bytes for redirected unfiltered responses with no explicit output transform, and `bp` for filters, metadata shortcuts, and formatted/collected output. |
+| `--rsh-raw` | `-r` | bool | | false | Direct HTTP requests write only response body bytes after HTTP content-encoding decompression on any stdout; bypasses decoding, filtering, formatting, pagination, and response middleware. |
 | `--rsh-silent` | `-S` | bool | | false | Suppress output. |
 | `--rsh-columns` | | string | | empty | Table columns. |
 | `--rsh-sort-by` | | string | | empty | Table sort column. |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -210,6 +210,9 @@ func (w *cascadingFlushWriter) ReadFrom(r io.Reader) (int64, error) {
 			if nw != nr {
 				return written, io.ErrShortWrite
 			}
+			if err := w.Flush(); err != nil {
+				return written, err
+			}
 		}
 		if er == io.EOF {
 			return written, nil
@@ -1268,12 +1271,12 @@ func flagConsumesNextArg(token string) bool {
 
 var boolLikeLongFlags = map[string]bool{
 	"help": true, "version": true,
-	"rsh-silent": true, "rsh-headers": true,
+	"rsh-raw": true, "rsh-silent": true, "rsh-headers": true,
 	"rsh-verbose": true, "rsh-insecure": true, "rsh-ignore-status-code": true,
 	"rsh-no-cache": true, "rsh-no-browser": true, "rsh-no-paginate": true,
 	"rsh-collect": true,
 }
 
 var boolLikeShortFlags = map[rune]bool{
-	'S': true, 'v': true,
+	'r': true, 'S': true, 'v': true,
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -974,6 +974,7 @@ func TestHelpGroupsTopLevelCommands(t *testing.T) {
 		"General Options",
 		"--rsh-auth",
 		"--rsh-config",
+		"--rsh-raw",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected root --help-all to contain %q:\n%s", want, got)
@@ -981,9 +982,10 @@ func TestHelpGroupsTopLevelCommands(t *testing.T) {
 	}
 	outputGroupIdx := strings.Index(got, "Output Options")
 	printFlagIdx := strings.Index(got, "--rsh-print")
+	rawFlagIdx := strings.Index(got, "--rsh-raw")
 	authGroupIdx := strings.Index(got, "Auth and Profile Options")
-	if outputGroupIdx < 0 || printFlagIdx < outputGroupIdx || authGroupIdx < 0 || printFlagIdx > authGroupIdx {
-		t.Fatalf("--rsh-print should be grouped under Output Options in --help-all:\n%s", got)
+	if outputGroupIdx < 0 || printFlagIdx < outputGroupIdx || rawFlagIdx < outputGroupIdx || authGroupIdx < 0 || printFlagIdx > authGroupIdx || rawFlagIdx > authGroupIdx {
+		t.Fatalf("--rsh-print and --rsh-raw should be grouped under Output Options in --help-all:\n%s", got)
 	}
 }
 

--- a/internal/cli/command_plugin_internal_test.go
+++ b/internal/cli/command_plugin_internal_test.go
@@ -328,6 +328,29 @@ func TestStripHostPersistentFlagsPreservesPluginArgs(t *testing.T) {
 	}
 }
 
+func TestCommandPluginRejectsRawOutput(t *testing.T) {
+	root := &cobra.Command{Use: "restish"}
+	cmd := &cobra.Command{Use: "plug"}
+	root.AddCommand(cmd)
+	cmd.SetContext(withGlobalFlags(context.Background(), GlobalFlags{Raw: true}))
+	if err := (&CLI{}).runCommandPlugin(cmd, "missing-plugin", pluginwire.CommandDecl{}, nil); err == nil || !strings.Contains(err.Error(), "restish plug does not support -r/--rsh-raw") {
+		t.Fatalf("parsed raw flag: unexpected error: %v", err)
+	}
+	cmd.SetContext(context.Background())
+	for _, flag := range []string{"--rsh-raw", "--rsh-raw=true"} {
+		err := (&CLI{}).runCommandPlugin(cmd, "missing-plugin", pluginwire.CommandDecl{}, []string{flag})
+		if err == nil || !strings.Contains(err.Error(), "restish plug does not support -r/--rsh-raw") {
+			t.Fatalf("%s: unexpected error: %v", flag, err)
+		}
+	}
+	for _, flag := range []string{"-r", "--rsh-raw=false"} {
+		err := (&CLI{}).runCommandPlugin(cmd, "missing-plugin", pluginwire.CommandDecl{}, []string{flag})
+		if err == nil || strings.Contains(err.Error(), "does not support -r/--rsh-raw") {
+			t.Fatalf("%s should remain plugin-owned: %v", flag, err)
+		}
+	}
+}
+
 func TestValidatePluginCommandNameRejectsCollisions(t *testing.T) {
 	c := &CLI{cfg: &config.Config{APIs: map[string]*config.APIConfig{"svc": {}}}}
 	root := &cobra.Command{Use: "restish"}

--- a/internal/cli/command_plugin_runtime.go
+++ b/internal/cli/command_plugin_runtime.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -120,6 +121,26 @@ func (w *commandPluginWaiter) Wait(grace time.Duration) error {
 }
 
 func (c *CLI) runCommandPlugin(cmd *cobra.Command, pluginPath string, decl pluginwire.CommandDecl, args []string) error {
+	if globalFlagsFromContext(requestContext(cmd)).Raw {
+		return fmt.Errorf("%s does not support -r/--rsh-raw", cmd.CommandPath())
+	}
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if arg == "--rsh-raw" {
+			return fmt.Errorf("%s does not support -r/--rsh-raw", cmd.CommandPath())
+		}
+		if value, ok := strings.CutPrefix(arg, "--rsh-raw="); ok {
+			enabled, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid --rsh-raw value %q: %w", value, err)
+			}
+			if enabled {
+				return fmt.Errorf("%s does not support -r/--rsh-raw", cmd.CommandPath())
+			}
+		}
+	}
 	syncErr := &commandPluginWriter{w: cmd.ErrOrStderr()}
 	cmd.SetErr(syncErr)
 	args = stripHostPersistentFlags(cmd, args)

--- a/internal/cli/command_surface_test.go
+++ b/internal/cli/command_surface_test.go
@@ -521,6 +521,11 @@ func TestPlainUtilityCommandsRejectResponseTransformFlags(t *testing.T) {
 			want: "does not support -f/--rsh-filter",
 		},
 		{
+			name: "version raw output",
+			args: []string{"restish", "version", "--rsh-raw"},
+			want: "does not support -r/--rsh-raw",
+		},
+		{
 			name: "cert output format",
 			args: []string{"restish", "cert", "https://example.com", "-o", "json"},
 			want: "does not support -o/--rsh-output-format",

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -42,6 +42,9 @@ func (c *CLI) addEditCommand(root *cobra.Command) {
 }
 
 func (c *CLI) runEdit(cmd *cobra.Command, args []string) error {
+	if globalFlagsFromContext(requestContext(cmd)).Raw {
+		return fmt.Errorf("%s does not support -r/--rsh-raw", cmd.CommandPath())
+	}
 	rawURL := args[0]
 	patchArgs := args[1:]
 	opts, err := c.httpOptsFromFlags(cmd)

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -289,6 +289,18 @@ func TestEditCommandNoEditorPrintsEditableResource(t *testing.T) {
 	}
 }
 
+func TestEditRejectsRawOutputBeforeRequest(t *testing.T) {
+	c, _, _ := newTestCLI(t)
+	c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		t.Fatal("request should not be sent when edit rejects raw output")
+		return nil, nil
+	})
+	err := c.Run([]string{"restish", "edit", "--rsh-raw", "https://api.example.com/items/1"})
+	if err == nil || !strings.Contains(err.Error(), "restish edit does not support -r/--rsh-raw") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEditCommandUpdateUsesProfileHeaders(t *testing.T) {
 	installFakeEditor(t, "{\n  \"name\": \"after\"\n}\n")
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -25,6 +25,7 @@ type GlobalFlags struct {
 	OutputFormatSet  bool
 	Print            string
 	PrintSet         bool
+	Raw              bool
 	Silent           bool
 	Columns          string
 	SortBy           string
@@ -92,6 +93,7 @@ func parseGlobalFlags(cmd *cobra.Command) (GlobalFlags, error) {
 	gf.Timeout, _ = cmd.Flags().GetString("rsh-timeout")
 
 	// Bool flags
+	gf.Raw, _ = cmd.Flags().GetBool("rsh-raw")
 	gf.Silent, _ = cmd.Flags().GetBool("rsh-silent")
 	gf.HeadersShorthand, _ = cmd.Flags().GetBool("rsh-headers")
 	gf.StatusShorthand, _ = cmd.Flags().GetBool("rsh-status")
@@ -206,6 +208,9 @@ func parseGlobalFlags(cmd *cobra.Command) (GlobalFlags, error) {
 		return gf, err
 	}
 	if err := validateTLSMinVersionFlag(cmd, gf); err != nil {
+		return gf, err
+	}
+	if err := validateRawOutputFlags(cmd, gf); err != nil {
 		return gf, err
 	}
 	return gf, nil

--- a/internal/cli/generated_test.go
+++ b/internal/cli/generated_test.go
@@ -551,6 +551,42 @@ func TestGeneratedCommandRefreshesStaleOperationCacheOnUse(t *testing.T) {
 	}
 }
 
+func TestLazyGeneratedCommandPreservesRawOutputFlag(t *testing.T) {
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, specWithOperations(serverURL))
+	})
+	raw := "[ { \"id\": 1 } ]\n"
+	mux.HandleFunc("/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, raw)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	serverURL = srv.URL
+
+	cfgData, _ := json.Marshal(&config.Config{APIs: map[string]*config.APIConfig{
+		"tapi": {BaseURL: srv.URL, SpecURL: srv.URL + "/openapi.json"},
+	}})
+	cfgFile := t.TempDir() + "/restish.json"
+	if err := os.WriteFile(cfgFile, cfgData, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = cfgFile
+	c.Hooks().SpecCachePath = t.TempDir()
+	c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return true }
+
+	if err := c.Run([]string{"restish", "-r", "tapi", "list-items"}); err != nil {
+		t.Fatalf("generated command: %v", err)
+	}
+	if got := out.String(); got != raw {
+		t.Fatalf("raw generated output = %q, want %q", got, raw)
+	}
+}
+
 func TestGeneratedCommandRefreshesStaleRawSpecWhenOperationCacheMissing(t *testing.T) {
 	var specHits atomic.Int32
 	mux := http.NewServeMux()

--- a/internal/cli/help_template.go
+++ b/internal/cli/help_template.go
@@ -46,6 +46,7 @@ var defaultFlagGroups = map[string]string{
 
 	"rsh-output-format": flagGroupOutput,
 	"rsh-print":         flagGroupOutput,
+	"rsh-raw":           flagGroupOutput,
 	"rsh-filter":        flagGroupOutput,
 	"rsh-filter-lang":   flagGroupOutput,
 	"rsh-headers":       flagGroupOutput,

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -290,9 +290,11 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 			return specErr
 		}
 		if spec.rawBodyOnly() {
-			if err := c.statusError(cmd, httpResp.StatusCode); err != nil {
-				_ = httpResp.Body.Close()
-				return err
+			if !gf.Raw {
+				if err := c.statusError(cmd, httpResp.StatusCode); err != nil {
+					_ = httpResp.Body.Close()
+					return err
+				}
 			}
 			reader, err := c.decompressedResponseBody(httpResp)
 			if err != nil {
@@ -303,8 +305,10 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 			trace.Info("Output", "raw")
 			trace.Step("raw")
 			trace.RenderAfter(c.Stderr, gf.Verbose)
-			_, err = io.Copy(c.Stdout, reader)
-			return err
+			if _, err := io.Copy(c.Stdout, reader); err != nil {
+				return err
+			}
+			return c.statusError(cmd, httpResp.StatusCode)
 		}
 		if err := c.statusError(cmd, httpResp.StatusCode); err != nil {
 			_ = httpResp.Body.Close()
@@ -494,6 +498,9 @@ func (c *CLI) formatResponse(cmd *cobra.Command, resp *output.Response, prepared
 	statusOnly := gf.StatusShorthand
 
 	if printPlan.rawBodyOnly() {
+		if gf.Raw && resp.Raw == nil {
+			return fmt.Errorf("raw response body is unavailable for this command")
+		}
 		if resp.Raw == nil && resp.Body != nil && !gf.PrintSet {
 			printPlan = printSpec{order: []rune{printRenderedBody}}
 		} else {

--- a/internal/cli/json_output.go
+++ b/internal/cli/json_output.go
@@ -50,6 +50,9 @@ func rejectUnsupportedResponseTransformFlags(cmd *cobra.Command, gf GlobalFlags,
 
 func unsupportedResponseTransformFlagNames(cmd *cobra.Command, gf GlobalFlags) []string {
 	var names []string
+	if gf.Raw {
+		names = append(names, "-r/--rsh-raw")
+	}
 	if gf.PrintSet {
 		names = append(names, "--rsh-print")
 	}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -998,6 +998,77 @@ func TestExplicitPrintBodyImageNonTTYWritesOriginalBytes(t *testing.T) {
 	}
 }
 
+func TestExplicitRawOutputPreservesDecompressedBytes(t *testing.T) {
+	raw := "{\n  \"z\": 1\n}\n"
+	encoded := gzipBytes(t, raw)
+	tests := []struct {
+		name string
+		args []string
+		tty  bool
+	}{
+		{name: "long flag on TTY", args: []string{"restish", "get", "--rsh-raw", "https://api.example.com/data"}, tty: true},
+		{name: "short flag off TTY", args: []string{"restish", "-r", "get", "https://api.example.com/data"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, out, _ := newTestCLI(t)
+			c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return tt.tty }
+			c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Proto:      "HTTP/1.1",
+					Header: http.Header{
+						"Content-Type":     []string{"application/json"},
+						"Content-Encoding": []string{"gzip"},
+					},
+					Body:    io.NopCloser(bytes.NewReader(encoded)),
+					Request: r,
+				}, nil
+			})
+			if err := c.Run(tt.args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := out.String(); got != raw {
+				t.Fatalf("raw output = %q, want decompressed bytes %q", got, raw)
+			}
+		})
+	}
+}
+
+func TestRawOutputRejectsIncompatibleFlagsBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "output format", args: []string{"-o", "auto"}, want: "-o/--rsh-output-format"},
+		{name: "print", args: []string{"--rsh-print", "auto"}, want: "--rsh-print"},
+		{name: "filter", args: []string{"-f", "body"}, want: "-f/--rsh-filter"},
+		{name: "headers", args: []string{"--rsh-headers"}, want: "--rsh-headers"},
+		{name: "status", args: []string{"--rsh-status"}, want: "--rsh-status"},
+		{name: "collect", args: []string{"--rsh-collect"}, want: "--rsh-collect"},
+		{name: "max items", args: []string{"--rsh-max-items", "1"}, want: "--rsh-max-items"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requested := false
+			c, _, _ := newTestCLI(t)
+			c.Hooks().HTTPTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				requested = true
+				return jsonResponse(http.StatusOK, `{}`), nil
+			})
+			args := append([]string{"restish", "get", "--rsh-raw", "https://api.example.com/items"}, tt.args...)
+			err := c.Run(args)
+			if err == nil || !strings.Contains(err.Error(), "--rsh-raw cannot be combined with "+tt.want) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if requested {
+				t.Fatal("request should not be sent with incompatible raw output flags")
+			}
+		})
+	}
+}
+
 func TestBinaryResponseDefaultNonTTYWritesOriginalBytes(t *testing.T) {
 	data := []byte{0x00, 0x01, 0xff, 0x7f}
 	for _, contentType := range []string{"application/octet-stream", "application/zip", "application/x-custom"} {

--- a/internal/cli/plugin_hook_test.go
+++ b/internal/cli/plugin_hook_test.go
@@ -236,17 +236,29 @@ func TestResponseMiddlewarePluginBypassedForRawRedirect(t *testing.T) {
 
 	raw := `{"hello":"world"}`
 	srv := hookJSONServer(t, 200, raw)
-	c, out, _ := newTestCLI(t)
-	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
-	if err := c.Run([]string{"restish", "get", srv.URL}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if got := out.String(); got != raw {
-		t.Fatalf("raw redirect path changed body bytes:\ngot  %q\nwant %q", got, raw)
-	}
-	if strings.Contains(out.String(), "plugin_added") {
-		t.Fatalf("response middleware ran on raw redirect path:\n%s", out.String())
+	for _, tt := range []struct {
+		name string
+		args []string
+		tty  bool
+	}{
+		{name: "automatic redirect"},
+		{name: "explicit TTY", args: []string{"--rsh-raw"}, tty: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, out, _ := newTestCLI(t)
+			c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+			c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return tt.tty }
+			args := append([]string{"restish", "get", srv.URL}, tt.args...)
+			if err := c.Run(args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := out.String(); got != raw {
+				t.Fatalf("raw output changed body bytes:\ngot  %q\nwant %q", got, raw)
+			}
+			if strings.Contains(out.String(), "plugin_added") {
+				t.Fatalf("response middleware ran on raw output path:\n%s", out.String())
+			}
+		})
 	}
 }
 

--- a/internal/cli/print.go
+++ b/internal/cli/print.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/rest-sh/restish/v2/internal/output"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -49,6 +50,9 @@ func (s printSpec) includesResponseBody() bool {
 }
 
 func (c *CLI) resolvePrintSpec(gf GlobalFlags, tty bool, kind printResponseKind) (printSpec, error) {
+	if gf.Raw {
+		return printSpec{order: []rune{printRawBody}}, nil
+	}
 	value := strings.TrimSpace(gf.Print)
 	if value == "" {
 		value = "auto"
@@ -57,6 +61,38 @@ func (c *CLI) resolvePrintSpec(gf GlobalFlags, tty bool, kind printResponseKind)
 		return c.autoPrintSpec(gf, tty, kind), nil
 	}
 	return parsePrintSpec(value)
+}
+
+func validateRawOutputFlags(cmd *cobra.Command, gf GlobalFlags) error {
+	if !gf.Raw {
+		return nil
+	}
+	var conflicts []string
+	if gf.OutputFormatSet {
+		conflicts = append(conflicts, "-o/--rsh-output-format")
+	}
+	if gf.PrintSet || cmd.Flags().Changed("rsh-print") {
+		conflicts = append(conflicts, "--rsh-print")
+	}
+	if gf.Filter != "" {
+		conflicts = append(conflicts, "-f/--rsh-filter")
+	}
+	if gf.HeadersShorthand {
+		conflicts = append(conflicts, "--rsh-headers")
+	}
+	if gf.StatusShorthand {
+		conflicts = append(conflicts, "--rsh-status")
+	}
+	if gf.Collect {
+		conflicts = append(conflicts, "--rsh-collect")
+	}
+	if gf.MaxItems != 0 {
+		conflicts = append(conflicts, "--rsh-max-items")
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("--rsh-raw cannot be combined with %s", strings.Join(conflicts, ", "))
+	}
+	return nil
 }
 
 func (c *CLI) autoPrintSpec(gf GlobalFlags, tty bool, kind printResponseKind) printSpec {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -51,6 +51,11 @@ func (c *CLI) newRootCmd() *cobra.Command {
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: c.completeRootURL,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Lazy generated-command redispatch already parsed the global flags.
+			if gf, ok := cmd.Context().Value(globalFlagsContextKey{}).(GlobalFlags); ok {
+				c.silentMode = gf.Silent
+				return nil
+			}
 			gf, err := parseGlobalFlags(cmd)
 			if err != nil {
 				return err
@@ -237,6 +242,7 @@ func (c *CLI) addGlobalFlags(root *cobra.Command) {
 	pf.StringP("rsh-server", "s", "", "Override scheme://host for all requests (e.g. https://staging.example.com)")
 	pf.StringP("rsh-output-format", "o", "auto", "Output format for rendered response bodies: "+output.FormatterNames(c.formatters)+" (use -o lines for shell-friendly filtered values; see --rsh-columns, --rsh-sort-by for table)")
 	pf.String("rsh-print", "auto", "Output parts to print: auto or any of H=request headers, B=request body, h=response headers, b=rendered body, p=pretty, c=color")
+	pf.BoolP("rsh-raw", "r", false, "Write only HTTP response body bytes; bypass decoding, filtering, formatting, pagination, and response middleware")
 	pf.BoolP("rsh-silent", "S", false, "Suppress all output; only the exit code conveys success or failure")
 	pf.String("rsh-columns", "", "Comma-separated column names for -o table (e.g. id,name,status)")
 	pf.String("rsh-sort-by", "", "Sort -o table rows by this column name")

--- a/internal/cli/stream_test.go
+++ b/internal/cli/stream_test.go
@@ -99,13 +99,26 @@ func TestStreamingRawRedirectDecompressesContentEncoding(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	c, out, _ := newTestCLI(t)
-	c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
-	if err := c.Run([]string{"restish", "get", srv.URL + "/stream"}); err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got := out.String(); got != raw {
-		t.Fatalf("raw streaming output = %q, want decompressed %q", got, raw)
+	for _, tt := range []struct {
+		name string
+		args []string
+		tty  bool
+	}{
+		{name: "automatic redirect"},
+		{name: "explicit TTY", args: []string{"--rsh-raw"}, tty: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c, out, _ := newTestCLI(t)
+			c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
+			c.Hooks().StdoutIsTerminal = func(io.Writer) bool { return tt.tty }
+			args := append([]string{"restish", "get", srv.URL + "/stream"}, tt.args...)
+			if err := c.Run(args); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if got := out.String(); got != raw {
+				t.Fatalf("raw streaming output = %q, want decompressed %q", got, raw)
+			}
+		})
 	}
 }
 
@@ -274,61 +287,74 @@ func TestNDJSONLineLimitUsesMaxBodySize(t *testing.T) {
 }
 
 func TestNDJSONFlushesBeforeResponseCompletes(t *testing.T) {
-	firstLineWritten := make(chan struct{})
-	finishResponse := make(chan struct{})
-	var finishOnce sync.Once
-	finish := func() {
-		finishOnce.Do(func() { close(finishResponse) })
-	}
-	defer finish()
+	for _, tt := range []struct {
+		name   string
+		args   []string
+		needle string
+		second string
+	}{
+		{name: "rendered", args: []string{"--rsh-print", "bp"}, needle: `"n": 1`, second: `"n": 2`},
+		{name: "raw", args: []string{"--rsh-raw"}, needle: `{"n":1}`, second: `{"n":2}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			firstLineWritten := make(chan struct{})
+			finishResponse := make(chan struct{})
+			var finishOnce sync.Once
+			finish := func() {
+				finishOnce.Do(func() { close(finishResponse) })
+			}
+			defer finish()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			t.Fatal("response writer does not implement http.Flusher")
-		}
-		fmt.Fprintln(w, `{"n":1}`)
-		flusher.Flush()
-		close(firstLineWritten)
-		<-finishResponse
-		fmt.Fprintln(w, `{"n":2}`)
-		flusher.Flush()
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
+			mux := http.NewServeMux()
+			mux.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Fatal("response writer does not implement http.Flusher")
+				}
+				fmt.Fprintln(w, `{"n":1}`)
+				flusher.Flush()
+				close(firstLineWritten)
+				<-finishResponse
+				fmt.Fprintln(w, `{"n":2}`)
+				flusher.Flush()
+			})
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
 
-	out := &signalWriter{needle: []byte(`"n": 1`), seen: make(chan struct{})}
-	c, _, _ := newTestCLI(t)
-	c.Stdout = out
-	c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
+			out := &signalWriter{needle: []byte(tt.needle), seen: make(chan struct{})}
+			c, _, _ := newTestCLI(t)
+			c.Stdout = out
+			c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- c.Run([]string{"restish", "get", "--rsh-print", "bp", srv.URL + "/stream"})
-	}()
+			errCh := make(chan error, 1)
+			go func() {
+				args := append([]string{"restish", "get", srv.URL + "/stream"}, tt.args...)
+				errCh <- c.Run(args)
+			}()
 
-	select {
-	case <-firstLineWritten:
-	case <-time.After(time.Second):
-		t.Fatal("server did not write first stream line")
-	}
+			select {
+			case <-firstLineWritten:
+			case <-time.After(time.Second):
+				t.Fatal("server did not write first stream line")
+			}
 
-	select {
-	case <-out.seen:
-	case err := <-errCh:
-		t.Fatalf("command finished before response completed: %v", err)
-	case <-time.After(time.Second):
-		t.Fatal("first NDJSON line was not rendered before response completed")
-	}
+			select {
+			case <-out.seen:
+			case err := <-errCh:
+				t.Fatalf("command finished before response completed: %v", err)
+			case <-time.After(time.Second):
+				t.Fatal("first NDJSON line was not flushed before response completed")
+			}
 
-	finish()
-	if err := <-errCh; err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got := out.String(); !strings.Contains(got, `"n": 2`) {
-		t.Fatalf("expected second line after response completed, got:\n%s", got)
+			finish()
+			if err := <-errCh; err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if got := out.String(); !strings.Contains(got, tt.second) {
+				t.Fatalf("expected second line after response completed, got:\n%s", got)
+			}
+		})
 	}
 }
 
@@ -866,6 +892,28 @@ func TestSSEErrorStatusFailsBeforeStreaming(t *testing.T) {
 	}
 	if out.Len() != 0 {
 		t.Fatalf("expected no stream output before status error, got %q", out.String())
+	}
+}
+
+func TestRawStreamWritesBodyBeforeStatusError(t *testing.T) {
+	body := sseBody(`{"error":"missing"}`)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, body)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = t.TempDir() + "/restish.json"
+	err := c.Run([]string{"restish", "get", "--rsh-raw", srv.URL + "/events"})
+	if exitCode(err) != 4 {
+		t.Fatalf("exit code = %v, want 4 (err=%v)", exitCode(err), err)
+	}
+	if got := out.String(); got != body {
+		t.Fatalf("raw stream body = %q, want %q", got, body)
 	}
 }
 

--- a/site/content/en/docs/getting-started/upgrade-from-v1.md
+++ b/site/content/en/docs/getting-started/upgrade-from-v1.md
@@ -97,8 +97,9 @@ These changes are intentional in v2 and are not treated as regressions:
 - redirected non-TTY output preserves response body bytes when no filter,
   collection, metadata shortcut, or output format is set; use `-o json` when a
   script needs Restish to render decoded structured data as JSON
-- `-r` is removed. Redirect stdout without a filter, metadata shortcut,
-  collection, or output format when you want to save response body bytes.
+- `-r` / `--rsh-raw` writes only response body bytes on both terminal and
+  redirected stdout. Unlike v1, it cannot be combined with filtering; use
+  `-o lines` for shell-friendly filtered scalar values.
 - interactive HTTP requests now print status, response headers, and formatted
   body to stdout when no explicit filter is set. Use `--rsh-print` to choose
   request/response parts, or `-f @` for the normalized response envelope.
@@ -128,6 +129,7 @@ Use this as the fast lookup table when muscle memory collides with v2.
 | profile `base`                        | profile `base_url`                                          | API/profile base field renamed                        |
 | API `base`                            | API `base_url`                                              | API base field renamed                                |
 | `-p`, `--rsh-profile`                 | `-p`, `--rsh-profile`                                       | Same flag, but invalid profile names now error        |
+| `-r`, `--rsh-raw`                     | `-r`, `--rsh-raw`                                           | Raw now means response body bytes only; use `-o lines` for filtered scalars |
 | external auth command hook            | `external-tool` auth                                        | Same local-helper idea; v2 plugin system is separate  |
 
 ## Extension Changes

--- a/site/content/en/docs/guides/output.md
+++ b/site/content/en/docs/guides/output.md
@@ -54,8 +54,10 @@ Restish prints the response status line, headers, and formatted body to stdout.
 Redirected output preserves raw response body bytes when there is no filter,
 metadata shortcut, collection, or explicit `-o` format. That raw-download path
 bypasses response middleware plugins so installed plugins cannot rewrite saved
-files. When you do ask Restish to select or transform a value, redirected output
-is pretty by default. Use `--rsh-print=b` for compact rendered output.
+files. Use `-r` / `--rsh-raw` to select the same path explicitly regardless of
+whether stdout is a terminal. When you do ask Restish to select or transform a
+value, redirected output is pretty by default. Use `--rsh-print=b` for compact
+rendered output.
 `json`, `yaml`, and `cbor` are document formats.
 `ndjson` is a record format for structured streams, and `lines` is for
 shell-friendly scalar values.
@@ -111,6 +113,7 @@ CBOR, YAML, images, octet streams, zip files, text, and unknown payloads:
 restish api.rest.sh/images/jpeg > dragonfly.jpg
 restish api.rest.sh/bytes/64 > sample.bin
 restish api.rest.sh/formats/cbor > response.cbor
+restish -r api.rest.sh/bytes/64
 ```
 
 Choose an output format when you want Restish to transform the decoded body:
@@ -126,8 +129,13 @@ for a different representation: default `Accept` negotiation still prefers
 JSON and other text-friendly structured formats unless you set `Accept`
 yourself. `raw` is not an `-o` format. To save bytes unchanged, redirect stdout
 without choosing a filter, metadata shortcut, collection, or explicit output
-format. Response middleware plugins are skipped on this raw-download path; they
-run when Restish renders, filters, collects, or prints an interpreted response.
+format, or pass `-r` / `--rsh-raw` to make the choice independent of the output
+destination. Explicit raw output cannot be combined with `-o`, `-f`,
+`--rsh-print`, `--rsh-collect`, `--rsh-max-items`, `--rsh-headers`, or
+`--rsh-status`. Response middleware plugins are skipped on this raw-download
+path; they run when Restish renders, filters, collects, or prints an interpreted
+response. Utility workflows and command plugins reject `--rsh-raw` when they
+cannot expose original HTTP response body bytes.
 
 Control exactly what stdout contains with `--rsh-print`:
 

--- a/site/content/en/docs/recipes/save-a-response-unchanged.md
+++ b/site/content/en/docs/recipes/save-a-response-unchanged.md
@@ -10,10 +10,13 @@ shortcut, or output format, Restish writes the response body bytes. That matters
 for binary files, structured fixtures such as CBOR, and anything another
 program will parse directly. Response middleware plugins are skipped for this
 raw-download path, so installed plugins cannot silently alter saved files.
+Pass `-r` / `--rsh-raw` when the command should use this path whether stdout is
+a terminal, pipe, or file.
 
 ```bash
 restish api.rest.sh/bytes/64 > sample.bin
 restish api.rest.sh/formats/cbor > response.cbor
+restish -r api.rest.sh/bytes/64
 ```
 
 For an image:

--- a/site/content/en/docs/reference/global-flags.md
+++ b/site/content/en/docs/reference/global-flags.md
@@ -223,6 +223,12 @@ Type: `stringArray`; default: none
 
 Query parameter in "key=value" format (repeatable)
 
+**`-r`, `--rsh-raw`**
+
+Type: `bool`; default: `false`
+
+Write only HTTP response body bytes; bypass decoding, filtering, formatting, pagination, and response middleware
+
 **`-s`, `--rsh-server`**
 
 Type: `string`; default: none

--- a/site/content/en/docs/reference/output-formats.md
+++ b/site/content/en/docs/reference/output-formats.md
@@ -172,12 +172,14 @@ arrays and streams of scalar values and rejects structured objects.
 
 ## Raw Bytes
 
-Raw byte output is automatic for redirected unfiltered responses. It is not an
-`-o` format and not a `--rsh-print` part:
+Raw byte output is automatic for redirected unfiltered responses. Use `-r` /
+`--rsh-raw` to select it explicitly on either terminal or redirected stdout. It
+is not an `-o` format and not a `--rsh-print` part:
 
 ```bash
 restish api.rest.sh/bytes/64 > sample.bin
 restish api.rest.sh/images/jpeg > dragonfly.jpg
+restish -r api.rest.sh/bytes/64
 ```
 
 Choose a format such as `-o json`, `-o lines`, or `-o table` when you want


### PR DESCRIPTION
## Summary

- Add `-r` / `--rsh-raw` to select response body bytes explicitly on both terminal and redirected stdout.
- Reuse the existing raw-download path for bounded and streaming responses, including HTTP content-encoding decompression and response-middleware bypass.
- Reject filters, formats, collection, item limits, metadata shortcuts, and explicit print selections that conflict with raw output.
- Keep v2 filtered-value behavior unchanged: `-o lines` remains the shell-friendly option for filtered scalars.

Fixes #406.

## CLI Behavior

```console
$ restish -r get URL
$ restish get --rsh-raw URL
```

Explicit raw output writes only the HTTP response body bytes. It bypasses structured decoding, filtering, formatting, pagination, and response middleware. Supported SSE and NDJSON responses pass through incrementally instead of waiting for the complete stream.

`raw` remains a byte selector rather than an `-o` format or `--rsh-print` part. Commands that cannot expose original HTTP response body bytes reject the flag instead of silently rendering a normalized value.

---

> [!NOTE]
> AI assistance: implementation, tests, documentation, PR description.
