### PR TITLE
fix(config): add JSONC mode line to v1→v2 migrated restish.json

### DIFF
--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -278,7 +278,11 @@ func renderMigratedConfig(cfg *config.Config, backupDir string) ([]byte, error) 
 		return nil, fmt.Errorf("config: marshal migrated config: %w", err)
 	}
 
+	// restish.json is JSONC. Lead with the recommended mode line so editors
+	// and tools know the .json file intentionally contains comments
+	// (https://jsonc.org/#filename-extension).
 	var out bytes.Buffer
+	out.WriteString("// -*- mode: jsonc -*-\n")
 	out.WriteString("// Migrated from Restish v1.\n")
 	fmt.Fprintf(&out, "// Original v1 files were copied to %s.\n", backupDir)
 	out.WriteString("// Secrets are intentionally not duplicated in comments.\n")

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rest-sh/restish/v2/config"
+)
+
+func TestRenderMigratedConfigLeadsWithJSONCModeLine(t *testing.T) {
+	cfg := &config.Config{
+		APIs: map[string]*config.APIConfig{
+			"example": {BaseURL: "https://api.example.com"},
+		},
+	}
+	backupDir := "/tmp/restish.bak.v1"
+
+	data, err := renderMigratedConfig(cfg, backupDir)
+	if err != nil {
+		t.Fatalf("renderMigratedConfig: %v", err)
+	}
+	out := string(data)
+
+	if !strings.HasPrefix(out, "// -*- mode: jsonc -*-\n") {
+		t.Fatalf("expected JSONC mode line prefix, got:\n%s", out)
+	}
+	if !strings.Contains(out, "// Migrated from Restish v1.\n") {
+		t.Fatalf("expected migration header, got:\n%s", out)
+	}
+	if !strings.Contains(out, backupDir) {
+		t.Fatalf("expected backup path %q in header, got:\n%s", backupDir, out)
+	}
+
+	// Restish loads the migrated payload as JSONC.
+	loaded, err := config.ParseConfigBytes("restish.json", data)
+	if err != nil {
+		t.Fatalf("ParseConfigBytes: %v", err)
+	}
+	api := loaded.APIs["example"]
+	if api == nil || api.BaseURL != "https://api.example.com" {
+		t.Fatalf("parsed config missing example API: %+v", loaded.APIs)
+	}
+}

--- a/site/content/en/docs/getting-started/upgrade-from-v1.md
+++ b/site/content/en/docs/getting-started/upgrade-from-v1.md
@@ -78,9 +78,11 @@ The migration carries over the main API-specific settings:
 - PKCS#11 TLS signer settings
 
 Comments from the v1 files remain in the backup copies. The generated
-`restish.json` is JSONC: it includes a short migration header, converted v2
-config, and comments that Restish preserves during later config edits where
-possible.
+`restish.json` is JSONC: it starts with a JSONC mode line
+(`// -*- mode: jsonc -*-`), a short migration header, converted v2 config,
+and comments that Restish preserves during later config edits where
+possible. Strict JSON tools such as `jq` still reject the file; use
+`restish config show -o json` for comment-free output.
 
 ## Deliberate Behavior Changes
 


### PR DESCRIPTION
## Summary

Fixes #391.

`restish.json` is intentionally JSONC (comments are stripped via `ParseConfigBytes`). The v1→v2 migration already writes a short header comment block, which is valid for Restish but surprising for tools that treat the `.json` extension as strict JSON.

Per the [JSONC filename guidance](https://jsonc.org/#filename-extension), when a `.json` extension is used the file should lead with a mode line. This change prefixes migrated configs with:

```text
// -*- mode: jsonc -*-
```

followed by the existing migration notes. Restish continues to load the file as JSONC. Strict JSON tools still need `restish config show -o json` for comment-free output (documented).

This is the smaller option discussed on the issue (mode line vs renaming to `restish.jsonc`). Filename rename is left for a separate decision if desired.

## Changes

- `internal/config/migrate.go`: lead `renderMigratedConfig` output with JSONC mode line
- `internal/config/migrate_test.go`: assert mode line + parse via `ParseConfigBytes`
- upgrade-from-v1 docs: mention mode line and `restish config show -o json`

## Test plan

- [x] `go test ./internal/config/ ./config/`
- [x] `go test ./internal/cli/ -run TestRun_PrintsLegacyMigrationNotice`
- [x] `go test ./internal/config/ -run TestRenderMigratedConfig -v`

## Notes

Does not touch MCP / #388 work.