### PR TITLE
feat(content): specify Content-Type per multipart part

### DIFF
--- a/docs/design/003-content-types-and-encodings.md
+++ b/docs/design/003-content-types-and-encodings.md
@@ -326,10 +326,14 @@ values become file parts. Array file fields are represented by repeated parts
 with the same field name, because that is what common multipart APIs expect for
 multi-file uploads. Generated OpenAPI commands pass `encoding.contentType`
 metadata into the multipart encoder so individual parts can carry the media
-type declared by the spec. A scalar string beginning with `@` is an explicit
-multipart file reference; missing files and directories fail before the request
-is sent. A scalar string beginning with `@@` escapes this behavior and sends a
-literal text value beginning with `@`.
+type declared by the spec. Generic multipart commands can set the same per-part
+`Content-Type` with a curl-style `;type=<media-type>` suffix on a scalar value
+(for example `file: @payload.json;type=application/json` or
+`name: daniel;type=text/foo`). An inline `;type=` overrides OpenAPI
+`encoding.contentType` for that part when both are present. A scalar string
+beginning with `@` is an explicit multipart file reference; missing files and
+directories fail before the request is sent. A scalar string beginning with
+`@@` escapes this behavior and sends a literal text value beginning with `@`.
 
 For `application/octet-stream` and other binary request media, Restish preserves
 raw bytes from files or stdin rather than re-encoding them as structured text.

--- a/internal/cli/http_test.go
+++ b/internal/cli/http_test.go
@@ -1180,3 +1180,59 @@ func TestMultipartBodyRejectsMissingFileBeforeRequest(t *testing.T) {
 		t.Fatal("request was sent despite missing multipart file reference")
 	}
 }
+
+func TestMultipartBodyInlinePartContentType(t *testing.T) {
+	var rr requestRecorder
+	c, _, _ := newTestCLI(t)
+	useTransport(c, func(r *http.Request) (*http.Response, error) {
+		rr.capture(r)
+		return jsonResponse(200, `{}`), nil
+	})
+	uploadPath := filepath.Join("testdata", "upload.txt")
+	err := c.Run([]string{
+		"restish", "post", "-c", "multipart", "https://api.example.com/items",
+		"name:", "daniel;type=text/foo,",
+		"file:", "@" + uploadPath + ";type=text/plain",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := rr.Last()
+	contentType := req.Header.Get("Content-Type")
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse media type: %v", err)
+	}
+	reader := multipart.NewReader(bytes.NewReader(rr.body), params["boundary"])
+	parts := map[string]string{}
+	partTypes := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("next part: %v", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		parts[part.FormName()] = string(content)
+		partTypes[part.FormName()] = part.Header.Get("Content-Type")
+	}
+
+	if parts["name"] != "daniel" {
+		t.Fatalf("name part: got %q", parts["name"])
+	}
+	if partTypes["name"] != "text/foo" {
+		t.Fatalf("name Content-Type: got %q, want text/foo", partTypes["name"])
+	}
+	if parts["file"] != "hello from upload\n" {
+		t.Fatalf("file part: got %q", parts["file"])
+	}
+	if partTypes["file"] != "text/plain" {
+		t.Fatalf("file Content-Type: got %q, want text/plain", partTypes["file"])
+	}
+}

--- a/internal/content/defaults.go
+++ b/internal/content/defaults.go
@@ -21,7 +21,10 @@ import (
 )
 
 // MultipartBody carries a structured multipart/form-data body plus optional
-// per-field Content-Type metadata from an OpenAPI encoding object.
+// per-field Content-Type metadata (OpenAPI encoding.contentType or equivalent).
+// Scalar values may also set a part Content-Type with a curl-style
+// ";type=<media-type>" suffix; an inline type overrides ContentTypes for that
+// field.
 type MultipartBody struct {
 	Value        any
 	ContentTypes map[string]string
@@ -446,17 +449,51 @@ func addMultipartParts(writer *multipart.Writer, prefix string, v any, opts mult
 		if prefix == "" {
 			return fmt.Errorf("multipart bodies must be an object")
 		}
-		if literal, ok := multipartEscapedAtLiteral(v); ok {
-			return writeMultipartField(writer, prefix, literal, opts.contentTypes[prefix])
+		value, inlineType := splitMultipartPartValue(v)
+		contentType := opts.contentTypes[prefix]
+		if inlineType != "" {
+			contentType = inlineType
 		}
-		if filePath, ok := multipartFilePath(v); ok {
-			return addMultipartFile(writer, prefix, filePath, opts.contentTypes[prefix])
-		} else if err := multipartFileReferenceError(v); err != nil {
+		if literal, ok := multipartEscapedAtLiteral(value); ok {
+			return writeMultipartField(writer, prefix, literal, contentType)
+		}
+		if filePath, ok := multipartFilePath(value); ok {
+			return addMultipartFile(writer, prefix, filePath, contentType)
+		} else if err := multipartFileReferenceError(value); err != nil {
 			return err
 		}
-		return writeMultipartField(writer, prefix, v, opts.contentTypes[prefix])
+		return writeMultipartField(writer, prefix, value, contentType)
 	}
 	return nil
+}
+
+// splitMultipartPartValue strips an optional curl-style ";type=<media-type>"
+// suffix from multipart scalar values so callers can set per-part Content-Type
+// without OpenAPI encoding metadata.
+func splitMultipartPartValue(v any) (any, string) {
+	s, ok := v.(string)
+	if !ok {
+		return v, ""
+	}
+	value, contentType := splitMultipartContentType(s)
+	if contentType == "" {
+		return v, ""
+	}
+	return value, contentType
+}
+
+func splitMultipartContentType(s string) (value, contentType string) {
+	const marker = ";type="
+	lower := strings.ToLower(s)
+	idx := strings.LastIndex(lower, marker)
+	if idx < 0 {
+		return s, ""
+	}
+	contentType = strings.TrimSpace(s[idx+len(marker):])
+	if contentType == "" {
+		return s, ""
+	}
+	return s[:idx], contentType
 }
 
 func writeMultipartField(writer *multipart.Writer, fieldName string, value any, contentType string) error {

--- a/internal/content/registry_test.go
+++ b/internal/content/registry_test.go
@@ -638,6 +638,97 @@ func TestMultipartEncodingEscapesAtLiteral(t *testing.T) {
 	}
 }
 
+func TestMultipartEncodingInlinePartContentType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.json")
+	if err := os.WriteFile(path, []byte(`{"hello":"there"}`), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	data, contentType, err := reg.EncodeWithType("multipart/form-data", map[string]any{
+		"name": "daniel;type=text/foo",
+		"file": "@" + path + ";type=application/json",
+	})
+	if err != nil {
+		t.Fatalf("encode with type: %v", err)
+	}
+
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse media type: %v", err)
+	}
+	reader := multipart.NewReader(bytes.NewReader(data), params["boundary"])
+	parts := map[string]string{}
+	partTypes := map[string]string{}
+	filenames := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("next part: %v", err)
+		}
+		content, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		name := part.FormName()
+		parts[name] = string(content)
+		partTypes[name] = part.Header.Get("Content-Type")
+		filenames[name] = part.FileName()
+	}
+
+	if parts["name"] != "daniel" {
+		t.Fatalf("name part: got %q", parts["name"])
+	}
+	if partTypes["name"] != "text/foo" {
+		t.Fatalf("name Content-Type: got %q", partTypes["name"])
+	}
+	if parts["file"] != `{"hello":"there"}` {
+		t.Fatalf("file part: got %q", parts["file"])
+	}
+	if partTypes["file"] != "application/json" {
+		t.Fatalf("file Content-Type: got %q, want application/json", partTypes["file"])
+	}
+	if filenames["file"] != "payload.json" {
+		t.Fatalf("file name: got %q", filenames["file"])
+	}
+}
+
+func TestMultipartEncodingInlineTypeOverridesOpenAPIMap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "payload.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	data, contentType, err := reg.EncodeWithType("multipart/form-data", content.MultipartBody{
+		Value: map[string]any{
+			"file": "@" + path + ";type=text/plain",
+		},
+		ContentTypes: map[string]string{
+			"file": "application/octet-stream",
+		},
+	})
+	if err != nil {
+		t.Fatalf("encode with type: %v", err)
+	}
+
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse media type: %v", err)
+	}
+	reader := multipart.NewReader(bytes.NewReader(data), params["boundary"])
+	part, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("next part: %v", err)
+	}
+	if got := part.Header.Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("Content-Type = %q, want text/plain (inline override)", got)
+	}
+}
+
 // jsonRoundTrip is a test helper that serialises v to JSON and back, so
 // that test assertions can compare normalised representations instead of
 // direct struct equality (which fails across CBOR/msgpack integer widths).

--- a/site/content/en/docs/guides/input.md
+++ b/site/content/en/docs/guides/input.md
@@ -94,7 +94,7 @@ printf 'hello from docs\n' > upload.txt
 restish post -c multipart api.rest.sh/uploads 'description: docs, file: @upload.txt'
 ```
 
-The response echoes multipart field values. When a client sends real file parts, `/uploads` also reports file metadata such as field name, filename, content type, and size. A multipart `@path` value must point to a readable file; use `@@value` when a text field should start with a literal `@`.
+The response echoes multipart field values. When a client sends real file parts, `/uploads` also reports file metadata such as field name, filename, content type, and size. A multipart `@path` value must point to a readable file; use `@@value` when a text field should start with a literal `@`. Append `;type=<media-type>` to set a part's `Content-Type` (for example `file: @payload.json;type=application/json`).
 
 ## File Loading
 

--- a/site/content/en/docs/recipes/upload-a-file-with-multipart.md
+++ b/site/content/en/docs/recipes/upload-a-file-with-multipart.md
@@ -17,7 +17,14 @@ restish post -c multipart api.rest.sh/uploads 'description: docs, file: @upload.
 The response echoes multipart fields. If a client sends real file parts,
 `/uploads` also reports file metadata. Missing file paths fail before the
 request is sent. Use `@@value` when a text field should start with a literal
-`@`. For plain URL-encoded forms, use `-c form` instead; both encodings are
+`@`. To set a part's `Content-Type`, append `;type=<media-type>`:
+
+```bash
+restish post -c multipart api.rest.sh/uploads \
+  'description: docs, file: @upload.txt;type=text/plain'
+```
+
+For plain URL-encoded forms, use `-c form` instead; both encodings are
 explained in [Input and Shorthand](/docs/guides/input/).
 
 Related: [Input and Shorthand](/docs/guides/input/), [Content Types](/docs/reference/content-types/).

--- a/site/content/en/docs/reference/content-types.md
+++ b/site/content/en/docs/reference/content-types.md
@@ -78,7 +78,19 @@ per line.
 
 For multipart bodies, `@path` creates a file part and fails locally if the file
 cannot be read. Use `@@value` when a text field should start with a literal
-`@`.
+`@`. Append `;type=<media-type>` to set that part's `Content-Type` (curl-style),
+for file or text parts:
+
+```bash
+restish post -c multipart api.rest.sh/uploads \
+  'description: docs;type=text/plain, file: @upload.txt;type=text/plain'
+restish post -c multipart api.example.test/items \
+  'file: @payload.json;type=application/json'
+```
+
+Generated OpenAPI commands also apply `encoding.contentType` from the operation
+spec. An inline `;type=` on the value overrides that encoding entry for the
+part.
 
 ## Response Decoding
 

--- a/site/content/en/docs/reference/openapi-cli-integration.md
+++ b/site/content/en/docs/reference/openapi-cli-integration.md
@@ -210,10 +210,14 @@ Generated commands use the normal Restish body syntax. JSON and `+json` media
 types use shorthand assignments, form bodies use form encoding, multipart
 bodies can include fields, repeated file-array fields, and
 `encoding.contentType` per-part metadata, and opaque body media types such as
-`application/octet-stream`, XML, and NDJSON send raw string or file input:
+`application/octet-stream`, XML, and NDJSON send raw string or file input.
+Generic multipart values can also set per-part types with `;type=<media-type>`
+(for example `file: @photo.jpg;type=image/jpeg`), which overrides
+`encoding.contentType` for that part when both are present:
 
 ```bash
 restish myapi upload-item 'name: alice, file: @photo.jpg'
+restish post -c multipart https://api.example.test/items 'file: @payload.json;type=application/json'
 restish myapi put-blob @payload.bin
 restish myapi webdav-operation @propfind.xml
 restish myapi insert-json-line @events.ndjson

--- a/site/content/en/docs/reference/shorthand.md
+++ b/site/content/en/docs/reference/shorthand.md
@@ -140,7 +140,8 @@ restish post api.rest.sh/post 'encoded: %photo.jpg'
 For literal values that begin with `@` or `%`, quote or otherwise force string
 semantics in the shell command. Multipart bodies treat `@path` as a file part
 reference at encoding time; use `@@value` in multipart input to send a literal
-text value that starts with `@`.
+text value that starts with `@`. Multipart scalars may also end with
+`;type=<media-type>` to set that part's `Content-Type`.
 
 ## Stdin
 


### PR DESCRIPTION
## Summary

Generic `-c multipart` requests could not set a part's `Content-Type`. File parts always fell through to Go's `CreateFormFile` default (`application/octet-stream`). OpenAPI-generated commands already applied `encoding.contentType` via `MultipartBody.ContentTypes`, but raw URL / shorthand multipart had no equivalent.

This adds curl-style per-part types:

```bash
restish post -c multipart <url> 'file: @test.json;type=application/json'
restish post -c multipart <url> 'name: daniel;type=text/foo, file: @index.html;type=text/html'
```

- Parser strips a case-insensitive `;type=<media-type>` suffix from multipart scalar values (last `;type=` wins so media types may include parameters such as `charset`).
- Inline `;type=` overrides OpenAPI `encoding.contentType` for that part when both are present.
- Generated OpenAPI `encoding.contentType` path is unchanged.
- Docs updated (guides, content-types, shorthand, multipart recipe, design 003).

Fixes #395

## Test plan

- [x] `go test ./internal/content/ -run Multipart -count=1`
- [x] `go test ./internal/cli/ -run Multipart -count=1`
- [x] `go test ./... -count=1` (all packages green except `cmd/restish-pkcs11` build, which fails on this machine with Xcode license / cgo — unrelated env issue)
- [ ] Manual: `restish --rsh-print B -c multipart post <url> 'file: @test.json;type=application/json'` shows `Content-Type: application/json` on the file part