### PR TITLE
fix(plugin): preserve response hook command context

### DIFF
--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -166,7 +167,7 @@ type HookFollowRequest struct {
 // runResponseMiddlewarePlugins invokes all "response-middleware" hook plugins.
 // Returns (drop, follow, err). drop=true means suppress all output. follow is
 // non-nil when the plugin wants Restish to issue a new request.
-func (c *CLI) runResponseMiddlewarePlugins(req *http.Request, resp *output.Response) (drop bool, follow *HookFollowRequest, err error) {
+func (c *CLI) runResponseMiddlewarePlugins(ctx context.Context, req *http.Request, resp *output.Response) (drop bool, follow *HookFollowRequest, err error) {
 	for _, p := range c.pluginsByHook["response-middleware"] {
 		if trace := requestTraceFromContext(req.Context()); trace != nil {
 			trace.AddInfo("Plugin", pluginInvocationTrace("response", p))
@@ -186,7 +187,7 @@ func (c *CLI) runResponseMiddlewarePlugins(req *http.Request, resp *output.Respo
 			},
 		}
 		var out pluginwire.ResponseMiddlewareOutput
-		if err := plugin.CallHookWithTimeoutContext(req.Context(), p.Path, plugin.HookTimeout(p.Manifest, "response-middleware"), in, &out); err != nil {
+		if err := plugin.CallHookWithTimeoutContext(ctx, p.Path, plugin.HookTimeout(p.Manifest, "response-middleware"), in, &out); err != nil {
 			return false, nil, fmt.Errorf("response-middleware plugin %s: %w", p.Manifest.Name, err)
 		}
 

--- a/internal/cli/http.go
+++ b/internal/cli/http.go
@@ -389,7 +389,7 @@ func (c *CLI) runHTTPWithOptions(cmd *cobra.Command, method string, args []strin
 	// Response-middleware plugins: can modify, drop, or follow.
 	// Skipped in follow mode to prevent infinite loops.
 	if !followMode && httpResp.Request != nil && !printSpec.rawBodyOnly() {
-		drop, followReq, mwErr := c.runResponseMiddlewarePlugins(httpResp.Request, resp)
+		drop, followReq, mwErr := c.runResponseMiddlewarePlugins(requestContext(cmd), httpResp.Request, resp)
 		if mwErr != nil {
 			return mwErr
 		}

--- a/internal/cli/plugin_hook_test.go
+++ b/internal/cli/plugin_hook_test.go
@@ -230,6 +230,25 @@ func TestResponseMiddlewarePluginModify(t *testing.T) {
 	}
 }
 
+// TestResponseMiddlewarePluginRunsAfterTimedResponseBodyClose verifies that
+// closing a bounded response body does not cancel the command-scoped plugin
+// invocation that follows it.
+func TestResponseMiddlewarePluginRunsAfterTimedResponseBodyClose(t *testing.T) {
+	installHookPlugin(t)
+	t.Setenv("RSH_HOOK_RM_BEHAVIOR", "")
+
+	srv := hookJSONServer(t, 200, `{"hello":"world"}`)
+	c, out, _ := newTestCLI(t)
+	c.Hooks().ConfigPath = sharedPluginConfigPath(t)
+	if err := c.Run([]string{"restish", "get", "--rsh-timeout", "1s", "-o", "json", srv.URL}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "plugin_added") {
+		t.Errorf("expected plugin_added in output, got:\n%s", out.String())
+	}
+}
+
 func TestResponseMiddlewarePluginBypassedForRawRedirect(t *testing.T) {
 	installHookPlugin(t)
 	t.Setenv("RSH_HOOK_RM_BEHAVIOR", "")


### PR DESCRIPTION
## Summary

- invoke response-middleware plugins with the command context instead of the bounded response-body context
- preserve command cancellation without canceling middleware when a bounded response body closes
- cover timed responses with a response-middleware integration test

## Behavior

Response-middleware hooks no longer fail with `context canceled` after a successful bounded response when `--rsh-timeout` is set.

## Verification

- `CGO_ENABLED=1 go test ./...`
- `CGO_ENABLED=1 go test -tags=integration ./...`
