### PR TITLE
fix(openapi): report affected security operations

### DIFF
--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -3589,16 +3589,15 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
 	if !strings.Contains(out.String(), "Synced") {
 		t.Errorf("expected Synced in output, got: %q", out.String())
 	}
-	if !strings.Contains(errOut.String(), `warning: OpenAPI security: security scheme "BearerAuth" is referenced`) {
-		t.Fatalf("expected undeclared security warning, got:\n%s", errOut.String())
-	}
-	if !strings.Contains(errOut.String(), `(2 operations; tags: admin, reports; operations: `) {
-		t.Fatalf("expected affected operation tags, got:\n%s", errOut.String())
-	}
-	for _, want := range []string{"GET /audit (getAudit)", "POST /audit (createAudit)"} {
-		if !strings.Contains(errOut.String(), want) {
-			t.Fatalf("expected affected operation %q, got:\n%s", want, errOut.String())
-		}
+	want := `warning: OpenAPI security: security scheme "BearerAuth" is referenced by operations but is not declared in components.securitySchemes (2 operations)
+  tags: admin, reports
+  operations:
+    - GET /audit (getAudit)
+    - POST /audit (createAudit)
+  action: fix the OpenAPI document or use --rsh-auth BearerAuth with configured credentials if you know what to send
+`
+	if errOut.String() != want {
+		t.Fatalf("security warning:\n%s\nwant:\n%s", errOut.String(), want)
 	}
 }
 

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -3592,8 +3592,13 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
 	if !strings.Contains(errOut.String(), `warning: OpenAPI security: security scheme "BearerAuth" is referenced`) {
 		t.Fatalf("expected undeclared security warning, got:\n%s", errOut.String())
 	}
-	if !strings.Contains(errOut.String(), `(2 operations; tags: admin, reports)`) {
+	if !strings.Contains(errOut.String(), `(2 operations; tags: admin, reports; operations: `) {
 		t.Fatalf("expected affected operation tags, got:\n%s", errOut.String())
+	}
+	for _, want := range []string{"GET /audit (getAudit)", "POST /audit (createAudit)"} {
+		if !strings.Contains(errOut.String(), want) {
+			t.Fatalf("expected affected operation %q, got:\n%s", want, errOut.String())
+		}
 	}
 }
 

--- a/internal/cli/api_manage_test.go
+++ b/internal/cli/api_manage_test.go
@@ -3557,6 +3557,13 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
     "/audit": {
       "get": {
         "operationId": "getAudit",
+        "tags": ["reports"],
+        "security": [{"BearerAuth": []}],
+        "responses": {"200": {"description": "OK"}}
+      },
+      "post": {
+        "operationId": "createAudit",
+        "tags": ["admin"],
         "security": [{"BearerAuth": []}],
         "responses": {"200": {"description": "OK"}}
       }
@@ -3584,6 +3591,9 @@ func TestAPISyncWarnsAboutUndeclaredSecurityScheme(t *testing.T) {
 	}
 	if !strings.Contains(errOut.String(), `warning: OpenAPI security: security scheme "BearerAuth" is referenced`) {
 		t.Fatalf("expected undeclared security warning, got:\n%s", errOut.String())
+	}
+	if !strings.Contains(errOut.String(), `(2 operations; tags: admin, reports)`) {
+		t.Fatalf("expected affected operation tags, got:\n%s", errOut.String())
 	}
 }
 

--- a/internal/cli/auth_readiness.go
+++ b/internal/cli/auth_readiness.go
@@ -95,6 +95,7 @@ type operationSecurityIssueKey struct {
 
 func operationSecurityIssues(ops []spec.Operation) []string {
 	counts := map[operationSecurityIssueKey]int{}
+	tagsByIssue := map[operationSecurityIssueKey]map[string]bool{}
 	for _, op := range ops {
 		seen := map[operationSecurityIssueKey]bool{}
 		for _, alternative := range op.CredentialAlternatives {
@@ -109,9 +110,18 @@ func operationSecurityIssues(ops []spec.Operation) []string {
 		}
 		for key := range seen {
 			counts[key]++
+			for _, tag := range op.Tags {
+				if tag == "" {
+					continue
+				}
+				if tagsByIssue[key] == nil {
+					tagsByIssue[key] = map[string]bool{}
+				}
+				tagsByIssue[key][tag] = true
+			}
 		}
 	}
-	return formatOperationSecurityIssues(counts, "operation")
+	return formatOperationSecurityIssues(counts, "operation", tagsByIssue)
 }
 
 func operationSecurityIssuesFromAlternatives(alternatives []spec.CredentialAlternative) []string {
@@ -134,7 +144,7 @@ func operationSecurityIssuesFromAlternatives(alternatives []spec.CredentialAlter
 			counts[key]++
 		}
 	}
-	return formatOperationSecurityIssues(counts, "alternative")
+	return formatOperationSecurityIssues(counts, "alternative", nil)
 }
 
 func operationSecurityIssueText(requirement spec.CredentialRequirement) (string, bool) {
@@ -148,7 +158,7 @@ func operationSecurityIssueText(requirement spec.CredentialRequirement) (string,
 	}
 }
 
-func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, unit string) []string {
+func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, unit string, tagsByIssue map[operationSecurityIssueKey]map[string]bool) []string {
 	keys := make([]operationSecurityIssueKey, 0, len(counts))
 	for key := range counts {
 		keys = append(keys, key)
@@ -165,7 +175,16 @@ func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, uni
 		if counts[key] == 1 {
 			unitWord = unit
 		}
-		out = append(out, fmt.Sprintf("%s (%d %s); fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.text, counts[key], unitWord, key.id))
+		tagNames := make([]string, 0, len(tagsByIssue[key]))
+		for tag := range tagsByIssue[key] {
+			tagNames = append(tagNames, tag)
+		}
+		sort.Strings(tagNames)
+		tagSummary := ""
+		if len(tagNames) > 0 {
+			tagSummary = "; tags: " + strings.Join(tagNames, ", ")
+		}
+		out = append(out, fmt.Sprintf("%s (%d %s%s); fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.text, counts[key], unitWord, tagSummary, key.id))
 	}
 	return out
 }

--- a/internal/cli/auth_readiness.go
+++ b/internal/cli/auth_readiness.go
@@ -96,6 +96,7 @@ type operationSecurityIssueKey struct {
 func operationSecurityIssues(ops []spec.Operation) []string {
 	counts := map[operationSecurityIssueKey]int{}
 	tagsByIssue := map[operationSecurityIssueKey]map[string]bool{}
+	operationsByIssue := map[operationSecurityIssueKey]map[string]bool{}
 	for _, op := range ops {
 		seen := map[operationSecurityIssueKey]bool{}
 		for _, alternative := range op.CredentialAlternatives {
@@ -110,6 +111,10 @@ func operationSecurityIssues(ops []spec.Operation) []string {
 		}
 		for key := range seen {
 			counts[key]++
+			if operationsByIssue[key] == nil {
+				operationsByIssue[key] = map[string]bool{}
+			}
+			operationsByIssue[key][operationSecurityIssueOperationLabel(op)] = true
 			for _, tag := range op.Tags {
 				if tag == "" {
 					continue
@@ -121,7 +126,7 @@ func operationSecurityIssues(ops []spec.Operation) []string {
 			}
 		}
 	}
-	return formatOperationSecurityIssues(counts, "operation", tagsByIssue)
+	return formatOperationSecurityIssues(counts, "operation", tagsByIssue, operationsByIssue)
 }
 
 func operationSecurityIssuesFromAlternatives(alternatives []spec.CredentialAlternative) []string {
@@ -144,7 +149,7 @@ func operationSecurityIssuesFromAlternatives(alternatives []spec.CredentialAlter
 			counts[key]++
 		}
 	}
-	return formatOperationSecurityIssues(counts, "alternative", nil)
+	return formatOperationSecurityIssues(counts, "alternative", nil, nil)
 }
 
 func operationSecurityIssueText(requirement spec.CredentialRequirement) (string, bool) {
@@ -158,7 +163,7 @@ func operationSecurityIssueText(requirement spec.CredentialRequirement) (string,
 	}
 }
 
-func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, unit string, tagsByIssue map[operationSecurityIssueKey]map[string]bool) []string {
+func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, unit string, tagsByIssue, operationsByIssue map[operationSecurityIssueKey]map[string]bool) []string {
 	keys := make([]operationSecurityIssueKey, 0, len(counts))
 	for key := range counts {
 		keys = append(keys, key)
@@ -184,9 +189,31 @@ func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, uni
 		if len(tagNames) > 0 {
 			tagSummary = "; tags: " + strings.Join(tagNames, ", ")
 		}
-		out = append(out, fmt.Sprintf("%s (%d %s%s); fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.text, counts[key], unitWord, tagSummary, key.id))
+		operationSummary := ""
+		operationNames := sortedStringSet(operationsByIssue[key])
+		if len(operationNames) > 0 {
+			operationSummary = "; operations: " + strings.Join(operationNames, ", ")
+		}
+		out = append(out, fmt.Sprintf("%s (%d %s%s%s); fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.text, counts[key], unitWord, tagSummary, operationSummary, key.id))
 	}
 	return out
+}
+
+func operationSecurityIssueOperationLabel(op spec.Operation) string {
+	label := strings.ToUpper(op.Method) + " " + op.Path
+	if op.ID != "" {
+		label += " (" + op.ID + ")"
+	}
+	return label
+}
+
+func sortedStringSet(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (c *CLI) operationAuthCoverage(apiName, profileName string, prof *config.ProfileConfig, ops []spec.Operation) operationAuthCoverage {

--- a/internal/cli/auth_readiness.go
+++ b/internal/cli/auth_readiness.go
@@ -185,16 +185,24 @@ func formatOperationSecurityIssues(counts map[operationSecurityIssueKey]int, uni
 			tagNames = append(tagNames, tag)
 		}
 		sort.Strings(tagNames)
-		tagSummary := ""
-		if len(tagNames) > 0 {
-			tagSummary = "; tags: " + strings.Join(tagNames, ", ")
-		}
-		operationSummary := ""
 		operationNames := sortedStringSet(operationsByIssue[key])
-		if len(operationNames) > 0 {
-			operationSummary = "; operations: " + strings.Join(operationNames, ", ")
+		action := fmt.Sprintf("fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.id)
+		if len(tagNames) == 0 && len(operationNames) == 0 {
+			out = append(out, fmt.Sprintf("%s (%d %s); %s", key.text, counts[key], unitWord, action))
+			continue
 		}
-		out = append(out, fmt.Sprintf("%s (%d %s%s%s); fix the OpenAPI document or use --rsh-auth %s with configured credentials if you know what to send", key.text, counts[key], unitWord, tagSummary, operationSummary, key.id))
+		var details []string
+		if len(tagNames) > 0 {
+			details = append(details, "  tags: "+strings.Join(tagNames, ", "))
+		}
+		if len(operationNames) > 0 {
+			details = append(details, "  operations:")
+			for _, operationName := range operationNames {
+				details = append(details, "    - "+operationName)
+			}
+		}
+		details = append(details, "  action: "+action)
+		out = append(out, fmt.Sprintf("%s (%d %s)\n%s", key.text, counts[key], unitWord, strings.Join(details, "\n")))
 	}
 	return out
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -341,7 +341,7 @@ func (c *CLI) runDoctorAPI(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(out, "Generated operations: %d %s\n", len(opInfo.Set.Operations), style.ok("available"))
 		}
 		for _, issue := range operationSecurityIssues(opInfo.Set.Operations) {
-			fmt.Fprintf(out, "  %s: %s\n", style.error("Issue"), issue)
+			fmt.Fprintf(out, "  %s: %s\n", style.error("Issue"), strings.ReplaceAll(issue, "\n", "\n    "))
 		}
 		printXCLIExtensionDoctorDetails(out, style, opInfo.Set.XCLIExtensions)
 	} else {


### PR DESCRIPTION
## Summary

- include affected operation tags in generated OpenAPI security warnings
- include affected method/path/operationId labels so `api sync` identifies the exact endpoints
- print operation details as a sorted, deduplicated multiline list
- preserve the existing compact warning when tag or operation context is unavailable

## Local demo

Serve this minimal OpenAPI document with `python3 -m http.server 18082` and connect Restish to `http://127.0.0.1:18082/openapi.json`:

```json
{
  "openapi": "3.1.0",
  "info": {"title": "Security warning demo", "version": "1.0.0"},
  "paths": {
    "/audit": {
      "get": {
        "operationId": "getAudit",
        "tags": ["reports"],
        "security": [{"authz": []}],
        "responses": {"200": {"description": "OK"}}
      },
      "post": {
        "operationId": "createAudit",
        "tags": ["admin"],
        "security": [{"authz": []}],
        "responses": {"200": {"description": "OK"}}
      }
    }
  }
}
```

```console
$ restish api connect demo http://127.0.0.1:18082 --spec http://127.0.0.1:18082/openapi.json --yes
$ restish api sync demo
```

Before, with `v2.3.0`:

```console
warning: OpenAPI security: security scheme "authz" is referenced by operations but is not declared in components.securitySchemes (2 operations); fix the OpenAPI document or use --rsh-auth authz with configured credentials if you know what to send
Synced spec for "demo".
```

After, with this PR at `c70c4ec`:

```console
warning: OpenAPI security: security scheme "authz" is referenced by operations but is not declared in components.securitySchemes (2 operations)
  tags: admin, reports
  operations:
    - GET /audit (getAudit)
    - POST /audit (createAudit)
  action: fix the OpenAPI document or use --rsh-auth authz with configured credentials if you know what to send
Synced spec for "demo".
```

---

> [!NOTE]
> AI assistance: diagnostic formatting, regression test, PR description.
